### PR TITLE
FOCUS #547-2: Consistency Review - PricingQuantity and PricingUnit

### DIFF
--- a/specification/columns/commitmentdiscountquantity.md
+++ b/specification/columns/commitmentdiscountquantity.md
@@ -35,7 +35,7 @@ The amount of a *commitment discount* purchased or accounted for in *commitment 
 
 | Constraint      | Value            |
 |:----------------|:-----------------|
-| Column type     | Dimension        |
+| Column type     | Metric           |
 | Feature level   | Conditional      |
 | Allows nulls    | True             |
 | Data type       | Decimal          |

--- a/specification/columns/commitmentdiscountquantity.md
+++ b/specification/columns/commitmentdiscountquantity.md
@@ -10,19 +10,14 @@ The CommitmentDiscountQuantity column adheres to the following requirements:
 
 * CommitmentDiscountQuantity MUST be present in a FOCUS dataset when the provider supports *commitment discounts*.
 * CommitmentDiscountQuantity MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements.
-* CommitmentDiscountQuantity MAY be negative if [*ChargeClass*](#chargeclass) is "Correction".
-
-In cases where the *ChargeCategory* is "Purchase" and [*CommitmentDiscountId*](#commitmentdiscountid) is not null, the following applies:
-
-* When [*ChargeFrequency*](#chargefrequency) is "One-Time", and *CommitmentDiscountId* is not null, CommitmentDiscountQuantity MUST be the positive quantity of *CommitmentDiscountUnits*, paid fully or partially upfront, that is eligible for consumption over the *commitment discount's* *term*.
-* When *ChargeFrequency* is "Recurring", and *CommitmentDiscountId* is not null, CommitmentDiscountQuantity MUST be the positive quantity of *CommitmentDiscountUnits* that is eligible for consumption for each *charge period* that corresponds with the purchase.
-
-In cases where the *ChargeCategory* is "Usage" and *CommitmentDiscountId* is not null, the following applies:
-
-* When *CommitmentDiscountStatus* is "Used", and *ChargeClass* is not "Correction", CommitmentDiscountQuantity MUST be the positive, metered quantity of *CommitmentDiscountUnits* that is consumed over the *row's* *charge period*.
-* When *CommitmentDiscountStatus* is "Unused", and *ChargeClass* is not "Correction", CommitmentDiscountQuantity MUST be the remaining, positive, unused quantity of *CommitmentDiscountUnits* for the *row's* *charge period*.
-
-CommitmentDiscountQuantity MUST be null for all other *ChargeCategory* values.
+* If [*CommitmentDiscountId*](#commitmentdiscountid) is not null and [*ChargeClass*](#chargeclass) is not "Correction", the following applies:
+  * CommitmentDiscountQuantity MUST NOT be null and MAY be any valid positive decimal value.
+  * When *ChargeCategory* is "Purchase" and [*ChargeFrequency*](#chargefrequency) is "One-Time", CommitmentDiscountQuantity MUST be the positive quantity of *CommitmentDiscountUnits*, paid fully or partially upfront, that is eligible for consumption over the *commitment discount's* *term*.
+  * When *ChargeCategory* is "Purchase" and *ChargeFrequency* is "Recurring", CommitmentDiscountQuantity MUST be the positive quantity of *CommitmentDiscountUnits* that is eligible for consumption for each *charge period* that corresponds with the purchase.
+  * When *ChargeCategory* is "Usage" and *CommitmentDiscountStatus* is "Used", CommitmentDiscountQuantity MUST be the positive, metered quantity of *CommitmentDiscountUnits* that is consumed over the *row's* *charge period*.
+  * When *ChargeCategory* is "Usage" and *CommitmentDiscountStatus* is "Unused", CommitmentDiscountQuantity MUST be the remaining, positive, unused quantity of *CommitmentDiscountUnits* for the *row's* *charge period*.
+* If *CommitmentDiscountId* is not null, and *ChargeClass* is "Correction", CommitmentDiscountQuantity MAY be null or any valid decimal value.
+* CommitmentDiscountQuantity MUST be null in all other cases.
 
 ## Column ID
 

--- a/specification/columns/commitmentdiscountquantity.md
+++ b/specification/columns/commitmentdiscountquantity.md
@@ -11,7 +11,7 @@ The CommitmentDiscountQuantity column adheres to the following requirements:
 * CommitmentDiscountQuantity MUST be present in a FOCUS dataset when the provider supports *commitment discounts*.
 * CommitmentDiscountQuantity MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements.
 * If [*CommitmentDiscountId*](#commitmentdiscountid) is not null and [*ChargeClass*](#chargeclass) is not "Correction", the following applies:
-  * CommitmentDiscountQuantity MUST NOT be null and MAY be any valid positive decimal value.
+  * CommitmentDiscountQuantity MUST NOT be null and MUST be a valid positive decimal value.
   * When *ChargeCategory* is "Purchase" and [*ChargeFrequency*](#chargefrequency) is "One-Time", CommitmentDiscountQuantity MUST be the positive quantity of *CommitmentDiscountUnits*, paid fully or partially upfront, that is eligible for consumption over the *commitment discount's* *term*.
   * When *ChargeCategory* is "Purchase" and *ChargeFrequency* is "Recurring", CommitmentDiscountQuantity MUST be the positive quantity of *CommitmentDiscountUnits* that is eligible for consumption for each *charge period* that corresponds with the purchase.
   * When *ChargeCategory* is "Usage" and *CommitmentDiscountStatus* is "Used", CommitmentDiscountQuantity MUST be the positive, metered quantity of *CommitmentDiscountUnits* that is consumed over the *row's* *charge period*.

--- a/specification/columns/commitmentdiscountunit.md
+++ b/specification/columns/commitmentdiscountunit.md
@@ -5,15 +5,15 @@ Commitment Discount Unit represents the provider-specified measurement unit indi
 The CommitmentDiscountUnit column adheres to the following requirements:
 
 * CommitmentDiscountUnit MUST be present in a FOCUS dataset when the provider supports [*commitment discounts*](#glossary:commitment-discount).
-* CommitmentDiscountUnit MUST be of type String, and the units of measure used in CommitmentDiscountUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
-* The CommitmentDiscountUnit MUST be the same across all *rows* where *CommitmentDiscountQuantity* has the same [*CommitmentDiscountId*](#commitmentdiscountid).
-* CommitmentDiscountUnit MUST NOT be null when *CommitmentDiscountId* is not null.
+* CommitmentDiscountUnit MUST be of type String.
+* Units of measure used in CommitmentDiscountUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
+* CommitmentDiscountUnit MUST NOT be null when *CommitmentDiscountId* is not null and [*ChargeClass*](#chargeclass) is not "Correction".
+* CommitmentDiscountUnit MAY be null when *CommitmentDiscountId* is not null and *ChargeClass* is "Correction".
 * CommitmentDiscountUnit MUST be null in all other cases.
-
-In cases where the CommitmentDiscountUnit is not null, the following applies:
-
-* The CommitmentDiscountUnit MUST represent the unit used to measure the *commitment discount*.
-* When accounting for *commitment flexibility*, the CommitmentDiscountUnit value SHOULD reflect this consideration.
+* In cases where the CommitmentDiscountUnit is not null, the following applies:
+  * CommitmentDiscountUnit MUST be the same across all *rows* having the same [*CommitmentDiscountId*](#commitmentdiscountid).
+  * CommitmentDiscountUnit MUST represent the unit used to measure the *commitment discount*.
+  * When accounting for *commitment flexibility*, the CommitmentDiscountUnit value SHOULD reflect this consideration.
 
 ## Column ID
 

--- a/specification/columns/consumedquantity.md
+++ b/specification/columns/consumedquantity.md
@@ -1,13 +1,13 @@
 # Consumed Quantity
 
-The Consumed Quantity represents the volume of a given SKU associated with a metered [*resource*](#glossary:resource) or [*service*](#glossary:service) used, based on the [Consumed Unit](#consumedunit). Consumed Quantity is often derived at a finer granularity or over a different time interval when compared to the [Pricing Quantity](#pricingquantity) (complementary to [Pricing Unit](#pricingunit)) and focuses on metered *resource* and *service* consumption, not pricing and cost.
+The Consumed Quantity represents the volume of a given SKU associated with a [*resource*](#glossary:resource) or [*service*](#glossary:service) used, based on the [Consumed Unit](#consumedunit). Consumed Quantity is often derived at a finer granularity or over a different time interval when compared to the [Pricing Quantity](#pricingquantity) (complementary to [Pricing Unit](#pricingunit)) and focuses on *resource* and *service* consumption, not pricing and cost.
 
 The ConsumedQuantity column adheres to the following requirements:
 
 * ConsumedQuantity MUST be present in a FOCUS dataset when the provider supports the measurement of usage.
 * ConsumedQuantity MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements.
 * If [ChargeCategory](#chargecategory) is "Usage" and [CommitmentDiscountStatus](#commitmentdiscountstatus) is not "Unused", the following applies:
-  * ConsumedQuantity MUST NOT be null and MUST be a valid non-negative decimal value if [ChargeClass](#chargeclass) is not "Correction".
+  * ConsumedQuantity MUST NOT be null and MUST be a valid positive decimal value if [ChargeClass](#chargeclass) is not "Correction".
   * ConsumedQuantity MAY be null or any valid decimal value if [ChargeClass](#chargeclass) is "Correction".
 * ConsumedQuantity MUST be null in all other cases.
 
@@ -21,7 +21,7 @@ Consumed Quantity
 
 ## Description
 
-The volume of a given SKU associated with a metered *resource* or *service* used, based on the Consumed Unit.
+The volume of a given SKU associated with a *resource* or *service* used, based on the Consumed Unit.
 
 ## Content constraints
 

--- a/specification/columns/consumedquantity.md
+++ b/specification/columns/consumedquantity.md
@@ -6,9 +6,10 @@ The ConsumedQuantity column adheres to the following requirements:
 
 * ConsumedQuantity MUST be present in a FOCUS dataset when the provider supports the measurement of usage.
 * ConsumedQuantity MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements.
-* ConsumedQuantity MUST NOT be null if [ChargeCategory](#chargecategory) is "Usage" and [ChargeClass](#chargeclass) is not "Correction".
-* ConsumedQuantity MUST be null if [CommitmentDiscountStatus](#commitmentdiscountstatus) is "Unused" or for other *ChargeCategory* values.
-* ConsumedQuantity MAY be negative or null in cases where *ChargeClass* is "Correction".
+* If [ChargeCategory](#chargecategory) is "Usage" and [CommitmentDiscountStatus](#commitmentdiscountstatus) is not "Unused", the following applies:
+  * ConsumedQuantity MUST NOT be null and MAY be any valid non-negative decimal value if [ChargeClass](#chargeclass) is not "Correction".
+  * ConsumedQuantity MAY be null or any valid decimal value if [ChargeClass](#chargeclass) is "Correction".
+* ConsumedQuantity MUST be null in all other cases.
 
 ## Column ID
 

--- a/specification/columns/consumedquantity.md
+++ b/specification/columns/consumedquantity.md
@@ -7,7 +7,7 @@ The ConsumedQuantity column adheres to the following requirements:
 * ConsumedQuantity MUST be present in a FOCUS dataset when the provider supports the measurement of usage.
 * ConsumedQuantity MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements.
 * If [ChargeCategory](#chargecategory) is "Usage" and [CommitmentDiscountStatus](#commitmentdiscountstatus) is not "Unused", the following applies:
-  * ConsumedQuantity MUST NOT be null and MAY be any valid non-negative decimal value if [ChargeClass](#chargeclass) is not "Correction".
+  * ConsumedQuantity MUST NOT be null and MUST be a valid non-negative decimal value if [ChargeClass](#chargeclass) is not "Correction".
   * ConsumedQuantity MAY be null or any valid decimal value if [ChargeClass](#chargeclass) is "Correction".
 * ConsumedQuantity MUST be null in all other cases.
 

--- a/specification/columns/consumedunit.md
+++ b/specification/columns/consumedunit.md
@@ -5,10 +5,12 @@ The Consumed Unit represents a provider-specified measurement unit indicating ho
 The ConsumedUnit column adheres to the following requirements:
 
 * ConsumedUnit MUST be present in the billing data when the provider supports the measurement of usage.
-* ConsumedUnit MUST be of type String, and the units of measure used in ConsumedUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
-* ConsumedUnit MUST NOT be null if [ChargeCategory](#chargecategory) is "Usage" and [ChargeClass](#chargeclass) is not "Correction".
-* When *ChargeCategory* is not "Usage", or *ChargeCategory* is "Usage" and [CommitmentDiscountStatus](#commitmentdiscountstatus) is "Unused", ConsumedUnit MUST be null when ChargeClass is not "Correction".
-* ConsumedUnit MAY be null if *ChargeCategory* is "Usage" and ChargeClass is "Correction".
+* ConsumedUnit MUST be of type String.
+* Units of measure used in ConsumedUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
+* If [ChargeCategory](#chargecategory) is "Usage" and [CommitmentDiscountStatus](#commitmentdiscountstatus) is not "Unused", the following applies:
+  * ConsumedUnit MUST NOT be null if [ChargeClass](#chargeclass) is not "Correction".
+  * ConsumedUnit MAY be null if *ChargeClass* is "Correction".
+* ConsumedUnit MUST be null in all other cases.
 
 ## Column ID
 

--- a/specification/columns/consumedunit.md
+++ b/specification/columns/consumedunit.md
@@ -1,6 +1,6 @@
 # Consumed Unit
 
-The Consumed Unit represents a provider-specified measurement unit indicating how a provider measures usage of a given SKU associated with a metered [*resource*](#glossary:resource) or [*service*](#glossary:service). Consumed Unit complements the [Consumed Quantity](#consumedquantity) metric. It is often listed at a finer granularity or over a different time interval when compared to [Pricing Unit](#pricingunit) (complementary to [Pricing Quantity](#pricingquantity)), and focuses on metered *resource* and *service* consumption, not pricing and cost.
+The Consumed Unit represents a provider-specified measurement unit indicating how a provider measures usage of a given SKU associated with a [*resource*](#glossary:resource) or [*service*](#glossary:service). Consumed Unit complements the [Consumed Quantity](#consumedquantity) metric. It is often listed at a finer granularity or over a different time interval when compared to [Pricing Unit](#pricingunit) (complementary to [Pricing Quantity](#pricingquantity)), and focuses on *resource* and *service* consumption, not pricing and cost.
 
 The ConsumedUnit column adheres to the following requirements:
 
@@ -22,7 +22,7 @@ Consumed Unit
 
 ## Description
 
-Provider-specified measurement unit indicating how a provider measures usage of a given SKU associated with a metered *resource* or *service*.
+Provider-specified measurement unit indicating how a provider measures usage of a given SKU associated with a *resource* or *service*.
 
 ## Content constraints
 

--- a/specification/columns/pricingquantity.md
+++ b/specification/columns/pricingquantity.md
@@ -2,7 +2,15 @@
 
 The Pricing Quantity represents the volume of a given SKU associated with a [*resource*](#glossary:resource) or [*service*](#glossary:service) used or purchased, based on the [Pricing Unit](#pricingunit). Distinct from [Consumed Quantity](#consumedquantity) (complementary to [Consumed Unit](#consumedunit)), it focuses on pricing and cost, not *resource* and *service* consumption.
 
-The PricingQuantity column MUST be present in a FOCUS dataset. This column MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements. The value MAY be negative in cases where [ChargeClass](#chargeclass) is "Correction". This column MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory. When unit prices are not null, multiplying PricingQuantity by a unit price MUST produce a result equal to the corresponding cost metric, except in cases of ChargeClass "Correction", which may address PricingQuantity or any cost discrepancies independently.
+The PricingQuantity column adheres to the following requirements:
+
+* PricingQuantity MUST be present in a FOCUS dataset.
+* PricingQuantity MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements.
+* PricingQuantity MUST NOT be null and MUST be a valid positive decimal value if [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase".
+* PricingQuantity MUST be null or a valid negative decimal value if ChargeClass is not "Correction" and ChargeCategory is "Credit".
+* PricingQuantity MUST be null when ChargeCategory is "Tax".
+* PricingQuantity MAY be null or any valid decimal value in all other cases.
+* When unit prices are not null, multiplying PricingQuantity by a unit price MUST produce a result equal to the corresponding cost metric, except in cases of ChargeClass "Correction", which may address PricingQuantity or any cost discrepancies independently.
 
 ## Column ID
 

--- a/specification/columns/pricingunit.md
+++ b/specification/columns/pricingunit.md
@@ -2,12 +2,17 @@
 
 The Pricing Unit represents a provider-specified measurement unit for determining unit prices, indicating how the provider rates measured usage and purchase quantities after applying pricing rules like [*block pricing*](#glossary:block-pricing). Common examples include the number of hours for compute appliance runtime (e.g. `Hours`), gigabyte-hours for a storage appliance (e.g., `GB-Hours`), or an accumulated count of requests for a network appliance or API service (e.g., `1000 Requests`). Pricing Unit complements the [Pricing Quantity](#pricingquantity) metric. Distinct from the [Consumed Unit](#consumedunit), it focuses on pricing and cost, not [*resource*](#glossary:resource) and [*service*](#glossary:service) consumption, often at a coarser granularity.
 
-The PricingUnit column MUST be present in a FOCUS dataset. This column MUST be of type String. It MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory. Units of measure used in PricingUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
+The PricingUnit column adheres to the following requirements:
 
-The PricingUnit value MUST be semantically equal to the corresponding pricing measurement unit value provided in:
-
-* The provider-published [*price list*](#glossary:price-list)
-* The invoice, when the invoice includes a pricing measurement unit
+* PricingUnit MUST be present in a FOCUS dataset.
+* PricingUnit MUST be of type String.
+* Units of measure used in PricingUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
+* PricingUnit MUST NOT be null if [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase".
+* PricingUnit MUST be null if ChargeCategory is "Tax".
+* PricingUnit MAY be null in all other cases.
+* In cases where the PricingUnit is not null, the value MUST be semantically equal to the corresponding pricing measurement unit value provided in:
+  * The provider-published [*price list*](#glossary:price-list)
+  * The invoice, when the invoice includes a pricing measurement unit
 
 ## Column ID
 


### PR DESCRIPTION
- **Scope of this PR:** 
  - PricingQuantity and PricingUnit - Switch to a bullet list before addressing value ranges

- **Status:**
  - Nullability already correctly specified.
  - **Identified issues/improvement suggestions:**
    - The following statement doesn't specify much: "The value MAY be negative in cases where ChargeClass is 'Correction.'"
       By the way, it’s assumed that negative values are expected in regular credit charges (see [#547: Corrections and value ranges - Metrics and ValueRanges sheet](https://docs.google.com/spreadsheets/d/1SvaD-PSzxwRKExKYbQXbtEmVPtbhN4HnycOatvLfGPI/edit?gid=1728767078#gid=1728767078) for more details).
    - Switch back to the version 1.0 definition and description considering it's not the resource or service being metered, but the associated SKUs (referring to 'SKU associated with a metered *resource* or *service*' vs 'SKU associated with a *resource* or *service*')
  - **Value ranges**
    - Discuss and confirm before proceeding with the PR (table overview available in [#547: Corrections and value ranges - Metrics and ValueRanges sheet](https://docs.google.com/spreadsheets/d/1SvaD-PSzxwRKExKYbQXbtEmVPtbhN4HnycOatvLfGPI/edit?gid=1728767078#gid=1728767078)).
    - **Switch to bullet list**
      - review and reach consensus