### PR TITLE
[ADMIN] Ratification of v1.0 by FOCUS Steering Committee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!--
+## v1.1
+
+[All unreleased changes](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/compare/1.0-cr...working_draft)
+
+<br>
+-->
+
 ## v1.0
 
 <sup>Announced June 20, 2024</sup>
@@ -96,7 +104,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `ChargeSubcategory` column - See `ChargeCategory` and `ChargeClass` columns
 
-[All unreleased changes](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/compare/v1.0-preview-cr...working_draft)
+[All unreleased changes](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/compare/v1.0-preview...v1.0)
 
 <br>
 
@@ -139,7 +147,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `AmortizedCost` column renamed to `EffectiveCost`
 - `ChargeType` column renamed to `ChargeCategory`
 
-[All 1.0-preview changes](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/compare/v0.5-cr...v1.0-preview-cr)
+[All 1.0-preview changes](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/compare/v0.5...v1.0-preview)
 
 <br>
 

--- a/license.md
+++ b/license.md
@@ -26,7 +26,7 @@ WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR
 OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
-This document is governed by the Patent Policy Option 3: Open Web Foundation 1.0 Mode:
+This document is governed by the Patent Policy Option 4: W3C Mode:
 See [project charter](https://github.com/FinOps-Open-Cost-and-Usage-Spec/foundation/blob/main/FOCUS_-_Membership_Agreement_Package_for_use.pdf).
 
 <div style="page-break-after: always"></div>

--- a/specification/columns/billingperiodend.md
+++ b/specification/columns/billingperiodend.md
@@ -1,6 +1,6 @@
 # Billing Period End
 
-Billing Period Start represents the [*exclusive*](#glossary:exclusivebound) end date and time of a [*billing period*](#glossary:billing-period). For example, a time period where [BillingPeriodStart](#glossary:billingperiodstart) is '2024-01-01T00:00:00Z' and BillingPeriodEnd is '2024-02-01T00:00:00Z' includes charges for January, since BillingPeriodStart is [*inclusive*](#glossary:inclusivebound), but does not include charges for February since BillingPeriodEnd is *exclusive*.
+Billing Period End represents the [*exclusive*](#glossary:exclusivebound) end date and time of a [*billing period*](#glossary:billing-period). For example, a time period where [BillingPeriodStart](#glossary:billingperiodstart) is '2024-01-01T00:00:00Z' and BillingPeriodEnd is '2024-02-01T00:00:00Z' includes charges for January, since BillingPeriodStart is [*inclusive*](#glossary:inclusivebound), but does not include charges for February since BillingPeriodEnd is *exclusive*.
 
 The BillingPeriodEnd column MUST be present in the billing data. This column MUST be of type [Date/Time Format](#date/timeformat), MUST be an *exclusive* value, and MUST NOT contain null values. The sum of the [BilledCost](#billedcost) column for [*rows*](#glossary:row) in a given *billing period* MUST match the sum of the invoices received for that *billing period* for a [*billing account*](#glossary:billing-account).
 

--- a/specification/columns/chargecategory.md
+++ b/specification/columns/chargecategory.md
@@ -31,7 +31,7 @@ Allowed values:
 | Value      | Description                          |
 | :--------- | :------------------------------------|
 | Usage      | Positive or negative charges based on the quantity of a service or resource that was consumed over a given period of time including refunds.     |
-| Purchase   | Positive or negative charges for the acquisition of a service or resource bought upfront or on a recurring basis inluding refunds.              |
+| Purchase   | Positive or negative charges for the acquisition of a service or resource bought upfront or on a recurring basis including refunds.              |
 | Tax        | Positive or negative applicable taxes that are levied by the relevant authorities including refunds. Tax charges may vary depending on factors such as the location, jurisdiction, and local or federal regulations. |
 | Credit      | Positive or negative charges granted by the provider for various scenarios e.g promotional credits or corrections to promotional credits.     |
 | Adjustment      | Positive or negative charges the provider applies that do not fall into other category values.    |

--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -18,8 +18,8 @@ The FOCUS specification defines a group of columns that provide qualitative valu
 !INCLUDE "commitmentdiscountcategory.md",1
 !INCLUDE "commitmentdiscountid.md",1
 !INCLUDE "commitmentdiscountname.md",1
-!INCLUDE "commitmentdiscounttype.md",1
 !INCLUDE "commitmentdiscountstatus.md",1
+!INCLUDE "commitmentdiscounttype.md",1
 !INCLUDE "consumedquantity.md",1
 !INCLUDE "consumedunit.md",1
 !INCLUDE "contractedcost.md",1

--- a/specification/columns/consumedunit.md
+++ b/specification/columns/consumedunit.md
@@ -6,7 +6,7 @@ The ConsumedUnit column MUST be present in the billing data when the provider su
 
 ## Column ID
 
-ConsumedeUnit
+ConsumedUnit
 
 ## Display Name
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -84,11 +84,7 @@ A category of compute resources that can be paused or terminated by the CSP with
 
 The suggested provider-published unit price for a single [Pricing Unit](#pricingunit) of the associated [SKU](#glossary:sku), exclusive of any discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
 
-<a name="glossary:list-unit-price"><b>Contracted Unit Price</b></a>
-
-The agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, inclusive of negotiated discounts, if present, and exclusive of any other discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
-
-<a name="glossary:list-unit-price"><b>Contracted Unit Price</b></a>
+<a name="glossary:contracted-unit-price"><b>Contracted Unit Price</b></a>
 
 The agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, inclusive of negotiated discounts, if present, and exclusive of any other discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
 


### PR DESCRIPTION
### Final Approval FOCUS Release v1.0
* 30-day IPR Review for Candidate Release v1.0 completed on Jun 11.
* GitHub Candidate Release v1.0, release tag: [v1.0-cr](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/releases/tag/1.0-cr)
* GitHub Candidate Release v1.0-preview, release tag: [v1.0-preview-cr](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/releases/tag/v1.0-preview-cr)
* No Exclusion Notices were received
* Presenting these two Candidate Releases for the Final Members Group Agreement:

[v1.0-cr](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/releases/tag/1.0-cr)

[v1.0-preview-cr](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/releases/tag/v1.0-preview-cr)

### Editorial PRs for Inclusion in v1.0 before Final Approval. *(identified during IPR Review)*
* Editorial PRs to merge against the Final Release v1.0: *(already merged into v1.1, `working_draft`)*
*
[#459](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/459) [EDITORIAL] v1.0 Correct typo in consumedunit.md
*
[#460](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/460) [EDITORIAL] Update columns.mdpp
*
[#461](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/461) [EDITORIAL] Correct a typographical error in the ChargeCategory. *
[#470](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/470) Fix changelog commit history link

* Editorial PRs to merge against the Final Release v1.0: *(pending to merge into v1.1, `working_drat`)*
*
[#480](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/480) [ADMIN] update reference to patent policy 4 W3C mode as stated in the FOCUS Membership doc
*
[#483](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/483) [EDITORIAL] Update billingperiodend by Zach

### Prepare new branch from Release Tag `1.0-cr`
* Created [`1.0-cr-editorial`](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/tree/1.0-cr-editorial) branch from release tag
[`1.0-cr`](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/tree/1.0-cr) branch.
* Apply PR [#484](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/484) containing all the above editorial changes.