### PR TITLE
FOCUS #406 (v1.1 draft): Extend CommitmentDiscountCategory column to categorize on-demand row eligibility for commitments

### DIFF
--- a/specification/columns/commitmentdiscountcategory.md
+++ b/specification/columns/commitmentdiscountcategory.md
@@ -1,8 +1,16 @@
 # Commitment Discount Category
 
-Commitment Discount Category indicates whether the [*commitment-based discount*](#glossary:commitment-based-discount) identified in the CommitmentDiscountId column is based on usage quantity or cost (aka "spend").
+Commitment Discount Category indicates the category of a [*commitment-based discount*](#glossary:commitment-based-discount) purchase or the eligibility category of an on-demand or usage-based charges.
 
-The CommitmentDiscountCategory column MUST be present in the billing data when the provider supports *commitment-based discounts*. This column MUST be of type String, MUST be null when [CommitmentDiscountId](#commitmentdiscountid) is null, and MUST NOT be null when CommitmentDiscountId is not null. The CommitmentDiscountCategory MUST be one of the allowed values.
+The CommitmentDiscountCategory column MUST be of type String and be present in the billing data when the provider supports commitment-based discounts.
+
+CommitmentDiscountCategory MUST NOT be *Multiple* when a CommitmentDiscountId exists.
+
+A CommitmentDiscountCategory value MUST be applied to a [*row*](#glossary:row) when [ChargeCategory](#chargecategory) is *Purchase*, or ChargeCategory is *Usage* and [ChargeSubCategory](#chargesubcategory) is *Used* or *Unused*.
+
+A CommitmentDiscountCategory value MUST be applied to a row where the ChargeCategory is *Usage*, ChargeSubCategory is *On-Demand*, and the [SkuId](#skuid) is eligible for one or more commitments offered by the provider.
+
+In all other cases, CommitmentDiscountCategory MUST be null.
 
 ## Column ID
 
@@ -14,7 +22,7 @@ Commitment Discount Category
 
 ## Description
 
-Indicates whether the *commitment-based discount* identified in the CommitmentDiscountId column is based on usage quantity or cost (aka "spend").
+Indicates the category of a Commitment-Based Discount purchase or the eligibility category of an on-demand or usage-based charges
 
 ## Content constraints
 
@@ -28,11 +36,12 @@ Indicates whether the *commitment-based discount* identified in the CommitmentDi
 
 Allowed values:
 
-| Value   | Description                                                              |
-|:--------|:-------------------------------------------------------------------------|
-| Spend   | Commitment-based discounts that require a predetermined amount of spend. |
-| Usage   | Commitment-based discounts that require a predetermined amount of usage. |
+| Value    | Description                                                                                   |
+|:---------|:----------------------------------------------------------------------------------------------|
+| Spend    | Commitment-based discounts that require a predetermined amount of spend.                      |
+| Usage    | Commitment-based discounts that require a predetermined amount of usage.                      |
+| Multiple | On-demand usage charges that are eligible for both Spend and Usage commitment-based discounts |
 
 ## Introduced (version)
 
-1.0-preview
+1.1

--- a/specification/columns/commitmentdiscountcategory.md
+++ b/specification/columns/commitmentdiscountcategory.md
@@ -1,6 +1,6 @@
 # Commitment Discount Category
 
-Commitment Discount Category indicates the category of a [*commitment-based discount*](#glossary:commitment-based-discount) purchase or the eligibility category of an on-demand or usage-based charges.
+Commitment Discount Category indicates the category of a [*commitment-based discount*](#glossary:commitment-based-discount) purchase or the eligibility category of on-demand or usage-based charges.
 
 The CommitmentDiscountCategory column MUST be of type String and be present in the billing data when the provider supports commitment-based discounts.
 
@@ -22,7 +22,7 @@ Commitment Discount Category
 
 ## Description
 
-Indicates the category of a Commitment-Based Discount purchase or the eligibility category of an on-demand or usage-based charges
+Indicates the category of a Commitment-Based Discount purchase or the eligibility category of on-demand or usage-based charges
 
 ## Content constraints
 

--- a/supporting_content/columns/commitmentdiscountcategory.md
+++ b/supporting_content/columns/commitmentdiscountcategory.md
@@ -14,14 +14,29 @@ Current column mappings found in available data sets:
 
 Current values observed in billing data for various scenarios:
 
-| Provider | Data set                 | CommitmentDiscountCategory     | CommitmentDiscountProgram (Name TBD)     |
-|----------|--------------------------|----------------------------|------------------------------------------|
-| AWS | CUR (PurchaseOption)                   | Usage               | Reserved Instances              |
-| AWS | CUR (PurchaseOption)                   | Spend               | Savings Plans                   |
-| Google Cloud | BigQuery Billing Export | Usage        | Resource-based CUD                            |
-| Google Cloud | BigQuery Billing Export | Spend        | Spend-based CUD                               |
-| Microsoft | Cost Details (PricingModel)| Spend                     | Savings Plan                     |
-| Microsoft | Cost Details (PricingModel)| Usage                     | Reservation                      |
+| Provider     | CommitmentDiscountName (Name TBD)      | CommitmentDiscountCateogory |
+|--------------|----------------------------------------------------------------------|
+| AWS          | Reserved Instances (RI)                | Usage                       |
+| AWS          | Savings Plan                           | Spend                       |
+| Google Cloud | Committed Use Discount (CUD)           | Usage                       |
+| Google Cloud | Flex Committed Use Discount (Flex CUD) | Usage                       |
+| Google Cloud | BigQuery Reservations                  | Usage                       |
+| Microsoft    | Reservation                            | Usage                       |
+| Microsoft    | Savings Plan                           | Spend                       |
+
+Additionally, typical SaaS annual commits should also fall under *Spend*.
+
+Example of mock dataset with Commitment Discount Category:
+
+| ProviderName | ServiceName         | Charge Category | Charge Subcategory | Commitment Discount Type | Commitment Discount Category |
+|--------------|----------------------------------------------------------------------------------------------------------------------|
+| AWS          | AmazonEC2           | Purchase        | null               | Reserved Instances (RI)  | Usage                        |
+| AWS          | ComputeSavingsPlans | Purchase        | null               | Savings Plan             | Spend                        |
+| AWS          | AmazonEC2           | Usage           | On-Demand          | null                     | Multiple                     |
+| AWS          | AmazonEC2           | Usage           | Used               | Reserved Instances (RI)  | Usage                        |
+| AWS          | AmazonEC2           | Usage           | Unused             | Reserved Instances (RI)  | Usage                        |
+| AWS          | AmazonEC2           | Usage           | Used               | Savings Plan             | Spend                        | 
+| AWS          | AmazonEC2           | Usage           | Unused             | Savings Plan             | Spend                        |
 
 ## Documentation
 - Microsoft

--- a/supporting_content/columns/commitmentdiscounttype.md
+++ b/supporting_content/columns/commitmentdiscounttype.md
@@ -18,6 +18,7 @@ Examples of found in available data sets:
 | AWS | Savings Plan |
 | AWS | Capacity Blocks for ML |
 | Google Cloud | Committed Use Discount (CUD) |
+| Google Cloud | Flex Committed Use Discount (Flex CUD) |
 | Google Cloud | BigQuery Reservations |
 | Microsoft | Savings Plan |
 | Microsoft | Reservation |


### PR DESCRIPTION
Extend column: `CommitmentDiscountCategory` provide visibility into commitment-based coverage potential.

A CommitmentDiscountCategory value exists when (assuming a Savings Plan):
1. ChargeCategory: Purchase -->  CommitmentDiscountCategory: Spend
2. ChargeCategory: Usage, ChargeSubCategory: Used -->  CommitmentDiscountCategory: Spend
3. ChargeCategory: Usage, ChargeSubCategory: Unused -->  CommitmentDiscountCategory: Spend

To help practitioners derive Commitment Coverage potential to determine how much _more_ savings is possible, this pr extends `CommitmentDiscountCategory` with the following scenarios where `CommitmentDiscountId` is null:

## Scenario 4: AWS EC2 VM is _eligible_ for an Reserved Instance or Savings Plan, so `Multiple` is assigned
- ChargeCategory: Usage
- ChargeSubCategory: On-Demand
- SkuId: <EC2 VM>
**--> CommitmentDiscountCategory: Multiple**

## Scenario 5: AWS RDS VM is _eligible_ for a Reserved Instance (only), so `Usage` is assigned
- ChargeCategory: Usage
- ChargeSubCategory: On-Demand
- SkuId: <RDS VM>
**--> CommitmentDiscountCategory: Usage**

## Scenario 6: AWS Lambda is _eligible_ for a  Savings Plan (only), so `Spend` is assigned
- ChargeCategory: Usage 
- ChargeSubCategory: On-Demand
- SkuId: <Lambda VM>
**--> CommitmentDiscountCategory: Spend**

With these additional scenarios, practitioners can calculate their commitment coverage rate (and drill down) as:
```
(SELECT SUM(ChargePeriodEnd - ChargePeriodStart) FROM <table> WHERE CommitmentDiscountCategory IS NOT NULL AND ChargeSubCategory = 'Used') 
/
(SELECT SUM(ChargePeriodEnd - ChargePeriodEnd) FROM <table> WHERE CommitmentDiscountCategory IS NOT NULL AND ChargeSubCategory IN ('Used', 'On-Demand'))
* 100
```