### PR TITLE
FOCUS #264 : (Draft) Vendor Prefix Proposal - with registration

### DIFF
--- a/specification/attributes/column_naming_convention.md
+++ b/specification/attributes/column_naming_convention.md
@@ -27,7 +27,33 @@ Naming convention for columns appearing in billing data.
 - Custom columns SHOULD follow the same rules as FOCUS columns listed above.
 - All custom column IDs MUST start with a vendor prefix string and an underscore (e.g., `abc_ColumnName`).
   - Vendor prefixes MUST be lowercase, alphanumeric strings and SHOULD NOT be longer than 10 characters in length.
-  - Vendor prefixes MUST be representative of the company or brand that generated the column.
+  - Vendor prefixes MUST much match an entry in the Vendor Prefix List as defined in this appendix when an vendor organization is present therein.
+  - Columns making use of a vendor prefix MUST be generated and managed by the Management Organization in the Vendor Prefix List.
+  - Providers and managing organzition names SHOULD be listed in the Vendor Prefix List as defined in this appendix.
+  - Managing organizations SHOULD public a specification document for custom columns including the vendor prefix, column name, and the version of the FOCUS specification each column is compatible with.
+
+### Vendor Prefix List
+
+The following table lists the vendor prefixes that are currently registered in the Vendor Prefix List as part of the FOCUS specification.
+
+| Vendor Prefix | Provider Name         | Managing Organziation |
+|:--------------|:----------------------|:----------------------|
+| aws           | Amazon Web Services   | Amazon.com, Inc.      |
+| azure         | Azure                 | Microsoft Corporation |
+| gcp           | Google Cloud Platform | Google LLC            |
+| ibm           | IBM Cloud             | IBM                   |
+| oci           | Oracle Cloud          | Oracle Corporation    |
+
+If a provider or organization is not listed in the Vendor Prefix List and a provider or organization is present in the billing data, the provider or organization SHOULD be added to the Vendor Prefix List as part of the FOCUS specification.  Vendors and organizations can public preliminary specifications for custom columns prior to being added to the Vendor Prefix List.  The Vendor Prefix List will be updated as part of the FOCUS specification release process.
+
+Vendors and managing organizations can request a vendor prefix by submitting a pull request to the Vendor Prefix List in the FOCUS specification repository.  The pull request MUST include the following information:
+
+- Vendor prefix
+- Provider name
+- Managing organization name
+- Managing organization website URL
+- Managing organization contact name
+- Managing organization contact email address
 
 ## Exceptions
 


### PR DESCRIPTION
This adds more formal language to the Vendor prefix proposal and calls out the managing organization for each prefix.  

Let's get specific on what organization maintains each of these prefixes.  If we don't do this, I worry that a vendor could try to move ahead of a provider and start to create vendor prefix columns. We need to be specific as to ownership of the namespace.