### PR TITLE
FOCUS #330: Update chargeclass value from "Regular" to "Standard"

### DIFF
--- a/specification/columns/chargeclass.md
+++ b/specification/columns/chargeclass.md
@@ -30,7 +30,7 @@ Allowed values:
 
 | Value      | Description                          |
 | :--------- | :------------------------------------|
-| Regular    | Standard charges for services used or purchased. |
+| Standard    | Standard charges for services used or purchased. |
 | Correction  | Modification to one or more previous charges, like refunds and credit modifications. |
 
 ## Introduced (version)


### PR DESCRIPTION
Pricing category had the value "on-demand" changed to "Standard", so recommend keeping consistency in naming and have charge class value as "Standard" instead of "Regular"