### PR TITLE
Clarify what qualifies as a tag and what different types of tags are

### DIFF
--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -1,6 +1,6 @@
 # Tags
 
-The Tags column represents the set of tags assigned to [*tag sources*](#glossary:tag-source) that also account for potential provider-defined or user-defined tag evaluations. Tags are commonly used for scenarios like adding business context to billing data to identify and accurately allocate charges. Tags may also be referred to by providers by other terms, such as labels or networks tags.
+The Tags column represents the set of tags assigned to [*tag sources*](#glossary:tag-source) that also account for potential provider-defined or user-defined tag evaluations. Tags are commonly used for scenarios like adding business context to billing data to identify and accurately allocate charges. Tags may also be referred to by providers using other terms such as labels.
 
 A tag becomes [*finalized*](#glossary:finalized-tag) when a single value is selected from a set of possible tag values assigned to the tag key.  When supported by a provider, this can occur when a tag value is set by provider-defined or user-defined rules.
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -1,6 +1,6 @@
 # Tags
 
-The Tags column represents the set of tags assigned to [*tag sources*](#glossary:tag-source) that also account for potential provider-defined or user-defined tag evaluations.  In FOCUS, "Tag" is a generic term to describe metadata that can be attached to a resource, account, etc. by a user or provider to help identify it. Tags may also be referred to by providers by other terms, such as labels or networks tags. Tags are commonly used for scenarios like adding business context to billing data to identify and accurately allocate charges. 
+The Tags column represents the set of tags assigned to [*tag sources*](#glossary:tag-source) that also account for potential provider-defined or user-defined tag evaluations. Tags are commonly used for scenarios like adding business context to billing data to identify and accurately allocate charges. Tags may also be referred to by providers by other terms, such as labels or networks tags.
 
 A tag becomes [*finalized*](#glossary:finalized-tag) when a single value is selected from a set of possible tag values assigned to the tag key.  When supported by a provider, this can occur when a tag value is set by provider-defined or user-defined rules.
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -1,6 +1,6 @@
 # Tags
 
-The Tags column represents the set of tags assigned to [*tag sources*](#glossary:tag-source) that also account for potential provider-defined or user-defined tag evaluations.  Tags are commonly used for scenarios like adding business context to billing data to identify and accurately allocate charges.
+The Tags column represents the set of tags assigned to [*tag sources*](#glossary:tag-source) that also account for potential provider-defined or user-defined tag evaluations.  In FOCUS, "Tag" is a generic term to describe metadata that can be attached to a resource, account, etc. by a user or provider to help identify it. Tags may also be referred to by providers by other terms, such as labels or networks tags. Tags are commonly used for scenarios like adding business context to billing data to identify and accurately allocate charges. 
 
 A tag becomes [*finalized*](#glossary:finalized-tag) when a single value is selected from a set of possible tag values assigned to the tag key.  When supported by a provider, this can occur when a tag value is set by provider-defined or user-defined rules.
 
@@ -11,7 +11,7 @@ The Tags column adheres to the following requirements:
 * The Tags column MUST be in [Key-Value Format](#key-valueformat).
 * A Tag key with a non-null value for a given resource SHOULD be included in the tags column.
 * A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
-* A Tag key that does *not* support a corresponding value, sometimes referred to as a *label*, MUST have a corresponding true (boolean) value set.
+* A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT alter user-defined Tag keys or values.
 


### PR DESCRIPTION
We incorrectly suggested that **labels** are usually **key-only tags**. In GCP, labels are key-value pairs https://cloud.google.com/compute/docs/labeling-resources

This PR corrects this by not trying to give a specific name to key-value tags and key-only tags.

This PR also attempts to provide some guidance on what qualifies as a tag (to prevent this from becoming a dumping ground for key-value data) and suggests some other names for tags.