### PR TITLE
Numeric columns should not use 0 when no value

### DIFF
--- a/specification/attributes/null_handling.md
+++ b/specification/attributes/null_handling.md
@@ -20,7 +20,7 @@ Indicates how to handle columns that don't have a value.
 ## Requirements
 
 * Columns MUST use NULL when there isn't a value that can be specified for a nullable column.
-* String columns MUST NOT use empty strings or placeholder values such as "Not Set" or "Not Applicable" in columns, regardless of whether the column allows nulls or not.
+* Columns MUST NOT use empty strings or placeholder values such as "Not Set" or "Not Applicable" in columns, regardless of whether the column allows nulls or not.
 * Numeric columns MUST use NULL and MUST NOT use 0 when there isn't a value, regardless of whether the column allows nulls or not.
 
 ## Exceptions

--- a/specification/attributes/null_handling.md
+++ b/specification/attributes/null_handling.md
@@ -20,8 +20,7 @@ Indicates how to handle columns that don't have a value.
 ## Requirements
 
 * Columns MUST use NULL when there isn't a value that can be specified for a nullable column.
-* Columns MUST NOT use empty strings or placeholder values such as "Not Set" or "Not Applicable" in columns, regardless of whether the column allows nulls or not.
-* Numeric columns MUST use NULL and MUST NOT use 0 when there isn't a value, regardless of whether the column allows nulls or not.
+* Columns MUST NOT use empty strings or placeholder values such as 0 for numeric columns or "Not Applicable" for string columns, regardless of whether the column allows nulls or not.
 
 ## Exceptions
 

--- a/specification/attributes/null_handling.md
+++ b/specification/attributes/null_handling.md
@@ -20,7 +20,8 @@ Indicates how to handle columns that don't have a value.
 ## Requirements
 
 * Columns MUST use NULL when there isn't a value that can be specified for a nullable column.
-* Columns MUST NOT use empty strings or placeholder values such as "Not Set" or "Not Applicable" in columns, regardless of if the column allows nulls or not.
+* String columns MUST NOT use empty strings or placeholder values such as "Not Set" or "Not Applicable" in columns, regardless of whether the column allows nulls or not.
+* Numeric columns MUST use NULL and MUST NOT use 0 when there isn't a value, regardless of whether the column allows nulls or not.
 
 ## Exceptions
 


### PR DESCRIPTION
Adding additional clarity to ensure numeric columns do not use `0` in place of a null when there is no value. 