### PR TITLE
Remove incorrect mention of 'Charge Subcategory' and correct with 'Charge Category'

### DIFF
--- a/specification/attributes/discount_handling.md
+++ b/specification/attributes/discount_handling.md
@@ -6,7 +6,7 @@ Some discount offers can be purchased from a provider to get reduced prices. The
 
 Amortization is a process used to break down and spread purchase costs over a period of time or term of use. When a purchase is applicable to resources, like commitment-based discounts, the amortized cost of a resource takes the initial payment and term into account and distributes it out based on the resource's usage, attributing the prorated cost for each unit of billing. Amortization enables users of billing data to distribute purchase charges to the appropriate audience in support of cost allocation efforts. Discount Handling for purchased commitments is commonly used for scenarios like calculating utilization and implementing chargeback for the purchase amount.
 
-While providers may use different terms to describe discounts, FOCUS identifies a discount as being a reduced price applied directly to a row. Any price or cost reductions that are awarded after the fact are identified as a "Credit" Charge Subcategory. One example might be when a provider offers a reduced rate after passing a certain threshold of usage or spend.
+While providers may use different terms to describe discounts, FOCUS identifies a discount as being a reduced price applied directly to a row. Any price or cost reductions that are awarded after the fact are identified as a "Credit" Charge Category. One example might be when a provider offers a reduced rate after passing a certain threshold of usage or spend.
 
 All rows defined in FOCUS MUST follow the discount handling requirements listed below.
 


### PR DESCRIPTION
Since 'Charge Subcategory' was rolled up into 'Charge Category', remove all references.