### PR TITLE
670 actions deprecation

### DIFF
--- a/.github/workflows/candidate_release.yml
+++ b/.github/workflows/candidate_release.yml
@@ -12,7 +12,7 @@ jobs:
       image: pandoc/extra:latest-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Install prequirements
         shell: bash
         run: |
@@ -27,7 +27,7 @@ jobs:
         run: |
           make STYLE=candidate_release
       - name: Upload Spec
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/candidate_release.yml
+++ b/.github/workflows/candidate_release.yml
@@ -12,7 +12,7 @@ jobs:
       image: pandoc/extra:latest-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install prequirements
         shell: bash
         run: |
@@ -27,7 +27,7 @@ jobs:
         run: |
           make STYLE=candidate_release
       - name: Upload Spec
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       image: pandoc/extra:latest-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Install prequirements
         shell: bash
         run: |
@@ -27,7 +27,7 @@ jobs:
         run: |
           make STYLE=main
       - name: Upload Spec
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       image: pandoc/extra:latest-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install prequirements
         shell: bash
         run: |
@@ -27,7 +27,7 @@ jobs:
         run: |
           make STYLE=main
       - name: Upload Spec
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -14,7 +14,7 @@ jobs:
       image: pandoc/extra:latest-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install prequirements
         shell: bash
         run: |
@@ -29,7 +29,7 @@ jobs:
         run: |
           make STYLE=working_draft
       - name: Upload Spec
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -14,7 +14,7 @@ jobs:
       image: pandoc/extra:latest-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Install prequirements
         shell: bash
         run: |
@@ -29,7 +29,7 @@ jobs:
         run: |
           make STYLE=working_draft
       - name: Upload Spec
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: FOCUS_specification
           path: |


### PR DESCRIPTION
Bump version of github actions used in Actions pipelines. Both actions/checkout@v3 and actions/upload-artifact@v3.1.2 need to be updated to v4. Testing on forked repo it appears this is safe for us to perform.