### PR TITLE
FOCUS #493: ConsumedQuantity and ConsumedUnit update - addressing Unused usage

### DIFF
--- a/specification/columns/consumedquantity.md
+++ b/specification/columns/consumedquantity.md
@@ -2,7 +2,16 @@
 
 The Consumed Quantity represents the volume of a given SKU associated with a [*resource*](#glossary:resource) or [*service*](#glossary:service) used, based on the [Consumed Unit](#consumedunit). Consumed Quantity is often derived at a finer granularity or over a different time interval when compared to the [Pricing Quantity](#pricingquantity) (complementary to [Pricing Unit](#pricingunit)) and focuses on *resource* and *service* consumption, not pricing and cost.
 
-ConsumedQuantity column MUST be present in the billing data when the provider supports the measurement of usage. This column MUST NOT be null if [ChargeCategory](#chargecategory) is "Usage" and  [ChargeClass](#chargeclass) is not "Correction". This column MUST be null for other ChargeCategory values. This column MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements. The value MAY be negative in cases where [ChargeClass](#chargeclass) is "Correction".
+The ConsumedQuantity column adheres to the following requirements:
+
+* ConsumedQuantity MUST be present in the billing data when the provider supports the measurement of usage.
+* ConsumedQuantity MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements.
+* ConsumedQuantity MUST NOT be null if [ChargeCategory](#chargecategory) is "Usage", unless [ChargeClass](#chargeclass) is "Correction" or [CommitmentStatus](#ommitmentstatus) is "Unused".
+* ConsumedQuantity MAY be null if ChargeCategory is "Usage" and ChargeClass is "Correction"
+* ConsumedQuantity MUST be null if CommitmentStatus is "Unused" or for other ChargeCategory values.
+* ConsumedQuantity value MAY be negative in cases where ChargeClass is "Correction".
+
+The ConsumedQuantity column MUST NOT be used to determine values related to any pricing or cost metrics.
 
 ## Column ID
 

--- a/specification/columns/consumedunit.md
+++ b/specification/columns/consumedunit.md
@@ -2,7 +2,15 @@
 
 The Consumed Unit represents a provider-specified measurement unit indicating how a provider measures usage of a given SKU associated with a [*resource*](#glossary:resource) or [*service*](#glossary:service). Consumed Unit complements the [Consumed Quantity](#consumedquantity) metric. It is often listed at a finer granularity or over a different time interval when compared to [Pricing Unit](#pricingunit) (complementary to [Pricing Quantity](#pricingquantity)), and focuses on *resource* and *service* consumption, not pricing and cost.
 
-The ConsumedUnit column MUST be present in the billing data when the provider supports the measurement of usage. This column MUST be of type String. ConsumedUnit MUST NOT be null if [ChargeCategory](#chargecategory) is "Usage" and [ChargeClass](#chargeclass) is not "Correction". This column MUST be null for other ChargeCategory values. Units of measure used in ConsumedUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute. The ConsumedUnit column MUST NOT be used to determine values related to any pricing or cost metrics.
+The ConsumedQuantity column adheres to the following requirements:
+
+* ConsumedUnit MUST be present in the billing data when the provider supports the measurement of usage.
+* ConsumedUnit MUST be of type String, and the units of measure used in ConsumedUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
+* ConsumedUnit MUST NOT be null if [ChargeCategory](#chargecategory) is "Usage", unless [ChargeClass](#chargeclass) is "Correction" or [CommitmentStatus](#ommitmentstatus) is "Unused".
+* ConsumedUnit MAY be null if ChargeCategory is "Usage" and ChargeClass is "Correction"
+* ConsumedUnit MUST be null if CommitmentStatus is "Unused" or for other ChargeCategory values.
+
+The ConsumedUnit column MUST NOT be used to determine values related to any pricing or cost metrics.
 
 ## Column ID
 


### PR DESCRIPTION
Currently in normative paragraphs for both ConsumedQuantity and ConsumedUnit:

> _MUST NOT be null if ChargeCategory is "Usage" and ChargeClass not "Correction". This column MUST be null for other ChargeCategory values._

We need to adjust this considering both ConsumedQuantity and ConsumedUnit MUST be null in case of ChargeCategory 'Usage' and CommitmentStatus 'Unused'.