### PR TITLE
Fix capacityreservation*, sku* build issues

### DIFF
--- a/specification/columns/capacityreservationstatus.md
+++ b/specification/columns/capacityreservationstatus.md
@@ -3,11 +3,12 @@
 Capacity Reservation Status indicates whether the charge represents either the consumption of the [*capacity reservation*](#glossary:capacity-reservation) identified in the CapacityReservationId column or when the *capacity reservation* is unused.
 
 The CapacityReservationStatus column adheres to the following requirements:
- * CapacityReservationStatus MUST be present in a FOCUS dataset when the provider supports *capacity reservations* and MUST be of type String.
- * CapacityReservationStatus MUST be null when CapacityReservationId is null.
- * CapacityReservationStatus MUST NOT be null when CapacityReservationId is not null and [ChargeCategory](#chargecategory) is "Usage".
- * CapacityReservationStatus MUST be one of the allowed values.
- * CapacityReservationStatus MUST label all unused *capacity reservation* charges and MUST label used *capacity reservation* charges if the provider supports it.
+
+* CapacityReservationStatus MUST be present in a FOCUS dataset when the provider supports *capacity reservations* and MUST be of type String.
+* CapacityReservationStatus MUST be null when CapacityReservationId is null.
+* CapacityReservationStatus MUST NOT be null when CapacityReservationId is not null and [ChargeCategory](#chargecategory) is "Usage".
+* CapacityReservationStatus MUST be one of the allowed values.
+* CapacityReservationStatus MUST label all unused *capacity reservation* charges and MUST label used *capacity reservation* charges if the provider supports it.
 
 ## Column ID
 

--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -9,6 +9,8 @@ The FOCUS specification defines a group of columns that provide qualitative valu
 !INCLUDE "billingcurrency.md",1
 !INCLUDE "billingperiodend.md",1
 !INCLUDE "billingperiodstart.md",1
+!INCLUDE "capacityreservationid.md",1
+!INCLUDE "capacityreservationstatus.md",1
 !INCLUDE "chargecategory.md",1
 !INCLUDE "chargeclass.md",1
 !INCLUDE "chargedescription.md",1

--- a/specification/columns/skupricedetails.md
+++ b/specification/columns/skupricedetails.md
@@ -2,22 +2,21 @@
 
 The **SKU Price Details** column represents a list of relevant properties shared by all charges with the same [**SKU Price ID**](#skupriceid). These properties provide qualitative and quantitative details about the service represented by a **SKU Price ID**. This can enable practitioners to calculate metrics such as total units of a service when it is not directly billed in those units (e.g. cores) and thus enables FinOps capabilities such as unit economics. These properties can also help a practitioner understand the specifics of a **SKU Price ID** and differentiate it other **SKU Price IDs**.
 
-
 The *SkuPriceDetails* column adheres to the following requirements:
 
-- The *SkuPriceDetails* column MUST be in [*KeyValueFormat*](#key-valueformat).
-- The key for a property SHOULD be formatted in [PascalCase](#glossary:pascalcase).
-- The properties (both keys and values) contained in the *SkuPriceDetails* column MUST be shared across all charges having the same *SkuPriceId*, subject to the below provisions.
-  - Additional properties (key-value pairs) MAY be added to *SkuPriceDetails* going forward for a given *SkuPriceId*.
-  - Properties SHOULD NOT be removed from *SkuPriceDetails* for a given *SkuPriceId*, once they have been included.
-  - Individual properties (key-value pairs) SHOULD NOT be modified for a given *SkuPriceId* and SHOULD remain consistent over time.
-- The key for a property SHOULD remain consistent across comparable SKUs having that property and the values for this key SHOULD remain in a consistent format.
-- The *SkuPriceDetails* column MUST NOT contain properties which are not applicable to the corresponding *SkuPriceId*.
-- The *SkuPriceDetails* column MAY contain properties which are already captured in other dedicated columns.
-- If a property has a numeric value, it MUST represent the value for a single [*PricingUnit*](#pricingunit).
-- The *SkuPriceDetails* column MUST be present in the billing data when the provider includes a *SkuPriceId*.
-  - The *SkuPriceDetails* column MAY be null when *SkuPriceId* is not null.
-  - The *SkuPriceDetails* column MUST be null when *SkuPriceId* is null.
+* The *SkuPriceDetails* column MUST be in [*KeyValueFormat*](#key-valueformat).
+* The key for a property SHOULD be formatted in [PascalCase](#glossary:pascalcase).
+* The properties (both keys and values) contained in the *SkuPriceDetails* column MUST be shared across all charges having the same *SkuPriceId*, subject to the below provisions.
+  * Additional properties (key-value pairs) MAY be added to *SkuPriceDetails* going forward for a given *SkuPriceId*.
+  * Properties SHOULD NOT be removed from *SkuPriceDetails* for a given *SkuPriceId*, once they have been included.
+  * Individual properties (key-value pairs) SHOULD NOT be modified for a given *SkuPriceId* and SHOULD remain consistent over time.
+* The key for a property SHOULD remain consistent across comparable SKUs having that property and the values for this key SHOULD remain in a consistent format.
+* The *SkuPriceDetails* column MUST NOT contain properties which are not applicable to the corresponding *SkuPriceId*.
+* The *SkuPriceDetails* column MAY contain properties which are already captured in other dedicated columns.
+* If a property has a numeric value, it MUST represent the value for a single [*PricingUnit*](#pricingunit).
+* The *SkuPriceDetails* column MUST be present in the billing data when the provider includes a *SkuPriceId*.
+  * The *SkuPriceDetails* column MAY be null when *SkuPriceId* is not null.
+  * The *SkuPriceDetails* column MUST be null when *SkuPriceId* is null.
 
 ## Examples
 

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -3,12 +3,13 @@
 A SKU Price ID is a unique identifier that defines the unit price used to calculate the charge. SKU Price ID can be referenced on a [*price list*](#glossary:price-list) published by a provider to look up detailed information, including a corresponding list unit price. The composition of the properties associated with the SKU Price ID may differ across providers. SKU Price ID is commonly used for analyzing cost based on pricing properties such as Terms and Tiers.
 
 The *SkuPriceId* column adheres to the following requirements:
-- *SkuPriceId* MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
-- *SkuPriceId* MUST define a single unit price used for calculating the charge.
-- [*ListUnitPrice*](#listunitprice) MUST be associated with the *SkuPriceId* in the provider published price list.
-- *SkuPriceId* MUST NOT be null when [*ChargeClass*](#chargeclass) is not "Correction" and [*ChargeCategory*](#chargecategory) is "Usage" or "Purchase", MUST be null when *ChargeCategory* is "Tax", and MAY be null for all other combinations of *ChargeClass* and *ChargeCategory*.
-- A given value of *SkuPriceId* MUST be associated with one and only one [*SkuId*](#skuid), except in cases of commitment discount flexibility.
-- If a provider does not have a *SkuPriceId* and wants to include information in columns linked to *SkuPriceId* such as *ListUnitPrice* or [*SkuPriceDetails*](#skupricedetails), the *SkuId* MAY be used in the *SkuPriceId* column as long as it adheres to the above conditions.
+
+* *SkuPriceId* MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
+* *SkuPriceId* MUST define a single unit price used for calculating the charge.
+* [*ListUnitPrice*](#listunitprice) MUST be associated with the *SkuPriceId* in the provider published price list.
+* *SkuPriceId* MUST NOT be null when [*ChargeClass*](#chargeclass) is not "Correction" and [*ChargeCategory*](#chargecategory) is "Usage" or "Purchase", MUST be null when *ChargeCategory* is "Tax", and MAY be null for all other combinations of *ChargeClass* and *ChargeCategory*.
+* A given value of *SkuPriceId* MUST be associated with one and only one [*SkuId*](#skuid), except in cases of commitment discount flexibility.
+* If a provider does not have a *SkuPriceId* and wants to include information in columns linked to *SkuPriceId* such as *ListUnitPrice* or [*SkuPriceDetails*](#skupricedetails), the *SkuId* MAY be used in the *SkuPriceId* column as long as it adheres to the above conditions.
 
 ## Column ID
 


### PR DESCRIPTION
No change to content, just makes the `working_draft` branch pass builds
1. Adds `capacityreservation{id,status}` columns to `columns.mdpp` file.
2. Adds linter correction across all capacityreservation*, sku* columns:
  - `-` --> `*` bullets
  - spaces around lists