### PR TITLE
[EDITORIAL] Reclassify ConsumedUnit as Dimension instead of Metric

### DIFF
--- a/specification/columns/consumedunit.md
+++ b/specification/columns/consumedunit.md
@@ -20,7 +20,7 @@ Provider-specified measurement unit indicating how a provider measures usage of 
 
 |    Constraint   |      Value      |
 |:----------------|:----------------|
-| Column type     | Metric          |
+| Column type     | Dimension       |
 | Feature level   | Conditional     |
 | Allows nulls    | True            |
 | Data type       | String          |


### PR DESCRIPTION
Correct ConsumedUnit column type to Dimension from Metric (similar to PricingUnit) because it is an attribute of how the consumption is measured and is not able to have mathematical operations applied to it.