### PR TITLE
Update glossary - remove duplicate entry

### DIFF
--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -88,10 +88,6 @@ The suggested provider-published unit price for a single [Pricing Unit](#pricing
 
 The agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, inclusive of negotiated discounts, if present, and exclusive of any other discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
 
-<a name="glossary:list-unit-price"><b>Contracted Unit Price</b></a>
-
-The agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, inclusive of negotiated discounts, if present, and exclusive of any other discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
-
 <a name="glossary:metric"><b>Metric</b></a>
 
 A FOCUS-defined column that provides numeric values, allowing for aggregation operations such as arithmetic operations (sum, multiplication, averaging etc.) and statistical operations.

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -52,6 +52,10 @@ Also known as Commitment Discount, this is a commitment for an amount of usage o
 
 A company or organization that provides remote access to computing resources, infrastructure, or applications for a fee.
 
+<a name="glossary:contracted-unit-price"><b>Contracted Unit Price</b></a>
+
+The agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, inclusive of negotiated discounts, if present, and exclusive of any other discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
+
 <a name="glossary:dimension"><b>Dimension</b></a>
 
 A specification-defined categorical attribute that provides context or categorization to billing data.
@@ -83,10 +87,6 @@ A category of compute resources that can be paused or terminated by the CSP with
 <a name="glossary:list-unit-price"><b>List Unit Price</b></a>
 
 The suggested provider-published unit price for a single [Pricing Unit](#pricingunit) of the associated [SKU](#glossary:sku), exclusive of any discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
-
-<a name="glossary:contracted-unit-price"><b>Contracted Unit Price</b></a>
-
-The agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, inclusive of negotiated discounts, if present, and exclusive of any other discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
 
 <a name="glossary:metric"><b>Metric</b></a>
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -84,7 +84,7 @@ A category of compute resources that can be paused or terminated by the CSP with
 
 The suggested provider-published unit price for a single [Pricing Unit](#pricingunit) of the associated [SKU](#glossary:sku), exclusive of any discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
 
-<a name="glossary:list-unit-price"><b>Contracted Unit Price</b></a>
+<a name="glossary:contracted-unit-price"><b>Contracted Unit Price</b></a>
 
 The agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, inclusive of negotiated discounts, if present, and exclusive of any other discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
 


### PR DESCRIPTION
There is a duplicated entry in the glossary which needs to be removed.