### PR TITLE
#503a - Update SkuPriceId per SkuPriceDetails

### DIFF
--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -3,7 +3,7 @@
 A SKU Price ID is a unique identifier that defines the unit price used to calculate the charge. SKU Price ID can be referenced on a [*price list*](#glossary:price-list) published by a provider to look up detailed information, including a corresponding list unit price. The composition of the properties associated with the SKU Price ID may differ across providers. SKU Price ID is commonly used for analyzing cost based on pricing properties such as Terms and Tiers.
 
 The SkuPriceId column adheres to the following requirements:
-- The SkuPriceId MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
+- SkuPriceId MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
 - SkuPriceId MUST define a single unit price used for calculating the charge.
 - [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published *price list*.
 - SkuPriceId MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -2,8 +2,8 @@
 
 A SKU Price ID is a unique identifier that defines the unit price used to calculate the charge. SKU Price ID can be referenced on a [*price list*](#glossary:price-list) published by a provider to look up detailed information, including a corresponding list unit price. The composition of the properties associated with the SKU Price ID may differ across providers. SKU Price ID is commonly used for analyzing cost based on pricing properties such as Terms and Tiers.
 
-- The SkuPriceId column MUST be present in a FOCUS dataset when the provider publishes a SKU price list.
-- This column MUST be of type String.
+The SkuPriceId column adheres to the following requirements:
+- The SkuPriceId MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
 - SkuPriceId MUST define a single unit price used for calculating the charge.
 - The [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published *price list*.
 - This column

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -6,8 +6,7 @@ The SkuPriceId column adheres to the following requirements:
 - The SkuPriceId MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
 - SkuPriceId MUST define a single unit price used for calculating the charge.
 - [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published *price list*.
-- This column
-- MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
+- SkuPriceId MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
 - A given value of SkuPriceId MUST be associated with one and only one [SkuId](#skuid), except in cases of commitment discount flexibility.
 - If a provider does not have a SkuPriceId and wants to include information in columns linked to SkuPriceId such as ListUnitPrice or [SkuPriceDetails](#skupricedetails), the SkuId MAY be used in the SkuPriceId column as long as it adheres to the above conditions.
 

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -5,10 +5,10 @@ A SKU Price ID is a unique identifier that defines the unit price used to calcul
 The SkuPriceId column adheres to the following requirements:
 - SkuPriceId MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
 - SkuPriceId MUST define a single unit price used for calculating the charge.
-- [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published *price list*.
-- SkuPriceId MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
-- A given value of SkuPriceId MUST be associated with one and only one [SkuId](#skuid), except in cases of commitment discount flexibility.
-- If a provider does not have a SkuPriceId and wants to include information in columns linked to SkuPriceId such as ListUnitPrice or [SkuPriceDetails](#skupricedetails), the SkuId MAY be used in the SkuPriceId column as long as it adheres to the above conditions.
+- [*ListUnitPrice*](#listunitprice) MUST be associated with the SkuPriceId in the provider published price list.
+- SkuPriceId MUST NOT be null when [*ChargeClass*](#chargeclass) is not "Correction" and [*ChargeCategory*](#chargecategory) is "Usage" or "Purchase", MUST be null when *ChargeCategory* is "Tax", and MAY be null for all other combinations of *ChargeClass* and *ChargeCategory*.
+- A given value of SkuPriceId MUST be associated with one and only one [*SkuId*](#skuid), except in cases of commitment discount flexibility.
+- If a provider does not have a SkuPriceId and wants to include information in columns linked to SkuPriceId such as *ListUnitPrice* or [*SkuPriceDetails*](#skupricedetails), the *SkuId* MAY be used in the SkuPriceId column as long as it adheres to the above conditions.
 
 ## Column ID
 

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -2,13 +2,13 @@
 
 A SKU Price ID is a unique identifier that defines the unit price used to calculate the charge. SKU Price ID can be referenced on a [*price list*](#glossary:price-list) published by a provider to look up detailed information, including a corresponding list unit price. The composition of the properties associated with the SKU Price ID may differ across providers. SKU Price ID is commonly used for analyzing cost based on pricing properties such as Terms and Tiers.
 
-The SkuPriceId column adheres to the following requirements:
-- SkuPriceId MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
-- SkuPriceId MUST define a single unit price used for calculating the charge.
-- [*ListUnitPrice*](#listunitprice) MUST be associated with the SkuPriceId in the provider published price list.
-- SkuPriceId MUST NOT be null when [*ChargeClass*](#chargeclass) is not "Correction" and [*ChargeCategory*](#chargecategory) is "Usage" or "Purchase", MUST be null when *ChargeCategory* is "Tax", and MAY be null for all other combinations of *ChargeClass* and *ChargeCategory*.
-- A given value of SkuPriceId MUST be associated with one and only one [*SkuId*](#skuid), except in cases of commitment discount flexibility.
-- If a provider does not have a SkuPriceId and wants to include information in columns linked to SkuPriceId such as *ListUnitPrice* or [*SkuPriceDetails*](#skupricedetails), the *SkuId* MAY be used in the SkuPriceId column as long as it adheres to the above conditions.
+The *SkuPriceId* column adheres to the following requirements:
+- *SkuPriceId* MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
+- *SkuPriceId* MUST define a single unit price used for calculating the charge.
+- [*ListUnitPrice*](#listunitprice) MUST be associated with the *SkuPriceId* in the provider published price list.
+- *SkuPriceId* MUST NOT be null when [*ChargeClass*](#chargeclass) is not "Correction" and [*ChargeCategory*](#chargecategory) is "Usage" or "Purchase", MUST be null when *ChargeCategory* is "Tax", and MAY be null for all other combinations of *ChargeClass* and *ChargeCategory*.
+- A given value of *SkuPriceId* MUST be associated with one and only one [*SkuId*](#skuid), except in cases of commitment discount flexibility.
+- If a provider does not have a *SkuPriceId* and wants to include information in columns linked to *SkuPriceId* such as *ListUnitPrice* or [*SkuPriceDetails*](#skupricedetails), the *SkuId* MAY be used in the *SkuPriceId* column as long as it adheres to the above conditions.
 
 ## Column ID
 

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -5,7 +5,7 @@ A SKU Price ID is a unique identifier that defines the unit price used to calcul
 The SkuPriceId column adheres to the following requirements:
 - The SkuPriceId MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
 - SkuPriceId MUST define a single unit price used for calculating the charge.
-- The [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published *price list*.
+- [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published *price list*.
 - This column
 - MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
 - A given value of SkuPriceId MUST be associated with one and only one [SkuId](#skuid), except in cases of commitment discount flexibility.

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -2,7 +2,14 @@
 
 A SKU Price ID is a unique identifier that defines the unit price used to calculate the charge. SKU Price ID can be referenced on a [*price list*](#glossary:price-list) published by a provider to look up detailed information, including a corresponding list unit price. The composition of the properties associated with the SKU Price ID may differ across providers. SKU Price ID is commonly used for analyzing cost based on pricing properties such as Terms and Tiers.
 
-The SkuPriceId column MUST be present in a FOCUS dataset when the provider publishes a SKU price list. This column MUST be of type String. SkuPriceId MUST define a single unit price used for calculating the charge. The [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published *price list*. This column MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory. A given value of SkuPriceId MUST be associated with one and only one [SkuId](#skuid), except in cases of commitment discount flexibility.
+- The SkuPriceId column MUST be present in a FOCUS dataset when the provider publishes a SKU price list.
+- This column MUST be of type String.
+- SkuPriceId MUST define a single unit price used for calculating the charge.
+- The [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published *price list*.
+- This column
+- MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
+- A given value of SkuPriceId MUST be associated with one and only one [SkuId](#skuid), except in cases of commitment discount flexibility.
+- If a provider does not have a SkuPriceId and wants to include information in columns linked to SkuPriceId such as ListUnitPrice or [SkuPriceDetails](#skupricedetails), the SkuId MAY be used in the SkuPriceId column as long as it adheres to the above conditions.
 
 ## Column ID
 


### PR DESCRIPTION
This change is dependent on #503 being merged as it links to SkuPriceDetails. This change to SkuPriceId solves for a case where a provider does not have a SkuPriceId but wants to include SkuPriceDetails. This case was introduced when there was a change in scope of #503 to not include SkuDetails.

Changes:
- Reformatted normative to bullets
- Added option (MAY) to repeat SkuId as SkuPriceId when there is no SkuPriceId, as long as other conditions are not violated.