### PR TITLE
FOCUS #547-p2: Consistency Review - PricingQuantity and PricingUnit

### DIFF
--- a/specification/columns/pricingquantity.md
+++ b/specification/columns/pricingquantity.md
@@ -2,7 +2,15 @@
 
 The Pricing Quantity represents the volume of a given SKU associated with a [*resource*](#glossary:resource) or [*service*](#glossary:service) used or purchased, based on the [Pricing Unit](#pricingunit). Distinct from [Consumed Quantity](#consumedquantity) (complementary to [Consumed Unit](#consumedunit)), it focuses on pricing and cost, not *resource* and *service* consumption.
 
-The PricingQuantity column MUST be present in a FOCUS dataset. This column MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements. The value MAY be negative in cases where [ChargeClass](#chargeclass) is "Correction". This column MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory. When unit prices are not null, multiplying PricingQuantity by a unit price MUST produce a result equal to the corresponding cost metric, except in cases of ChargeClass "Correction", which may address PricingQuantity or any cost discrepancies independently.
+The PricingQuantity column adheres to the following requirements:
+
+* PricingQuantity MUST be present in a FOCUS dataset.
+* PricingQuantity MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements.
+* PricingQuantity MUST NOT be null and MUST be a valid positive decimal value if [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase".
+* PricingQuantity MUST be null or a valid negative decimal value if ChargeClass is not "Correction" and ChargeCategory is "Credit".
+* PricingQuantity MUST be null when ChargeCategory is "Tax".
+* PricingQuantity MAY be null or any valid decimal value in all other cases.
+* When unit prices are not null, multiplying PricingQuantity by a unit price MUST produce a result equal to the corresponding cost metric, except in cases of ChargeClass "Correction", which may address PricingQuantity or any cost discrepancies independently.
 
 ## Column ID
 

--- a/specification/columns/pricingunit.md
+++ b/specification/columns/pricingunit.md
@@ -2,12 +2,17 @@
 
 The Pricing Unit represents a provider-specified measurement unit for determining unit prices, indicating how the provider rates measured usage and purchase quantities after applying pricing rules like [*block pricing*](#glossary:block-pricing). Common examples include the number of hours for compute appliance runtime (e.g. `Hours`), gigabyte-hours for a storage appliance (e.g., `GB-Hours`), or an accumulated count of requests for a network appliance or API service (e.g., `1000 Requests`). Pricing Unit complements the [Pricing Quantity](#pricingquantity) metric. Distinct from the [Consumed Unit](#consumedunit), it focuses on pricing and cost, not [*resource*](#glossary:resource) and [*service*](#glossary:service) consumption, often at a coarser granularity.
 
-The PricingUnit column MUST be present in a FOCUS dataset. This column MUST be of type String. It MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory. Units of measure used in PricingUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
+The PricingUnit column adheres to the following requirements:
 
-The PricingUnit value MUST be semantically equal to the corresponding pricing measurement unit value provided in:
-
-* The provider-published [*price list*](#glossary:price-list)
-* The invoice, when the invoice includes a pricing measurement unit
+* PricingUnit MUST be present in a FOCUS dataset.
+* PricingUnit MUST be of type String.
+* Units of measure used in PricingUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
+* PricingUnit MUST NOT be null if [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase".
+* PricingUnit MUST be null if ChargeCategory is "Tax".
+* PricingUnit MAY be null in all other cases.
+* In cases where the PricingUnit is not null, the value MUST be semantically equal to the corresponding pricing measurement unit value provided in:
+  * The provider-published [*price list*](#glossary:price-list)
+  * The invoice, when the invoice includes a pricing measurement unit
 
 ## Column ID
 


### PR DESCRIPTION
- **Scope of this PR:** 
  - PricingQuantity and PricingUnit - Switch to a bullet list before addressing value ranges

- **Status:**
  - Nullability already correctly specified.
  - **Identified issues/improvement suggestions:**
    - The following statement doesn't specify much: "The value MAY be negative in cases where ChargeClass is 'Correction.'"
       By the way, it’s assumed that negative values are expected in regular credit charges (see [#547: Corrections and value ranges - Metrics and ValueRanges sheet](https://docs.google.com/spreadsheets/d/1SvaD-PSzxwRKExKYbQXbtEmVPtbhN4HnycOatvLfGPI/edit?gid=1728767078#gid=1728767078) for more details).
    - Switch back to the version 1.0 definition and description considering it's not the resource or service being metered, but the associated SKUs (referring to 'SKU associated with a metered *resource* or *service*' vs 'SKU associated with a *resource* or *service*')
  - **Value ranges**
    - Discuss and confirm before proceeding with the PR (table overview available in [#547: Corrections and value ranges - Metrics and ValueRanges sheet](https://docs.google.com/spreadsheets/d/1SvaD-PSzxwRKExKYbQXbtEmVPtbhN4HnycOatvLfGPI/edit?gid=1728767078#gid=1728767078)).
    - **Switch to bullet list**
      - review and reach consensus