### PR TITLE
FOCUS #532: PricingCategory update - Classify commitment discount purchase records as Standard instead of Committed

### DIFF
--- a/specification/columns/pricingcategory.md
+++ b/specification/columns/pricingcategory.md
@@ -8,7 +8,7 @@ The PricingCategory column adheres to the following requirements:
 * PricingCategory MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
 * PricingCategory MUST be one of the allowed values.
 * PricingCategory MUST be "Standard" when pricing is predetermined at the agreed upon rate for the [billing account](#glossary:billing-account).
-* PricingCategory MUST be "Committed" when [CommitmentDiscountId](#commitmentdiscountid) is not null, except when ChargeCategory is "Purchase" and [ResourceId](#resourceid) matches CommitmentDiscountId, representing a charge related to the purchase of that commitment discount.
+* PricingCategory MUST be "Committed" when [CommitmentDiscountId](#commitmentdiscountid) is not null, except when ChargeCategory is "Purchase" and the [ResourceId](#resourceid) matches the CommitmentDiscountId.
 * PricingCategory MUST be "Dynamic" when pricing is determined by the provider and may change over time, regardless of predetermined agreement pricing.
 * PricingCategory MUST be "Other" when there is a pricing model but none of the allowed values apply.
 

--- a/specification/columns/pricingcategory.md
+++ b/specification/columns/pricingcategory.md
@@ -8,7 +8,7 @@ The PricingCategory column adheres to the following requirements:
 * PricingCategory MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
 * PricingCategory MUST be one of the allowed values.
 * PricingCategory MUST be "Standard" when pricing is predetermined at the agreed upon rate for the [billing account](#glossary:billing-account).
-* PricingCategory MUST be "Committed" when [CommitmentDiscountId](#commitmentdiscountid) is not null, except when ChargeCategory is "Purchase" and the [ResourceId](#resourceid) matches the CommitmentDiscountId.
+* PricingCategory MUST be "Committed" when the charge is subject to an existing *commitment discount* and is not the purchase of a *commitment discount*.
 * PricingCategory MUST be "Dynamic" when pricing is determined by the provider and may change over time, regardless of predetermined agreement pricing.
 * PricingCategory MUST be "Other" when there is a pricing model but none of the allowed values apply.
 

--- a/specification/columns/pricingcategory.md
+++ b/specification/columns/pricingcategory.md
@@ -8,7 +8,7 @@ The PricingCategory column adheres to the following requirements:
 * PricingCategory MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
 * PricingCategory MUST be one of the allowed values.
 * PricingCategory MUST be "Standard" when pricing is predetermined at the agreed upon rate for the [billing account](#glossary:billing-account).
-* PricingCategory MUST be "Committed" when the charge is subject to an existing *commitment discount* and is not the purchase of a *commitment discount*.
+* PricingCategory MUST be "Committed" when the charge is subject to an existing *commitment discount* and is not the purchase of the *commitment discount*.
 * PricingCategory MUST be "Dynamic" when pricing is determined by the provider and may change over time, regardless of predetermined agreement pricing.
 * PricingCategory MUST be "Other" when there is a pricing model but none of the allowed values apply.
 

--- a/specification/columns/pricingcategory.md
+++ b/specification/columns/pricingcategory.md
@@ -8,7 +8,7 @@ The PricingCategory column adheres to the following requirements:
 * PricingCategory MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
 * PricingCategory MUST be one of the allowed values.
 * PricingCategory MUST be "Standard" when pricing is predetermined at the agreed upon rate for the [billing account](#glossary:billing-account).
-* PricingCategory MUST be "Committed" when [CommitmentDiscountId](#commitmentdiscountid) is not null.
+* PricingCategory MUST be "Committed" when [CommitmentDiscountId](#commitmentdiscountid) is not null, except when ChargeCategory is "Purchase" and [ResourceId](#resourceid) matches CommitmentDiscountId, representing a charge related to the purchase of that commitment discount.
 * PricingCategory MUST be "Dynamic" when pricing is determined by the provider and may change over time, regardless of predetermined agreement pricing.
 * PricingCategory MUST be "Other" when there is a pricing model but none of the allowed values apply.
 


### PR DESCRIPTION
**Lead Maintainer**: Irena

Classify commitment discount purchase records as Standard instead of Committed, by rephrasing the following requirement:

> * PricingCategory MUST be "Committed" when [CommitmentDiscountId](#commitmentdiscountid) is not null.

New version:

> * PricingCategory MUST be "Committed" when [CommitmentDiscountId](#commitmentdiscountid) is not null, except when ChargeCategory is "Purchase" and the [ResourceId](#resourceid) matches the CommitmentDiscountId.

or 

> * PricingCategory MUST be "Committed" when [CommitmentDiscountId](#commitmentdiscountid) is not null, except when ChargeCategory is "Purchase" and the [ResourceId](#resourceid) matches the CommitmentDiscountId, representing a charge related to the purchase of that commitment discount.