### PR TITLE
Update column_naming_convention.md

### DIFF
--- a/specification/attributes/column_naming_convention.md
+++ b/specification/attributes/column_naming_convention.md
@@ -24,6 +24,7 @@ Naming convention for columns appearing in billing data.
   * Column IDs SHOULD NOT use acronyms.
   * Column IDs MUST be alphanumeric with no special characters.
   * Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the Name suffix if there are no other columns with the same name prefix.
+  * Columns names MUST must not exceed a certain string length. Maximum 64 characters.
 * Custom (e.g., provider-defined) columns SHOULD follow the same rules as FOCUS columns listed above.
 * Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the `Name` suffix if it is considered superfluous.
 * Columns with the `Category` suffix must be normalized.

--- a/specification/attributes/column_naming_convention.md
+++ b/specification/attributes/column_naming_convention.md
@@ -18,7 +18,7 @@ Naming convention for columns appearing in billing data.
 
 ## Requirements
 
-* All columns defined by FOCUS(*) MUST follow the following rules:
+* All columns defined by FOCUS MUST follow the following rules:
   * Column IDs MUST use [Pascal case](https://techterms.com/definition/pascalcase).
   * Column IDs MUST NOT use abbreviations.
   * Column IDs MUST be alphanumeric with no special characters.

--- a/specification/attributes/column_naming_convention.md
+++ b/specification/attributes/column_naming_convention.md
@@ -24,7 +24,7 @@ Naming convention for columns appearing in billing data.
   * Column IDs SHOULD NOT use acronyms.
   * Column IDs MUST be alphanumeric with no special characters.
   * Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the Name suffix if there are no other columns with the same name prefix.
-  * Columns names MUST must not exceed a certain string length. Maximum 64 characters.
+  * Column IDs SHOULD NOT exceed 59 characters.
 * Custom (e.g., provider-defined) columns SHOULD follow the same rules as FOCUS columns listed above.
 * Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the `Name` suffix if it is considered superfluous.
 * Columns with the `Category` suffix must be normalized.

--- a/specification/attributes/column_naming_convention.md
+++ b/specification/attributes/column_naming_convention.md
@@ -18,17 +18,17 @@ Naming convention for columns appearing in billing data.
 
 ## Requirements
 
-* All columns defined by FOCUS MUST follow the following rules:
+* All columns defined by FOCUS(*) MUST follow the following rules:
   * Column IDs MUST use [Pascal case](https://techterms.com/definition/pascalcase).
   * Column IDs MUST NOT use abbreviations.
-  * Column IDs SHOULD NOT use acronyms.
   * Column IDs MUST be alphanumeric with no special characters.
   * Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the Name suffix if there are no other columns with the same name prefix.
+  * Column IDs SHOULD NOT use acronyms.
   * Column IDs SHOULD NOT exceed 59 characters.
-* Custom (e.g., provider-defined) columns SHOULD follow the same rules as FOCUS columns listed above.
-* Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the `Name` suffix if it is considered superfluous.
-* Columns with the `Category` suffix must be normalized.
 * All custom columns MUST be prefixed with a consistent `x_` prefix to identify them as external, custom columns and distinguish them from FOCUS columns to avoid conflicts in future releases.
+* Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the `Name` suffix if it is considered superfluous.
+* Columns with the `Category` suffix MUST be normalized.
+* Custom (e.g., provider-defined) columns SHOULD follow the same rules as FOCUS(*) columns listed above.
 * All FOCUS columns SHOULD be first in the provided dataset.
   * Custom columns SHOULD be listed after all FOCUS columns and SHOULD NOT be intermixed.
   * Columns MAY be sorted alphabetically but custom columns SHOULD be after all FOCUS columns.

--- a/specification/attributes/column_naming_convention.md
+++ b/specification/attributes/column_naming_convention.md
@@ -24,7 +24,7 @@ Naming convention for columns appearing in billing data.
   * Column IDs MUST be alphanumeric with no special characters.
   * Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the Name suffix if there are no other columns with the same name prefix.
   * Column IDs SHOULD NOT use acronyms.
-  * Column IDs SHOULD NOT exceed 59 characters.
+  * Column IDs SHOULD NOT exceed 50 characters to accommodate column length restrictions of various data repositories.
 * All custom columns MUST be prefixed with a consistent `x_` prefix to identify them as external, custom columns and distinguish them from FOCUS columns to avoid conflicts in future releases.
 * Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the `Name` suffix if it is considered superfluous.
 * Columns with the `Category` suffix MUST be normalized.


### PR DESCRIPTION
ColumnNameLegth suggestion.
* The suggestion is to put a column name length limit to the columns, let's say 64 characters. This character length can be changed as decided by the group members
* This would prevent super long unreadable column names and add some discipline.
* Issue created : https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/362