### PR TITLE
426-consistency-review-chargecategory-definition-and-description-review

### DIFF
--- a/specification/columns/chargecategory.md
+++ b/specification/columns/chargecategory.md
@@ -1,6 +1,6 @@
 # Charge Category
 
-A Charge Category is the highest level classification for the type of charge that the billing row represents. The Charge Category is commonly used to identify prepaid purchases separately from usage-based charges or to separate charges that may require special handling from regular usage.
+Charge Category represents the highest-level classification of a charge based on its nature, distinguishing between usage-based charges, purchases (one-time or recurring), after-the-fact adjustments, credits, and taxes.
 
 The ChargeCategory column MUST be present in the billing data and MUST NOT be null. This column is of type String and MUST be one of the allowed values.
 
@@ -14,7 +14,7 @@ Charge Category
 
 ## Description
 
-Indicates whether the row represents an upfront or recurring fee, cost of usage that already occurred, an after-the-fact *adjustment* (e.g., credits), or taxes.
+Represents the highest-level classification of a charge based on its nature, distinguishing between usage-based charges, purchases (one-time or recurring), after-the-fact adjustments, credits, and taxes.
 
 ## Content Constraints
 

--- a/specification/columns/chargecategory.md
+++ b/specification/columns/chargecategory.md
@@ -14,7 +14,7 @@ Charge Category
 
 ## Description
 
-Represents the highest-level classification of a charge based on its nature, distinguishing between usage-based charges, purchases (one-time or recurring), after-the-fact adjustments, credits, and taxes.
+Represents the highest-level classification of a charge based on the nature of how it is billed.
 
 ## Content Constraints
 

--- a/specification/columns/chargecategory.md
+++ b/specification/columns/chargecategory.md
@@ -1,6 +1,6 @@
 # Charge Category
 
-Charge Category represents the highest-level classification of a charge based on its nature, distinguishing between usage-based charges, purchases (one-time or recurring), after-the-fact adjustments, credits, and taxes.
+Charge Category represents the highest-level classification of a charge based on the nature of how it is billed. Charge Category is commonly used to identify and distinguish between types of charges that may require different handling.
 
 The ChargeCategory column MUST be present in the billing data and MUST NOT be null. This column is of type String and MUST be one of the allowed values.
 


### PR DESCRIPTION
Parts of the initial definition are no longer applicable since changes to the allowed values list (credit is no longer part of the adjustment category but a separate category) and the introduction of additional columns. It has beeb raised for example, how this column would be used for separate charges that may require special handling from regular usage.