### PR TITLE
Minor grammar/formatting cleanup around Tags and Charge Description

### DIFF
--- a/specification/columns/chargedescription.md
+++ b/specification/columns/chargedescription.md
@@ -1,6 +1,6 @@
 # Charge Description
 
-A Charge Description provides a high-level context of a row without requiring additional discovery. This column is a self-contained, summary explanation of what the charge is for and how it was priced. It typically covers a select group of corresponding details across a billing dataset or provides information not otherwise available.
+A Charge Description provides a high-level context of a row without requiring additional discovery. This column is a self-contained summary of what the charge is for and how it is priced. It typically covers a select group of corresponding details across a billing dataset or provides information not otherwise available.
 
 The Charge Description column MUST be present within the dataset, MUST be of type String, and SHOULD NOT be null. Providers SHOULD specify the length of this column in their publicly available FOCUS documentation.
 

--- a/specification/columns/chargedescription.md
+++ b/specification/columns/chargedescription.md
@@ -14,7 +14,7 @@ Charge Description
 
 ## Description
 
-Brief, human-readable summary of a row.
+Self-contained summary of the charge's purpose and price.
 
 ## Content Constraints
 

--- a/specification/columns/chargedescription.md
+++ b/specification/columns/chargedescription.md
@@ -1,6 +1,6 @@
 # Charge Description
 
-A Charge Description provides a high-level context of a row without requiring additional discovery. This column is a self-contained summary of what the charge is for and how it is priced. It typically covers a select group of corresponding details across a billing dataset or provides information not otherwise available.
+A Charge Description provides a high-level context of a row without requiring additional discovery. This column is a self-contained summary of the charge's purpose and price. It typically covers a select group of corresponding details across a billing dataset or provides information not otherwise available.
 
 The Charge Description column MUST be present within the dataset, MUST be of type String, and SHOULD NOT be null. Providers SHOULD specify the length of this column in their publicly available FOCUS documentation.
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -20,7 +20,7 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-The following is an example of one user-defined tag and one provider-defined tag, respectively, with tag key, `foo`.  The first tag, which is user-defined, is not prefixed. The second tag is prefixed with marketplace/ which the provider has specified as a reserved tag key prefix.
+The following is an example of one user-defined tag and one provider-defined tag, respectively, with tag key, `foo`.  The first tag is user-defined and is not prefixed. The second tag is provider-defined and is prefixed with `marketplace/` which the provider has specified as a reserved tag key prefix.
 
 ```json
     {
@@ -49,7 +49,7 @@ The table below represents a finalized billing dataset with these resources.  It
 | Sub Account     | my-sub-account | { "team": "ops", "env": "prod" }            |
 | Virtual Machine | my-vm          | { "team": "web", *"env": "prod"* }          |
 
-Because the the Virtual Machine Resource did not have an `env` tag, it inherited tag, `env:prod` (italicized), from its parent Sub Account.  Conversely, because the Virtual Machine Resource already has a `team` tag (`team:web`), it did not inherit `team:ops` from its parent Sub Account.
+Because the the Virtual Machine Resource does not have an `env` tag, `env:prod` is inherited tag, `env:prod` (italicized), from its parent Sub Account.  Conversely, because the Virtual Machine Resource already has a `team` tag (`team:web`), it does not inherit `team:ops` from its parent Sub Account.
 
 ## Column ID
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -20,12 +20,12 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-The following is an example of one user-defined tag and one provider-defined tag, respectively, with tag key, `foo`.  The first tag is user-defined and not prefixed. The second tag is provider-defined and prefixed with `marketplace/`, which the provider has specified as a reserved tag key prefix.
+The following is an example of one user-defined tag and one provider-defined tag, respectively, with tag key, `foo`.  The first tag is user-defined and not prefixed. The second tag is provider-defined and prefixed with `acme/`, which the provider has specified as a reserved tag key prefix.
 
 ```json
     {
         "foo":"bar",
-        "marketplace/foo": "bar"
+        "acme/foo": "bar"
     }
 ```
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -49,7 +49,7 @@ The table below represents a finalized billing dataset with these resources.  It
 | Sub Account     | my-sub-account | { "team": "ops", "env": "prod" }            |
 | Virtual Machine | my-vm          | { "team": "web", *"env": "prod"* }          |
 
-Because the the Virtual Machine Resource does not have an `env` tag, `env:prod` is inherited tag, `env:prod` (italicized), from its parent Sub Account.  Conversely, because the Virtual Machine Resource already has a `team` tag (`team:web`), it does not inherit `team:ops` from its parent Sub Account.
+Because the Virtual Machine Resource does not have an `env` tag, `env:prod` is the inherited tag from its parent Sub Account.  Conversely, because the Virtual Machine Resource already has a `team` tag (`team:web`), it does not inherit `team:ops` from its parent Sub Account.
 
 ## Column ID
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -20,7 +20,7 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-The following is an example of one user-defined tag and one provider-defined tag, respectively, with tag key, `foo`.  The first tag is user-defined and is not prefixed. The second tag is provider-defined and is prefixed with `marketplace/` which the provider has specified as a reserved tag key prefix.
+The following is an example of one user-defined tag and one provider-defined tag, respectively, with tag key, `foo`.  The first tag is user-defined and not prefixed. The second tag is provider-defined and prefixed with `marketplace/`, which the provider has specified as a reserved tag key prefix.
 
 ```json
     {


### PR DESCRIPTION
Minor grammar/format cleanup around Tags and Charge Description
- Minor sentence restructure
- Past tense -> Present tense
- Formatting a prefix as `code`