### PR TITLE
#441 ChargePeriod Start and End spec change

### DIFF
--- a/specification/columns/chargeperiodend.md
+++ b/specification/columns/chargeperiodend.md
@@ -2,7 +2,7 @@
 
 Charge Period End represents the [*exclusive*](#glossary:exclusivebound) end date and time of a [*charge period*](#glossary:chargeperiod). For example, a time period where [ChargePeriodStart](#chargeperiodstart) is '2024-01-01T00:00:00Z' and ChargePeriodEnd is '2024-01-02T00:00:00Z' includes charges for January 1, since ChargePeriodStart is [*inclusive*](#glossary:inclusivebound), but does not include charges for January 2 since ChargePeriodEnd is *exclusive*.
 
-ChargePeriodEnd MUST be present in the billing data, MUST be of type Date/Time, MUST be an *exclusive* value, and MUST NOT contain null values.
+ChargePeriodEnd MUST be present in the billing data, MUST be of type Date/Time, MUST be an *exclusive* value, and MUST NOT contain null values. When [ChargeCategory](#chargecategory) is "Purchase" and the charge contains an expiration or ending date and time boundary, ChargePeriodEnd MUST match the ending date and time boundary for which the charge is active.
 
 ## Column ID
 

--- a/specification/columns/chargeperiodend.md
+++ b/specification/columns/chargeperiodend.md
@@ -2,7 +2,7 @@
 
 Charge Period End represents the [*exclusive*](#glossary:exclusivebound) end date and time of a [*charge period*](#glossary:chargeperiod). For example, a time period where [ChargePeriodStart](#chargeperiodstart) is '2024-01-01T00:00:00Z' and ChargePeriodEnd is '2024-01-02T00:00:00Z' includes charges for January 1, since ChargePeriodStart is [*inclusive*](#glossary:inclusivebound), but does not include charges for January 2 since ChargePeriodEnd is *exclusive*.
 
-ChargePeriodEnd MUST be present in the billing data, MUST be of type Date/Time, MUST be an *exclusive* value, and MUST NOT contain null values. When [ChargeCategory](#chargecategory) is "Purchase" and the charge contains an expiration or ending date and time boundary, ChargePeriodEnd MUST match the ending date and time boundary for which the charge is active.
+ChargePeriodEnd MUST be present in the billing data, MUST be of type Date/Time, MUST be an *exclusive* value, and MUST NOT contain null values. ChargePeriodEnd MUST match the ending date and time boundary of the effective period of the charge.
 
 ## Column ID
 

--- a/specification/columns/chargeperiodstart.md
+++ b/specification/columns/chargeperiodstart.md
@@ -2,7 +2,7 @@
 
 Charge Period Start represents the [*inclusive*](#glossary:inclusivebound) start date and time within a [*charge period*](#glossary:chargeperiod). For example, a time period where ChargePeriodStart is '2024-01-01T00:00:00Z' and [ChargePeriodEnd](#chargeperiodend) is '2024-01-02T00:00:00Z' includes charges for January 1, since ChargePeriodStart is *inclusive*, but does not include charges for January 2 since ChargePeriodEnd is [*exclusive*](#glossary:exclusivebound).
 
-ChargePeriodStart MUST be present in the billing data, MUST be of type Date/Time, MUST be an *inclusive* value, and MUST NOT contain null values.
+ChargePeriodStart MUST be present in the billing data, MUST be of type Date/Time, MUST be an *inclusive* value, and MUST NOT contain null values. ChargePeriodStart MUST match the beginning date and time boundary for which a charge is active.
 
 ## Column ID
 

--- a/specification/columns/chargeperiodstart.md
+++ b/specification/columns/chargeperiodstart.md
@@ -2,7 +2,7 @@
 
 Charge Period Start represents the [*inclusive*](#glossary:inclusivebound) start date and time within a [*charge period*](#glossary:chargeperiod). For example, a time period where ChargePeriodStart is '2024-01-01T00:00:00Z' and [ChargePeriodEnd](#chargeperiodend) is '2024-01-02T00:00:00Z' includes charges for January 1, since ChargePeriodStart is *inclusive*, but does not include charges for January 2 since ChargePeriodEnd is [*exclusive*](#glossary:exclusivebound).
 
-ChargePeriodStart MUST be present in the billing data, MUST be of type Date/Time, MUST be an *inclusive* value, and MUST NOT contain null values. ChargePeriodStart MUST match the beginning date and time boundary for which a charge is active.
+ChargePeriodStart MUST be present in the billing data, MUST be of type Date/Time, MUST be an *inclusive* value, and MUST NOT contain null values. ChargePeriodStart MUST match the beginning date and time boundary of the effective period of the charge.
 
 ## Column ID
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -38,7 +38,7 @@ A row in a FOCUS-compatible cost and usage dataset.
 
 <a name="glossary:chargeperiod"><b>Charge Period</b></a>
 
-The time window in which a charge was incurred, inclusive of the start date and exclusive of the end date. A charge can start and/or end at any time within a charge period window. The charge period for continuous usage should match the time granularity of the dataset (e.g., 1 hour for hourly, 1 day for daily).
+The time window for which a charge is effective, inclusive of the start date and exclusive of the end date. The charge period for continuous usage should match the time granularity of the dataset (e.g., 1 hour for hourly, 1 day for daily). The charge period for a non-usage charge with time boundaries should match the duration of eligibility.
 
 <a name="glossary:commitment"><b>Commitment</b></a>
 


### PR DESCRIPTION
Based on #441 

Clarifying description and normative statements for expected values between usage, time-bound purchase, and time-agnostic purchase scenarios

### v2

ChargePeriodStart

>ChargePeriodStart MUST be present in the billing data, MUST be of type Date/Time, MUST be an *inclusive* value, and MUST NOT contain null values. ChargePeriodStart MUST match the beginning date and time boundary of the effective period of the charge.

ChargePeriodEnd

> ChargePeriodEnd MUST be present in the billing data, MUST be of type Date/Time, MUST be an *exclusive* value, and MUST NOT contain null values. ChargePeriodEnd MUST match the ending date and time boundary of the effective period of the charge. 


Note: there is a grey area when [ChargeCategory](#chargecategory) is "Purchase" and the charge does not contain an expiration or ending date and time boundary.

<details>
<summary>

### v1

</summary>

ChargePeriodStart

>ChargePeriodStart MUST be present in the billing data, MUST be of type Date/Time, MUST be an *inclusive* value, and MUST NOT contain null values. ChargePeriodStart MUST match the beginning date and time boundary for which a charge is active.

ChargePeriodEnd

> ChargePeriodEnd MUST be present in the billing data, MUST be of type Date/Time, MUST be an *exclusive* value, and MUST NOT contain null values. When [ChargeCategory](#chargecategory) is "Purchase" and the charge contains an expiration or ending date and time boundary, ChargePeriodEnd MUST match the ending date and time boundary for which the charge is active.

</details>