### PR TITLE
Fix issue with OSX builds missing last line #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,23 @@ Most people will not need any development environment, it is mostly needed by th
 
 1. Install homebrew (as per: https://brew.sh)
 2. Setup cask
+
 	`brew install cask`
 3. Install python
+
 	`brew install python`
 4. Add packages for python
+
 	`pip3 install MarkdownPP pymarkdownlnt`
 5. Install pandoc and required filter library
-	
+
 	`brew install pandoc`
 	
 	`brew install --cask wkhtmltopdf`
-6. If your machine does not have git/make etc, you might fun the following: Install developer command line tools for MacOS 
+6. Install GNU sed
+
+	`brew install gnu-sed`
+7. If your machine does not have git/make etc, you might fun the following: Install developer command line tools for MacOS 
 
 	`xcode-select --install`
 

--- a/specification/Makefile
+++ b/specification/Makefile
@@ -1,7 +1,11 @@
 PANDOC=$(shell which pandoc)
 MARKDOWNPP=$(shell which markdown-pp)
 PYMARKDOWNLNT=$(shell which pymarkdownlnt)
-SED=$(shell which sed)
+ifeq ($(shell uname -s), Darwin)
+	SED=$(shell which gsed)
+else
+	SED=$(shell which sed)
+endif
 ifeq ($(STYLE),)
 STYLE="styles/draft.css"
 endif
@@ -21,15 +25,9 @@ spec.md: $(SPEC_SOURCE_FILES)
 	./validate_includes.py attributes
 	./validate_includes.py appendix
 	$(MARKDOWNPP) spec.mdpp -o $@
-ifeq ($(shell uname -s), Darwin)
-	$(SED) -i '' 's|\(<a name=\".*\">\)</a>|\1\&nbsp;</a>|g' $@
-	$(SED) -Ei '' '/^[0-9]+.[0-9]+.[0-9]+\\\.\ \ /d' $@
-	$(SED) -i '' 'N;/^\n<a name=/!P;D' $@
-else
 	$(SED) -i 's|\(<a name=\".*\">\)</a>|\1\&nbsp;</a>|g' $@
 	$(SED) -ri '/^[0-9]+.[0-9]+.[0-9]+\\\.\ \ /d' $@
 	$(SED) -i 'N;/^\n<a name=/!P;D' $@
-endif
 	$(PYMARKDOWNLNT) --config markdownlnt.cfg scan $(SPEC_SOURCE_MDFILES)
 	$(PYMARKDOWNLNT) --config markdownlnt.cfg scan $@
 


### PR DESCRIPTION
Removed dependancy on OSX default sed
Added steps to install gsed (GNU Sed) on OSX for development This gsed on OSX is the same GNU sed used on GitHub Actions Possibly a different version but generally the same features. This simplifies the Makefile and avoids the duplicate effort to maintain.