### PR TITLE
[ADMIN] Add steering, contributors and maintainers who contributed to FOCUS

### DIFF
--- a/specification/contributors.md
+++ b/specification/contributors.md
@@ -4,7 +4,6 @@
 
 Thanks to the following FOCUS Maintainers for their leadership of the FOCUS specification.
 
-* Anne Johnston (Capital One)
 * Christopher Harris (Datadog)
 * Dennis Park-Rodriguez (Amazon Web Services)
 * Erik Peterson (CloudZero)
@@ -14,10 +13,8 @@ Thanks to the following FOCUS Maintainers for their leadership of the FOCUS spec
 * Larry Advey (Twilio)
 * Michael Flanakin (Microsoft)
 * Mike Fuller (FinOps Foundation)
-* Riley Jenkins (Domo)
-* Roy Wolman (Amazon Web Services)
+* Riley Jenkins (DOMO)
 * Rupa Patel (Google)
-* Sarah McMullin (Google)
 * Tim O'Brien (Walmart)
 * Udam Dewaraja (FinOps Foundation)
 
@@ -25,6 +22,7 @@ Thanks to the following FOCUS Maintainers for their leadership of the FOCUS spec
 
 Thanks to the following FOCUS members for their contributions to the FOCUS specification.
 
+* Adam Schwartz (Ernst & Young)
 * Alex Hullah (Goldman Sachs)
 * Amit Wadhwa (Google)
 * Anand Tripathi (Amazon Web Services)
@@ -40,8 +38,13 @@ Thanks to the following FOCUS members for their contributions to the FOCUS speci
 * Colin Jack (Snow Software)
 * Deeja Cruz (Datadog)
 * Eleni Rundle (Google)
+* Francesco Sodano (Microsoft)
 * Graham Murphy (Australian Retirement Trust)
-* Jacky Liu (Google)
+* Harish Kumar Munagapat (Kyndryl)
+* Hrishikesh Sardar (Kyndryl)
+* Ilia Semenov (CloudThread)
+* Jacky Liu (Google Cloud)
+* Jacqui Wilson (Old Mutual South Africa)
 * Janine Pickard-Green (MagicOrange Group Limited)
 * Jason Kelly (Anglepoint Group Inc)
 * Joe Ferrero (DB Gurus Inc)
@@ -49,7 +52,7 @@ Thanks to the following FOCUS members for their contributions to the FOCUS speci
 * Joshua Kwan (Ternary)
 * Letian Wang (Atlassian)
 * Luna Bernal (Twilio)
-* Marc Perreaut (amadeus)
+* Marc Perreaut (Amadeus)
 * Marcin Walkow (Nordcloud)
 * Mark Krawczeniuk (NetApp)
 * Matt Ray (Kubecost)
@@ -63,11 +66,13 @@ Thanks to the following FOCUS members for their contributions to the FOCUS speci
 * Rodney Joyce (CloudMonitor)
 * Sanjna Srivatsa (VMWare)
 * Shawn Alpay (Envisor)
+* Sireesha Oram (Kyndryl)
 * Sonal Garg (Kyndryl)
 * Sumaira Nazir (Platform.sh)
 * Tatiana Dubovchenko (Flexera)
 * Trey Morgan (Microsoft)
 * Trig Ghosh (Accenture)
+* Venu Potanker (Ernst & Young)
 * Webb Brown (Kubecost)
 * Yuriy Prykhodko (Amazon Web Services)
 * Zach Erdman (Amazon Web Services)


### PR DESCRIPTION
As agreed by the group during the Members' meeting on May 9. 
This PR lists in three categories all the contributors to the FOCUS v1.0 and prior releases.