### PR TITLE
Fix broken builds reported in #438

### DIFF
--- a/.github/workflows/candidate_release.yml
+++ b/.github/workflows/candidate_release.yml
@@ -2,36 +2,36 @@ name: generate_candidate_release_spec
 on:
   push:
     branches:
-      - 'candidate_release'
+      - "candidate_release"
 
 jobs:
-    # The job that will use the container image you just pushed to ghcr.io
-    gen_pdf:
-        runs-on: ubuntu-20.04
-        container:
-            image: pandoc/extra:latest-ubuntu
-        steps:
-            - name: Check out repository code
-              uses: actions/checkout@v3
-            - name: Install prequirements
-              shell: bash
-              run: |
-                /usr/bin/apt-get -y update
-                wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-                DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make
-                DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y -f ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-                /usr/bin/pip3 install -r requirements.txt
-            - name: Build PDF
-              shell: bash
-              working-directory: ./specification
-              run: |
-                make STYLE=candidate_release
-            - name: Upload Spec
-              uses: actions/upload-artifact@v3.1.2
-              with:
-                name: FOCUS_specification
-                path: |
-                  specification/spec.html
-                  specification/spec.pdf
-                  specification/images/*
-                  specification/styles/*
+  # The job that will use the container image you just pushed to ghcr.io
+  gen_pdf:
+    runs-on: ubuntu-20.04
+    container:
+      image: pandoc/extra:latest-ubuntu
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Install prequirements
+        shell: bash
+        run: |
+          /usr/bin/apt-get -y update
+          wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+          DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make
+          DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y -f ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+          /usr/bin/pip3 install --break-system-packages -r requirements.txt
+      - name: Build PDF
+        shell: bash
+        working-directory: ./specification
+        run: |
+          make STYLE=candidate_release
+      - name: Upload Spec
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: FOCUS_specification
+          path: |
+            specification/spec.html
+            specification/spec.pdf
+            specification/images/*
+            specification/styles/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,36 +2,36 @@ name: generate_publication_spec
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
-    # The job that will use the container image you just pushed to ghcr.io
-    gen_pdf:
-        runs-on: ubuntu-20.04
-        container:
-            image: pandoc/extra:latest-ubuntu
-        steps:
-            - name: Check out repository code
-              uses: actions/checkout@v3
-            - name: Install prequirements
-              shell: bash
-              run: |
-                /usr/bin/apt-get -y update
-                wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-                DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make
-                DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y -f ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-                /usr/bin/pip3 install -r requirements.txt
-            - name: Build PDF
-              shell: bash
-              working-directory: ./specification
-              run: |
-                make STYLE=main
-            - name: Upload Spec
-              uses: actions/upload-artifact@v3.1.2
-              with:
-                name: FOCUS_specification
-                path: |
-                  specification/spec.html
-                  specification/spec.pdf
-                  specification/images/*
-                  specification/styles/*
+  # The job that will use the container image you just pushed to ghcr.io
+  gen_pdf:
+    runs-on: ubuntu-20.04
+    container:
+      image: pandoc/extra:latest-ubuntu
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Install prequirements
+        shell: bash
+        run: |
+          /usr/bin/apt-get -y update
+          wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+          DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make
+          DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y -f ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+          /usr/bin/pip3 install --break-system-packages -r requirements.txt
+      - name: Build PDF
+        shell: bash
+        working-directory: ./specification
+        run: |
+          make STYLE=main
+      - name: Upload Spec
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: FOCUS_specification
+          path: |
+            specification/spec.html
+            specification/spec.pdf
+            specification/images/*
+            specification/styles/*

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -2,38 +2,38 @@ name: generate_draft_spec
 on:
   push:
     branches:
-      - '*'
-      - '!main'
-      - '!candidate_release'
+      - "*"
+      - "!main"
+      - "!candidate_release"
 
 jobs:
-    # The job that will use the container image you just pushed to ghcr.io
-    gen_pdf:
-        runs-on: ubuntu-20.04
-        container:
-            image: pandoc/extra:latest-ubuntu
-        steps:
-            - name: Check out repository code
-              uses: actions/checkout@v3
-            - name: Install prequirements
-              shell: bash
-              run: |
-                /usr/bin/apt-get -y update
-                wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-                DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make
-                DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y -f ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-                /usr/bin/pip3 install -r requirements.txt
-            - name: Build PDF
-              shell: bash
-              working-directory: ./specification
-              run: |
-                make STYLE=working_draft
-            - name: Upload Spec
-              uses: actions/upload-artifact@v3.1.2
-              with:
-                name: FOCUS_specification
-                path: |
-                  specification/spec.html
-                  specification/spec.pdf
-                  specification/images/*
-                  specification/styles/*
+  # The job that will use the container image you just pushed to ghcr.io
+  gen_pdf:
+    runs-on: ubuntu-20.04
+    container:
+      image: pandoc/extra:latest-ubuntu
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Install prequirements
+        shell: bash
+        run: |
+          /usr/bin/apt-get -y update
+          wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+          DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make
+          DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y -f ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+          /usr/bin/pip3 install --break-system-packages -r requirements.txt
+      - name: Build PDF
+        shell: bash
+        working-directory: ./specification
+        run: |
+          make STYLE=working_draft
+      - name: Upload Spec
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: FOCUS_specification
+          path: |
+            specification/spec.html
+            specification/spec.pdf
+            specification/images/*
+            specification/styles/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 watchdog==3.0.0
-pymarkdownlnt==0.9.11
+pymarkdownlnt==0.9.12


### PR DESCRIPTION
In order to unbreak the github actions pipeline, adding temporary fix which will allow the pip install to apply to the system python on the container. This is low risk as the python install is only active for the life of the build. If we want to avoid this we need to do further testing on using a venv for the spec creation. But this PR gets the pipeline unblocked for the pending 1.0 release.