### PR TITLE
Remove pricing model from wd chargetype

### DIFF
--- a/specification/attributes/column_naming_convention.md
+++ b/specification/attributes/column_naming_convention.md
@@ -34,7 +34,7 @@ Naming convention for columns appearing in billing data.
 
 ## Exceptions
 
-- Identifiers will use the "Id" abbreviation since this is a standard pattern across the industry.
+* Identifiers will use the "Id" abbreviation since this is a standard pattern across the industry.
 * Product offerings that incur charges will use the "Sku" abbreviation because it is a well-understood term both within and outside the industry.
 
 ## Introduced (version)

--- a/supporting_content/columns/chargetype.md
+++ b/supporting_content/columns/chargetype.md
@@ -64,13 +64,14 @@ Current values observed in billing data for various scenarios:
 | GCP       | regular                                                                                              |                                                                  | rounding_error<br>credit | tax |
 | Microsoft | Usage                                                                                                | Purchase                                                         | Refund<br>Adjustment     | Tax |
 
-### Examples of how Charge Type relates to Pricing Model / Frequency columns
+### Examples of how Charge Type relates to Pricing Category / Charge Frequency columns
 
-| Charge Type | PricingModel                                                                  | Frequency                                                                                     |
-| ----------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Purchase    | Commitment Discount<br>(Upfront SavingsPlan / Reservation)                    | OneTime (e.g., Upfront portion for InvoiceCost or Unused portion for AmortizedCost)           |
-| Purchase    | Commitment Discount (Partial upfront or no upfront SavingsPlan / Reservation) | Monthly (e.g., Recurring portion for InvoiceCost or Unused monthly portion for AmortizedCost) |
-| Usage       | OnDemand                                                                      | Hourly                                                                                        |
-| Usage       | SavingsPlan / Reservation                                                     | Hourly                                                                                        |
-| Adjustment  | NULL? OnDemand?                                                               | OneTime                                                                                       |
-| Tax         | NULL? OnDemand?                                                               | Monthly                                                                                       |
+| Scenario| ChargeCategory | ChargeSubcategory | PricingCategory  | Charge Frequency |
+|-|-|-|-|-|
+| Upfront discount purchase | Purchase| NULL  | On-Demand  | One-time |
+| Partial Upfront discount monthly fee | Purchase    | NULL  | On-Demand  | Recurring  |
+| Usage covered by upfront portion of partial upfront discount | Usage   | Used Commitment   | Commitment-based | Usage-based  |
+| Unused commitment of partial upfront discount    | Usage   | Unused Commitment | Commitment-based | Usage-based      |
+| Usage not covered by discount | Usage | On-Demand  | On-Demand   | Usage-based|
+| Refund | Adjustment   | Refund | NULL | One-time  |
+| Usage invoice tax charge   | Tax   |  NULL |  NULL | Recurring        |

--- a/supporting_content/columns/chargetype.md
+++ b/supporting_content/columns/chargetype.md
@@ -66,7 +66,7 @@ Current values observed in billing data for various scenarios:
 
 ### Examples of how Charge Type relates to Pricing Category / Charge Frequency columns
 
-| Scenario| ChargeCategory | ChargeSubcategory | PricingCategory  | Charge Frequency |
+| Scenario| ChargeType | ChargeSubcategory | PricingCategory  | Charge Frequency |
 |-|-|-|-|-|
 | Upfront discount purchase | Purchase| NULL  | On-Demand  | One-time |
 | Partial Upfront discount monthly fee | Purchase    | NULL  | On-Demand  | Recurring  |


### PR DESCRIPTION
Also updated the example table to include correct values for chargetype, chargefrequency, pricingcategory

Also fixed build error with seeing the earlier PR