### PR TITLE
FOCUS #617: FOCUS dataset - glossary term update

### DIFF
--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -86,7 +86,8 @@ An open-source specification that defines requirements for billing data.
 
 <a name="glossary:FOCUS-dataset"><b>FOCUS Dataset</b></a>
 
-A structured collection of cost and usage data that meets or exceeds the Basic compliance criteria of FOCUS.
+A structured collection of cost and usage data that meets or exceeds the Basic compliance criteria of FOCUS. In addition to FOCUS columns, the dataset should include custom provider columns (prefixed with x_) when these columns provide additional information not captured by the existing FOCUS columns.
+If introducing a custom column could result in splitting original charge records into multiple entries, The Invoice Issuer is responsible for ensuring that the FOCUS dataset fully conforms to all aggregation-related requirements for metric columns, particularly those concerning costs and quantities.
 
 <a name="glossary:inclusivebound"><b>Inclusive Bound</b></a>
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -86,8 +86,7 @@ An open-source specification that defines requirements for billing data.
 
 <a name="glossary:FOCUS-dataset"><b>FOCUS Dataset</b></a>
 
-A structured collection of cost and usage data that meets or exceeds the Basic compliance criteria of FOCUS. In addition to FOCUS columns, the dataset should include custom provider columns (prefixed with x_) when these columns provide additional information not captured by the existing FOCUS columns.
-If introducing a custom column could result in splitting original charge records into multiple entries, The Invoice Issuer is responsible for ensuring that the FOCUS dataset fully conforms to all aggregation-related requirements for metric columns, particularly those concerning costs and quantities.
+A structured collection of cost and usage data that meets or exceeds the Basic compliance criteria of FOCUS. In addition to FOCUS columns, the dataset should include custom provider columns (prefixed with x_) when these columns provide additional information not captured by the existing FOCUS columns. If introducing a custom column could result in splitting original charge records into multiple entries, The Invoice Issuer is responsible for ensuring that the FOCUS dataset fully conforms to all aggregation-related requirements for metric columns, particularly those concerning costs and quantities.
 
 <a name="glossary:inclusivebound"><b>Inclusive Bound</b></a>
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -86,7 +86,7 @@ An open-source specification that defines requirements for billing data.
 
 <a name="glossary:FOCUS-dataset"><b>FOCUS Dataset</b></a>
 
-A structured collection of cost and usage data that meets or exceeds the Basic compliance criteria of FOCUS. In addition to FOCUS columns, the dataset should include custom provider columns (prefixed with x_) when these columns provide additional information not captured by the existing FOCUS columns. If introducing a custom column could result in splitting original charge records into multiple entries, The Invoice Issuer is responsible for ensuring that the FOCUS dataset fully conforms to all aggregation-related requirements for metric columns, particularly those concerning costs and quantities.
+A structured collection of cost and usage data that meets or exceeds the Basic compliance criteria of FOCUS. In addition to FOCUS columns, the dataset should include custom provider columns (prefixed with `x_`) when these columns provide additional information not captured by the existing FOCUS columns. If introducing a custom column could result in splitting original charge records into multiple entries, the Invoice Issuer is responsible for ensuring that the FOCUS dataset fully conforms to all aggregation-related requirements for metric columns, particularly those concerning costs and quantities.
 
 <a name="glossary:inclusivebound"><b>Inclusive Bound</b></a>
 


### PR DESCRIPTION
This PR updates the FOCUS specification to clarify the inclusion of custom/native provider-specific columns (prefixed with `x_`) in the FOCUS dataset. 

#### Changes:
1. **Glossary Update:**
   - Updated the FOCUS dataset glossary term to specify that `x_` columns should be included when they provide additional information not captured by existing FOCUS columns.
   - Clarified that introducing custom columns must adhere to aggregation-related requirements for metric columns (e.g., costs, quantities) to prevent aggregation errors.
