### PR TITLE
Have consumedquantity be 0 for unused commitment

### DIFF
--- a/specification/columns/consumedquantity.md
+++ b/specification/columns/consumedquantity.md
@@ -7,6 +7,7 @@ The ConsumedQuantity column adheres to the following requirements:
 * ConsumedQuantity MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports the measurement of usage.
 * ConsumedQuantity MUST be of type Decimal and MUST conform to [Numeric Format](#numericformat) requirements.
 * ConsumedQuantity MUST NOT be null and MUST be a valid positive decimal value if [ChargeCategory](#chargecategory) is "Usage", [CommitmentDiscountStatus](#commitmentdiscountstatus) is not "Unused", and [ChargeClass](#chargeclass) is not "Correction".
+* ConsumedQuantity MUST be 0 if ChargeCategory is "Usage", CommitmentDiscountStatus is "Unused", and ChargeClass is not "Correction". 
 * ConsumedQuantity MAY be null or any valid decimal value if ChargeCategory is "Usage", CommitmentDiscountStatus is not "Unused", and ChargeClass is "Correction".
 * ConsumedQuantity MUST be null in all other cases.
 

--- a/specification/columns/consumedunit.md
+++ b/specification/columns/consumedunit.md
@@ -6,8 +6,8 @@ The ConsumedUnit column adheres to the following requirements:
 
 * ConsumedUnit MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports the measurement of usage.
 * ConsumedUnit MUST be of type String, and the units of measure used in ConsumedUnit SHOULD adhere to the values and format requirements specified in the [UnitFormat](#unitformat) attribute.
-* ConsumedUnit MUST NOT be null if [ChargeCategory](#chargecategory) is "Usage", [CommitmentDiscountStatus](#commitmentdiscountstatus) is not "Unused", and [ChargeClass](#chargeclass) is not "Correction".
-* ConsumedUnit MAY be null if ChargeCategory is "Usage", CommitmentDiscountStatus is not "Unused", and ChargeClass is "Correction".
+* ConsumedUnit MUST NOT be null if [ChargeCategory](#chargecategory) is "Usage" and [ChargeClass](#chargeclass) is not "Correction".
+* ConsumedUnit MAY be null if ChargeCategory is "Usage" and ChargeClass is "Correction".
 * ConsumedUnit MUST be null in all other cases.
 
 ## Column ID


### PR DESCRIPTION
If we don't force Unused commitment line items to be null for ConsumedQuantity, this is no longer a breaking change between FOCUS 1.0 and FOCUS 1.1. Making it 0 accomplishes the same goal as making it null, without the breaking change.

I also updated the ConsumedUnit to allow for this.