### PR TITLE
Related to Issue #342 - Tag key differentation when a supporting value can or cannot exist.

### DIFF
--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -26,7 +26,7 @@ The following is an example of one user-defined tag and one provider-defined tag
 ```json
     {
         "foo":"bar",
-        "acme/foo": "bar"
+        "acme/foo":"bar"
     }
 ```
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -9,7 +9,7 @@ The Tags column adheres to the following requirements:
 * The Tags column MUST contain user-defined and provider-defined tags.
 * The Tags column MUST only contain finalized tags.
 * The Tags column MUST be in [Key-Value Format](#key-valueformat).
-* A Tag key that supports a corresponding, non-null value tied to a resource SHOULD NOT be included.
+* A Tag key that supports a corresponding, non-null value tied to a resource SHOULD be included.
 * A Tag key that does *not* support a corresponding value, sometimes referred to as a *label*, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT alter user-defined Tag keys or values.

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -9,8 +9,8 @@ The Tags column adheres to the following requirements:
 * The Tags column MUST contain user-defined and provider-defined tags.
 * The Tags column MUST only contain finalized tags.
 * The Tags column MUST be in [Key-Value Format](#key-valueformat).
-* A Tag key that supports a corresponding value but that value is null MUST NOT be included.
-* A Tag key that does *not* support a corresponding value, sometimes referred to as a *label*, MUST have a corresponding null value set.
+* A Tag key that supports a corresponding value but that value is null SHOULD NOT be included.
+* A Tag key that does *not* support a corresponding value, sometimes referred to as a *label*, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT alter user-defined Tag keys or values.
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -9,7 +9,7 @@ The Tags column adheres to the following requirements:
 * The Tags column MUST contain user-defined and provider-defined tags.
 * The Tags column MUST only contain finalized tags.
 * The Tags column MUST be in [Key-Value Format](#key-valueformat).
-* A Tag key that supports a corresponding value but that value is null SHOULD NOT be included.
+* A Tag key that supports a corresponding, non-null value tied to a resource SHOULD NOT be included.
 * A Tag key that does *not* support a corresponding value, sometimes referred to as a *label*, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT alter user-defined Tag keys or values.

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -9,7 +9,7 @@ The Tags column adheres to the following requirements:
 * The Tags column MUST contain user-defined and provider-defined tags.
 * The Tags column MUST only contain finalized tags.
 * The Tags column MUST be in [Key-Value Format](#key-valueformat).
-* A Tag key that supports a corresponding value and that value is null MUST NOT be included.
+* A Tag key that supports a corresponding value but that value is null MUST NOT be included.
 * A Tag key that does *not* support a corresponding value, sometimes referred to as a *label*, MUST have a corresponding null value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT alter user-defined Tag keys or values.

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -9,7 +9,8 @@ The Tags column adheres to the following requirements:
 * The Tags column MUST contain user-defined and provider-defined tags.
 * The Tags column MUST only contain finalized tags.
 * The Tags column MUST be in [Key-Value Format](#key-valueformat).
-* A Tag key without a specified value MUST have its tag value set to null.
+* A Tag key that supports a corresponding value and that value is null MUST NOT be included.
+* A Tag key that does *not* support a corresponding value, sometimes referred to as a *label*, MUST have a corresponding null value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT alter user-defined Tag keys or values.
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -9,7 +9,8 @@ The Tags column adheres to the following requirements:
 * The Tags column MUST contain user-defined and provider-defined tags.
 * The Tags column MUST only contain finalized tags.
 * The Tags column MUST be in [Key-Value Format](#key-valueformat).
-* A Tag key that supports a corresponding, non-null value tied to a resource SHOULD be included.
+* A Tag key with a non-null value for a given resource SHOULD be included in the tags column.
+* Depending on the provider's tag finalization process, a Tag key with a null value for a given resource MAY be included in the tags column.
 * A Tag key that does *not* support a corresponding value, sometimes referred to as a *label*, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT alter user-defined Tag keys or values.
@@ -21,12 +22,13 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-The following is an example of one user-defined tag and one provider-defined tag, respectively, with tag key, `foo`.  The first tag is user-defined and not prefixed. The second tag is provider-defined and prefixed with `acme/`, which the provider has specified as a reserved tag key prefix.
+The following is an example of one user-defined tag, one provider-defined tag, respectively, with tag key, `foo`, and one tag key without a supported value.  The first tag is user-defined and not prefixed. The second tag is provider-defined and prefixed with `acme/`, which the provider has specified as a reserved tag key prefix. The third tag with tag key, `baz`, does not support a value, so `null` is assigned as its value.
 
 ```json
     {
-        "foo":"bar",
-        "acme/foo":"bar"
+        "foo": "bar",
+        "acme/foo": "bar",
+        "baz": null,
     }
 ```
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -10,7 +10,7 @@ The Tags column adheres to the following requirements:
 * The Tags column MUST only contain finalized tags.
 * The Tags column MUST be in [Key-Value Format](#key-valueformat).
 * A Tag key with a non-null value for a given resource SHOULD be included in the tags column.
-* Depending on the provider's tag finalization process, a Tag key with a null value for a given resource MAY be included in the tags column.
+* A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
 * A Tag key that does *not* support a corresponding value, sometimes referred to as a *label*, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT alter user-defined Tag keys or values.

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -22,7 +22,7 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-The following is an example of one user-defined tag, one provider-defined tag, respectively, with tag key, `foo`, and one tag key without a supported value.  The first tag is user-defined and not prefixed. The second tag is provider-defined and prefixed with `acme/`, which the provider has specified as a reserved tag key prefix. The third tag with tag key, `baz`, does not support a value, so `true` (boolean) is assigned as its value.
+This example illustrates three different tagging scenarios. The first two illustrate when the provider supports both keys and values, while the third is for supporting keys only. The first tag is user-defined and doesn't have a provider prefix. The second tag is provider-defined and has a prefix of `acme/`, which is reserved by the provider. The third tag has a tag key of `baz` and its value is assigned the boolean value `true` since the tag doesn't support a value.
 
 ```json
     {

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -22,13 +22,13 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-The following is an example of one user-defined tag, one provider-defined tag, respectively, with tag key, `foo`, and one tag key without a supported value.  The first tag is user-defined and not prefixed. The second tag is provider-defined and prefixed with `acme/`, which the provider has specified as a reserved tag key prefix. The third tag with tag key, `baz`, does not support a value, so `null` is assigned as its value.
+The following is an example of one user-defined tag, one provider-defined tag, respectively, with tag key, `foo`, and one tag key without a supported value.  The first tag is user-defined and not prefixed. The second tag is provider-defined and prefixed with `acme/`, which the provider has specified as a reserved tag key prefix. The third tag with tag key, `baz`, does not support a value, so `true` (boolean) is assigned as its value.
 
 ```json
     {
         "foo": "bar",
         "acme/foo": "bar",
-        "baz": null,
+        "baz": true,
     }
 ```
 

--- a/supporting_content/columns/tags.md
+++ b/supporting_content/columns/tags.md
@@ -51,4 +51,6 @@ Discussion / Scratch space:
 		- “Custom Tags/Labels”?
 		- One key/value pair for all tags “tags”: [ … ]
 	- Which raw format do we go with?
-
+    	- After much discussion and exploring multiple different options, and formats, the following were decided:
+        	- Tags are presented in a json structure - key/value (tags) and key-only (labels) are both included using the same json object.
+        	- Labels will be shown with a value of true (boolean not string). Other options were to break labels out into a separate column, separate part of the JSON object, or provide inline with null OR the boolean    	- 


### PR DESCRIPTION
Related to Issue: https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/342

Further clarifying that:
1. Tag keys that cannot support values are given a `true` (boolean) value
--> (ex: [GCP single-entity tags](https://cloud.google.com/vpc/docs/add-remove-network-tags)) `vpc` becomes `"vpc":true` and is included in `Tags`
3. Tag keys that exist but aren't set on a resource aren't included as tags
--> If tag `team` exists but is not set on resource id 'abc', associated `Tags` will _not_ contain `"team":true`