### PR TITLE
Adding OCI mappings in supporting content for billingperiodstart

### DIFF
--- a/supporting_content/dimensions/billingperiodstart.md
+++ b/supporting_content/dimensions/billingperiodstart.md
@@ -9,7 +9,7 @@ Current column mappings found in available data sets:
 | AWS       | CUR                      | bill/BillingPeriodStartDate |
 | GCP       | BigQuery Billing Export  | invoice.month               |
 | Microsoft | Cost details             | BillingPeriodStartDate      |
-| OCI       | Cost reports             | lineItem/intervalUsageStart |
+| OCI       | Usage proxy BillingScheduleSummary API | timeStart |
 
 ## Example usage scenarios
 
@@ -19,7 +19,7 @@ Current column mappings found in available data sets:
 | GCP       | BigQuery Billing Export | Not available                      | 202304                   |
 | Microsoft | Cost details            | via Consumption API (usageDetails) | 2022-10-11T00:00:00Z     |
 | Microsoft | Cost details            | via Cost export file               | 02/13/2023               |
-| OCI       | Cost reports            | via Cost report file               | 2022-08-19T01:00Z        |
+| OCI       | Usage proxy BillingScheduleSummary API            | via [API](https://docs.oracle.com/en-us/iaas/api/#/en/usage-proxy/20190111/BillingScheduleSummary/)               | NA        |
 
 ## Discussion Topics
 


### PR DESCRIPTION
Adding OCI mappings in supporting content for billingperiodstart