### PR TITLE
Editorial changes to columns names and ids

### DIFF
--- a/specification/columns/skupricedetails.md
+++ b/specification/columns/skupricedetails.md
@@ -39,7 +39,7 @@ SKU Price Details
 
 ## Description
 
-A set of properties of a **SKU Price ID** which are meaningful and common to all instances of that **SKU Price ID**.
+A set of properties of a SKU Price ID which are meaningful and common to all instances of that SKU Price ID.
 
 ## Content Constraints
 

--- a/specification/columns/skupricedetails.md
+++ b/specification/columns/skupricedetails.md
@@ -1,22 +1,22 @@
 # SKU Price Details
 
-The **SKU Price Details** column represents a list of relevant properties shared by all charges with the same [**SKU Price ID**](#skupriceid). These properties provide qualitative and quantitative details about the service represented by a **SKU Price ID**. This can enable practitioners to calculate metrics such as total units of a service when it is not directly billed in those units (e.g. cores) and thus enables FinOps capabilities such as unit economics. These properties can also help a practitioner understand the specifics of a **SKU Price ID** and differentiate it other **SKU Price IDs**.
+The SKU Price Details column represents a list of relevant properties shared by all charges with the same [SKU Price ID](#skupriceid). These properties provide qualitative and quantitative details about the service represented by a SKU Price ID. This can enable practitioners to calculate metrics such as total units of a service when it is not directly billed in those units (e.g. cores) and thus enables FinOps capabilities such as unit economics. These properties can also help a practitioner understand the specifics of a SKU Price ID and differentiate it other SKU Price IDs.
 
-The *SkuPriceDetails* column adheres to the following requirements:
+The SkuPriceDetails column adheres to the following requirements:
 
-* The *SkuPriceDetails* column MUST be in [*KeyValueFormat*](#key-valueformat).
+* The SkuPriceDetails column MUST be in [KeyValueFormat](#key-valueformat).
 * The key for a property SHOULD be formatted in [PascalCase](#glossary:pascalcase).
-* The properties (both keys and values) contained in the *SkuPriceDetails* column MUST be shared across all charges having the same *SkuPriceId*, subject to the below provisions.
-  * Additional properties (key-value pairs) MAY be added to *SkuPriceDetails* going forward for a given *SkuPriceId*.
-  * Properties SHOULD NOT be removed from *SkuPriceDetails* for a given *SkuPriceId*, once they have been included.
-  * Individual properties (key-value pairs) SHOULD NOT be modified for a given *SkuPriceId* and SHOULD remain consistent over time.
+* The properties (both keys and values) contained in the SkuPriceDetails column MUST be shared across all charges having the same SkuPriceId, subject to the below provisions.
+  * Additional properties (key-value pairs) MAY be added to SkuPriceDetails going forward for a given SkuPriceId.
+  * Properties SHOULD NOT be removed from SkuPriceDetails for a given SkuPriceId, once they have been included.
+  * Individual properties (key-value pairs) SHOULD NOT be modified for a given SkuPriceId and SHOULD remain consistent over time.
 * The key for a property SHOULD remain consistent across comparable SKUs having that property and the values for this key SHOULD remain in a consistent format.
-* The *SkuPriceDetails* column MUST NOT contain properties which are not applicable to the corresponding *SkuPriceId*.
-* The *SkuPriceDetails* column MAY contain properties which are already captured in other dedicated columns.
-* If a property has a numeric value, it MUST represent the value for a single [*PricingUnit*](#pricingunit).
-* The *SkuPriceDetails* column MUST be present in the billing data when the provider includes a *SkuPriceId*.
-  * The *SkuPriceDetails* column MAY be null when *SkuPriceId* is not null.
-  * The *SkuPriceDetails* column MUST be null when *SkuPriceId* is null.
+* The SkuPriceDetails column MUST NOT contain properties which are not applicable to the corresponding SkuPriceId.
+* The SkuPriceDetails column MAY contain properties which are already captured in other dedicated columns.
+* If a property has a numeric value, it MUST represent the value for a single [PricingUnit](#pricingunit).
+* The SkuPriceDetails column MUST be present in the billing data when the provider includes a SkuPriceId.
+  * The SkuPriceDetails column MAY be null when SkuPriceId is not null.
+  * The SkuPriceDetails column MUST be null when SkuPriceId is null.
 
 ## Examples
 

--- a/specification/columns/skupricedetails.md
+++ b/specification/columns/skupricedetails.md
@@ -4,7 +4,7 @@ The SKU Price Details column represents a list of relevant properties shared by 
 
 The SkuPriceDetails column adheres to the following requirements:
 
-* The SkuPriceDetails column MUST be in [KeyValueFormat](#key-valueformat).
+* The SkuPriceDetails column MUST be in [Key-Value Format](#key-valueformat).
 * The key for a property SHOULD be formatted in [PascalCase](#glossary:pascalcase).
 * The properties (both keys and values) contained in the SkuPriceDetails column MUST be shared across all charges having the same SkuPriceId, subject to the below provisions.
   * Additional properties (key-value pairs) MAY be added to SkuPriceDetails going forward for a given SkuPriceId.

--- a/specification/columns/skupricedetails.md
+++ b/specification/columns/skupricedetails.md
@@ -4,7 +4,7 @@ The SKU Price Details column represents a list of relevant properties shared by 
 
 The SkuPriceDetails column adheres to the following requirements:
 
-* The SkuPriceDetails column MUST be in [Key-Value Format](#key-valueformat).
+* The SkuPriceDetails column MUST be in [KeyValueFormat](#key-valueformat).
 * The key for a property SHOULD be formatted in [PascalCase](#glossary:pascalcase).
 * The properties (both keys and values) contained in the SkuPriceDetails column MUST be shared across all charges having the same SkuPriceId, subject to the below provisions.
   * Additional properties (key-value pairs) MAY be added to SkuPriceDetails going forward for a given SkuPriceId.

--- a/specification/columns/skupricedetails.md
+++ b/specification/columns/skupricedetails.md
@@ -14,7 +14,7 @@ The SkuPriceDetails column adheres to the following requirements:
 * The SkuPriceDetails column MUST NOT contain properties which are not applicable to the corresponding SkuPriceId.
 * The SkuPriceDetails column MAY contain properties which are already captured in other dedicated columns.
 * If a property has a numeric value, it MUST represent the value for a single [PricingUnit](#pricingunit).
-* The SkuPriceDetails column MUST be present in the billing data when the provider includes a SkuPriceId.
+* The SkuPriceDetails column MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider includes a SkuPriceId.
   * The SkuPriceDetails column MAY be null when SkuPriceId is not null.
   * The SkuPriceDetails column MUST be null when SkuPriceId is null.
 

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -2,14 +2,14 @@
 
 A SKU Price ID is a unique identifier that defines the unit price used to calculate the charge. SKU Price ID can be referenced on a [*price list*](#glossary:price-list) published by a provider to look up detailed information, including a corresponding list unit price. The composition of the properties associated with the SKU Price ID may differ across providers. SKU Price ID is commonly used for analyzing cost based on pricing properties such as Terms and Tiers.
 
-The *SkuPriceId* column adheres to the following requirements:
+The SkuPriceId column adheres to the following requirements:
 
-* *SkuPriceId* MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
-* *SkuPriceId* MUST define a single unit price used for calculating the charge.
-* [*ListUnitPrice*](#listunitprice) MUST be associated with the *SkuPriceId* in the provider published price list.
-* *SkuPriceId* MUST NOT be null when [*ChargeClass*](#chargeclass) is not "Correction" and [*ChargeCategory*](#chargecategory) is "Usage" or "Purchase", MUST be null when *ChargeCategory* is "Tax", and MAY be null for all other combinations of *ChargeClass* and *ChargeCategory*.
-* A given value of *SkuPriceId* MUST be associated with one and only one [*SkuId*](#skuid), except in cases of [*commitment discount flexibility*](glossary:commitment-discount-flexibility).
-* If a provider does not have a *SkuPriceId* and wants to include information in columns linked to *SkuPriceId* such as *ListUnitPrice* or [*SkuPriceDetails*](#skupricedetails), the *SkuId* MAY be used in the *SkuPriceId* column as long as it adheres to the above conditions.
+* SkuPriceId MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
+* SkuPriceId MUST define a single unit price used for calculating the charge.
+* [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published price list.
+* SkuPriceId MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
+* A given value of SkuPriceId MUST be associated with one and only one [SkuId](#skuid), except in cases of [commitment discount flexibility](glossary:commitment-discount-flexibility).
+* If a provider does not have a SkuPriceId and wants to include information in columns linked to SkuPriceId such as ListUnitPrice or [SkuPriceDetails](#skupricedetails), the SkuId MAY be used in the SkuPriceId column as long as it adheres to the above conditions.
 
 ## Column ID
 

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -4,7 +4,7 @@ A SKU Price ID is a unique identifier that defines the unit price used to calcul
 
 The SkuPriceId column adheres to the following requirements:
 
-* SkuPriceId MUST be present in a FOCUS dataset when the provider publishes a SKU price list and MUST be of type String.
+* SkuPriceId MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider publishes a SKU price list and MUST be of type String.
 * SkuPriceId MUST define a single unit price used for calculating the charge.
 * [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published price list.
 * SkuPriceId MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.

--- a/specification/columns/skupriceid.md
+++ b/specification/columns/skupriceid.md
@@ -8,7 +8,7 @@ The SkuPriceId column adheres to the following requirements:
 * SkuPriceId MUST define a single unit price used for calculating the charge.
 * [ListUnitPrice](#listunitprice) MUST be associated with the SkuPriceId in the provider published price list.
 * SkuPriceId MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction" and [ChargeCategory](#chargecategory) is "Usage" or "Purchase", MUST be null when ChargeCategory is "Tax", and MAY be null for all other combinations of ChargeClass and ChargeCategory.
-* A given value of SkuPriceId MUST be associated with one and only one [SkuId](#skuid), except in cases of [commitment discount flexibility](glossary:commitment-discount-flexibility).
+* A given value of SkuPriceId MUST be associated with one and only one [SkuId](#skuid), except in cases of [commitment discount flexibility](#glossary:commitment-discount-flexibility).
 * If a provider does not have a SkuPriceId and wants to include information in columns linked to SkuPriceId such as ListUnitPrice or [SkuPriceDetails](#skupricedetails), the SkuId MAY be used in the SkuPriceId column as long as it adheres to the above conditions.
 
 ## Column ID


### PR DESCRIPTION
_The changes in this PR are in accordance with the agreement that we will continue to use the previous version of the editorial guidelines in FOCUS version 1.1 (for details, see the table below)._

<table>
    <tr>
        <th width="20%">Component</th>
        <th width="30%">Markdown (examples)</th>
        <th width="50%">Editorial Guidelines</th>
    </tr>
    <tr>
        <td><strong>Column Names</strong>:</td>
        <td>
            <strong>Column Names</strong>:<br>
            Pricing Quantity<br>
            Pricing Unit<br>
            Provider<br>
        </td>
        <td>
            <ul>
                <li>Normal text without bold or italics.</li>
                <li>Use the display name in the introductory (non-normative) section and description.</li>
                <li>The first occurrence in a section is linked to the section, except when referring to itself.</li>
            </ul>
        </td>
    </tr>
    <tr>
        <td><strong>Attribute Names</strong>:</td>
        <td>
            <strong>Attribute Names</strong>:<br>
             Currency Code Format<br>
            Date/Time Format<br>
        </td>
        <td>
            <ul>
                <li>Normal text without bold or italics.</li>
                <li>Use the attribute display name in the introductory (non-normative) section, description, normative section, and content constraints table.</li>
                <li>The first occurrence in a section is linked to the section, except when referring to itself.</li>
            </ul>
        </td>
    </tr>
    <tr>
        <td><strong>Column IDs</strong>:</td>        
        <td>
            <strong>Column IDs</strong>:<br>
            PricingQuantity<br>
            PricingUnit<br>
            ProviderName<br>
        </td>
        <td>
            <ul>
                <li>Normal text without bold or italics.</li>
                <li>Use the column ID in the normative section and when referencing column values.</li>
                <li>For column IDs, use PascalCase (the first letter of every word is capitalized).</li>
                <li>The first occurrence in a section is linked to the corresponding column, except when referring to itself.</li>
            </ul>
        </td>
    </tr>
    <tr>
        <td><strong>Glossary</strong></td>
        <td>
            [*SKU*](#glossary:sku) <br>
            [*resource*](#glossary:resource) <br>
            [*service*](#glossary:service) <br>
        </td>
        <td>
            <ul>
                <li>Italic.</li>
                <li>The first occurrence in a section is linked to the glossary term.</li>
            </ul>
        </td>
    </tr>
</table>