### PR TITLE
Update availabilityzone when column no present

### DIFF
--- a/specification/columns/availabilityzone.md
+++ b/specification/columns/availabilityzone.md
@@ -2,7 +2,7 @@
 
 An [*availability zone*](#glossary:availability-zone) is a provider-assigned identifier for a physically separated and isolated area within a Region that provides high availability and fault tolerance. Availability Zone is commonly used for scenarios like analyzing cross-zone data transfer usage and the corresponding cost based on where [*resources*](#glossary:resource) are deployed.
 
-The AvailabilityZone column SHOULD be present in the billing data when the provider supports deploying resources or services within an *availability zone*. This column MUST be of type String and MAY contain null values when a charge is not specific to an *availability zone*. The AvailabilityZone column MAY NOT be present in the billing dataset when the provider does not support provisioning resources into an Availability Zone. However, if it is provided, it MUST be null.
+The AvailabilityZone column is RECOMMENDED to be present in the billing data when the provider supports deploying resources or services within an *availability zone*. This column MUST be of type String and MAY contain null values when a charge is not specific to an *availability zone*. 
 
 ## Column ID
 

--- a/specification/columns/availabilityzone.md
+++ b/specification/columns/availabilityzone.md
@@ -21,7 +21,7 @@ A provider-assigned identifier for a physically separated and isolated area with
 | Constraint      | Value            |
 |:----------------|:-----------------|
 | Column type     | Dimension        |
-| Feature level   | Conditional      |
+| Feature level   | Recommended      |
 | Allows nulls    | True             |
 | Data type       | String           |
 | Value format    | \<not specified> |

--- a/specification/columns/availabilityzone.md
+++ b/specification/columns/availabilityzone.md
@@ -2,7 +2,7 @@
 
 An [*availability zone*](#glossary:availability-zone) is a provider-assigned identifier for a physically separated and isolated area within a Region that provides high availability and fault tolerance. Availability Zone is commonly used for scenarios like analyzing cross-zone data transfer usage and the corresponding cost based on where [*resources*](#glossary:resource) are deployed.
 
-The AvailabilityZone column SHOULD be present in the billing data when the provider supports deploying resources or services within an *availability zone*. This column MUST be of type String and MAY contain null values when a charge is not specific to an *availability zone*.
+The AvailabilityZone column SHOULD be present in the billing data when the provider supports deploying resources or services within an *availability zone*. This column MUST be of type String and MAY contain null values when a charge is not specific to an *availability zone*. The AvailabilityZone column MAY NOT be present in the billing dataset when the provider does not support provisioning resources into an Availability Zone. However, if it is provided, it MUST be null.
 
 ## Column ID
 


### PR DESCRIPTION
This PR is based on discussions in Issue #387.
The PR aims to introduce the less changes as possible. In this case, it provides a clarification when the column MAY NOT be present and if provided value MUST be null.