### PR TITLE
Update naming and ordering attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `Column naming convention` attribute includes the following new provisions:
   - Column IDs should not exceed 50 characters.
+  - Attribute renamed to `Column naming and ordering` to denote it also includes rules for column ordering.
 - `ChargeCategory` column updates:
   - Added "Credit" value for credits and any applicable credit corrections. See added `ChargeClass` column.
   - Updated "Usage", "Purchase", and "Tax" to include refunds/corrections. See added `ChargeClass` column.

--- a/specification/attributes/attributes.mdpp
+++ b/specification/attributes/attributes.mdpp
@@ -5,7 +5,7 @@ conventions, data types, formatting standardizations, etc. Attributes may introd
 for data granularity, recency, frequency, etc. Requirements defined in attributes are necessary for servicing
 [FinOps capabilities][FODOFC] accurately using a standard set of instructions regardless of the origin of the data.
 
-!INCLUDE "column_naming_convention.md",1
+!INCLUDE "column_naming_and_ordering.md",1
 !INCLUDE "currency_code_format.md",1
 !INCLUDE "datetime_format.md",1
 !INCLUDE "discount_handling.md",1

--- a/specification/attributes/column_naming_and_ordering.md
+++ b/specification/attributes/column_naming_and_ordering.md
@@ -1,23 +1,24 @@
-# Column Naming Convention
+# Column Naming and Ordering
 
-Column IDs provided in cost data following a consistent naming convention reduce friction for FinOps practitioners who consume the data for analysis, reporting, and other use cases.
+Column IDs provided in cost data following a consistent naming and ordering convention reduce friction for FinOps practitioners who consume the data for analysis, reporting, and other use cases.
 
-All columns defined in the FOCUS specification MUST follow the naming requirements listed below.
+All columns defined in the FOCUS specification MUST follow the naming and ordering requirements listed below.
 
 ## Attribute ID
 
-ColumnNamingConvention
+ColumnNamingAndOrdering
 
 ## Attribute Name
 
-Column Naming Convention
+Column Naming and Ordering
 
 ## Description
 
-Naming convention for columns appearing in billing data.
+Naming and ordering convention for columns appearing in billing data.
 
 ## Requirements
 
+### Column Names
 * All columns defined by FOCUS MUST follow the following rules:
   * Column IDs MUST use [Pascal case](https://techterms.com/definition/pascalcase).
   * Column IDs MUST NOT use abbreviations.
@@ -28,10 +29,12 @@ Naming convention for columns appearing in billing data.
 * All custom columns MUST be prefixed with a consistent `x_` prefix to identify them as external, custom columns and distinguish them from FOCUS columns to avoid conflicts in future releases.
 * Columns that have an ID and a Name MUST have the `Id` or `Name` suffix in the Column ID. Display Name for a Column MAY avoid the `Name` suffix if it is considered superfluous.
 * Columns with the `Category` suffix MUST be normalized.
-* Custom (e.g., provider-defined) columns SHOULD follow the same rules as FOCUS(*) columns listed above.
+* Custom (e.g., provider-defined) columns SHOULD follow the same rules listed above for FOCUS columns.
+
+### Column Order
 * All FOCUS columns SHOULD be first in the provided dataset.
-  * Custom columns SHOULD be listed after all FOCUS columns and SHOULD NOT be intermixed.
-  * Columns MAY be sorted alphabetically but custom columns SHOULD be after all FOCUS columns.
+* Custom columns SHOULD be listed after all FOCUS columns and SHOULD NOT be intermixed.
+* Columns MAY be sorted alphabetically, but custom columns SHOULD be after all FOCUS columns.
 
 ## Exceptions
 


### PR DESCRIPTION
Update naming and ordering attribute to reference "ordering" explicitly in various places.

This is a replacement pull request [for this request](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/405) which was generated from a repo fork.

This new PR was generated from a branch created directly in the FOCUS repo.