### PR TITLE
[ADMIN]update reference to patent policy 4 W3C mode as stated in the FOCUS Membership doc.

### DIFF
--- a/license.md
+++ b/license.md
@@ -26,7 +26,7 @@ WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR
 OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
-This document is governed by the Patent Policy Option 3: Open Web Foundation 1.0 Mode:
+This document is governed by the Patent Policy Option 4: W3C Mode:
 See [project charter](https://github.com/FinOps-Open-Cost-and-Usage-Spec/foundation/blob/main/FOCUS_-_Membership_Agreement_Package_for_use.pdf).
 
 <div style="page-break-after: always"></div>


### PR DESCRIPTION
It was identified that the reference to the Patent Policy was incorrect in the license document. It should be listed as Option 4, W3C mode, stated in the FOCUS Membership Agreement rather than Patent Policy Option 3: Open Web Foundation 1.0 Mode. See the screenshot below with the correct reference to the W3C Mode patent.

![image](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/assets/3258579/25d47b58-7ae1-4a37-ad2a-443501ea1992)
