### PR TITLE
Correction of term sponsored with supported

### DIFF
--- a/specification/overview.md
+++ b/specification/overview.md
@@ -8,7 +8,7 @@ The FOCUS specification's schema definition and FinOps-aligned terminology provi
 
 ## Background and History
 
-This project is sponsored by the [FinOps Foundation][FODO]. This work initially started under the Open Billing working group under the FinOps Foundation. The decision was made in Jan 2023 to begin to migrate the work to a newly formed project under the Linux Foundation called the FinOps Open Cost and Usage Specification (FOCUS) to better support the creation of a specification.
+This project is supported by the [FinOps Foundation][FODO]. This work initially started under the Open Billing working group under the FinOps Foundation. The decision was made in Jan 2023 to begin to migrate the work to a newly formed project under the Linux Foundation called the FinOps Open Cost and Usage Specification (FOCUS) to better support the creation of a specification.
 
 ## Intended Audience
 


### PR DESCRIPTION
The FinOps Foundation is a supporter of the FOCUS Project. The FinOps Foundation would like the phrase "This project is sponsored by the FinOps Foundation" be updated to "This project is supported by the FinOps Foundation"