### PR TITLE
[EDITORIAL] EffectiveCost: convert normative statements into bullet p…

### DIFF
--- a/specification/columns/effectivecost.md
+++ b/specification/columns/effectivecost.md
@@ -7,7 +7,11 @@ This column resolves two challenges that are faced by practitioners:
 1. Practitioners need to *amortize* relevant purchases, such as upfront fees, throughout the *commitment* and distribute them to the appropriate reporting groups (e.g. [*tags*](#glossary:tag), [*resources*](#glossary:resource)).
 2. Many [*commitment discount*](#glossary:commitment-discount) constructs include a recurring expense for the *commitment* for every [*billing period*](#glossary:billing-period) and must distribute this cost to the *resources* using the *commitment*. This forces reconciliation between the initial *commitment* [*row*](#glossary:row) per period and the actual usage *rows*.
 
-The EffectiveCost column MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) and MUST NOT be null. This column MUST be of type Decimal, MUST conform to [Numeric Format](#numericformat) requirements, and be denominated in the BillingCurrency. EffectiveCost MUST be 0 when ChargeCategory is "Purchase" and the purchase is intended to cover future eligible charges. The aggregated EffectiveCost for a billing period may not match the charge received on the invoice for the same *billing period*.
+The EffectiveCost column adheres to the following requirements:
+
+* The EffectiveCost column MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) and MUST NOT be null.
+* This column MUST be of type Decimal, MUST conform to [Numeric Format](#numericformat) requirements, and be denominated in the BillingCurrency.
+* EffectiveCost MUST be 0 when ChargeCategory is "Purchase" and the purchase is intended to cover future eligible charges. The aggregated EffectiveCost for a billing period may not match the charge received on the invoice for the same *billing period*.
 
 In cases where the [ChargeCategory](#chargecategory) is not "Usage" or "Purchase", the following applies:
 


### PR DESCRIPTION
This PR is related to the issue https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/606 and converts normative statements into bullet points.