### PR TITLE
WI #540: Ensure all user-defined Tags are encapsulated within the Tags column

### DIFF
--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -14,7 +14,11 @@ The Tags column adheres to the following requirements:
 * A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
-* Providers with two or more user-defined tag schemes MUST ensure that all but one user-defined tag scheme are uniquely identified by a provider-defined prefix, allowing one scheme to remain unprefixed at their discretion.
+
+User-defined Tags additionally adhere to the following requirements:
+
+* When a provider has only 1 user-defined tag scheme, the provider MUST NOT alter any user-defined Tag keys.
+* When a provider has 2 or more user-defined tag scheme, the provider MUST alter all but 1 provider-determined tag scheme with unique, provider-defined prefixes.
 
 Provider-defined Tags additionally adhere to the following requirements:
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -14,6 +14,7 @@ The Tags column adheres to the following requirements:
 * A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
+* Providers MUST NOT alter user-defined Tag values
 
 User-defined Tags additionally adhere to the following requirements:
 
@@ -27,13 +28,17 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-This example illustrates four different tagging scenarios. The first three illustrate when the provider supports both keys and values, while the third is for supporting keys only. The first tag is user-defined and doesn't have a provider prefix. The second and third tags are provider-defined and have prefixes of `scheme2/` & `scheme3/` which are reserved by the provider. The fourth tag has a tag key of `baz` and its value is assigned the boolean value `true` since the tag doesn't support a value.
+This example illustrates various tags produced from multiple user-defined and provider-defined tag schemes.  The first three tags illustrate examples from three different, user-defined tag schemes, and the provider has predetermined that 1 user-defined tag scheme (i.e. `"foo": "bar"`) does not have a prepended prefix, but the two (i.e. `"userDefinedTagScheme2/foo": "bar"`, `"userDefinedTagScheme3/foo": true`) have predetermined and reserved prefixes.  Additionally, the third tag was produced from a valueless, user-defined tag scheme, so the provider provides `true` as its default value.
+
+The last two tags illustrate examples from two different, provider-defined tag schemes, and since all provider-defined tag schemes require a prefix, the provider has prepended prefixes (`providerDefinedTagScheme1/`, `providerDefinedTagScheme2/`) to each tag.
 
 ```json
     {
         "foo": "bar",
-        "scheme2/foo": "bar",
-        "scheme3/foo": "baz",
+        "userDefinedTagScheme2/foo": "bar",
+        "userDefinedTagScheme3/foo": true,
+        "providerDefinedTagScheme1/foo": "bar",
+        "providerDefinedTagScheme2/foo": "bar"
         "baz": true,
     }
 ```

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -13,7 +13,7 @@ The Tags column adheres to the following requirements:
 * A Tag key with a non-null value for a given resource SHOULD be included in the tags column.
 * A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
-* Providers MUST NOT alter Tag values unless applying true (boolean) to valueless tags
+* Providers MUST NOT alter tag values unless applying true (boolean) to valueless tags
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT allow reserved tag key prefixes to be used as prefixes for any user-defined tag keys within a prefixless, user-defined tag scheme.  
 * Providers SHOULD publish all provider-specified tag key prefixes within their respective documentation.

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -28,7 +28,7 @@ Provider-defined tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-This example illustrates various tags produced from multiple user-defined and provider-defined tag schemes.  The first three tags illustrate examples from three different, user-defined tag schemes. The provider predetermined that 1 user-defined tag scheme (i.e. `"foo": "bar"`) does not have a prepended prefix, but the remaining two user-defined tag schemes (i.e. `"userDefinedTagScheme2/foo": "bar"`, `"userDefinedTagScheme3/foo": true`) do have predefined and reserved prefixes specified by the provider.  Additionally, the third tag was produced from a valueless, user-defined tag scheme, so the provider also applies `true` as its default value.
+This example illustrates various tags produced from multiple user-defined and provider-defined tag schemes.  The first three tags illustrate examples from three different, user-defined tag schemes. The provider predetermined that 1 user-defined tag scheme (i.e. `"foo": "bar"`) does not have a prepended prefix, but the remaining two user-defined tag schemes (i.e. `"userDefinedTagScheme2/foo": "bar"`, `"userDefinedTagScheme3/foo": true`) do have provider-defined and reserved prefixes.  Additionally, the third tag is produced from a valueless, user-defined tag scheme, so the provider also applies `true` as its default value.
 
 The last two tags illustrate examples from two different, provider-defined tag schemes. Since all provider-defined tag schemes require a prefix, the provider has prepended predefined and reserved prefixes (`providerDefinedTagScheme1/`, `providerDefinedTagScheme2/`) to each tag.
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -30,7 +30,7 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 This example illustrates various tags produced from multiple user-defined and provider-defined tag schemes.  The first three tags illustrate examples from three different, user-defined tag schemes. The provider predetermined that 1 user-defined tag scheme (i.e. `"foo": "bar"`) does not have a prepended prefix, but the remaining two user-defined tag schemes (i.e. `"userDefinedTagScheme2/foo": "bar"`, `"userDefinedTagScheme3/foo": true`) do have predefined and reserved prefixes specified by the provider.  Additionally, the third tag was produced from a valueless, user-defined tag scheme, so the provider also applies `true` as its default value.
 
-The last two tags illustrate examples from two different, provider-defined tag schemes, and since all provider-defined tag schemes require a prefix, the provider has prepended prefixes (`providerDefinedTagScheme1/`, `providerDefinedTagScheme2/`) to each tag.
+The last two tags illustrate examples from two different, provider-defined tag schemes. Since all provider-defined tag schemes require a prefix, the provider has prepended predefined and reserved prefixes (`providerDefinedTagScheme1/`, `providerDefinedTagScheme2/`) to each tag.
 
 ```json
     {

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -10,9 +10,9 @@ The Tags column adheres to the following requirements:
 * Tags MUST contain all user-defined and provider-defined tags.
 * Tags MUST only contain finalized tags.
 * Tags MUST be in [KeyValueFormat](#key-valueformat).
-* A Tag key with a non-null value for a given resource SHOULD be included in the tags column.
-* A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
-* A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
+* A tag key with a non-null value for a given resource SHOULD be included in the tags column.
+* A tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
+* A tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * Providers MUST NOT alter tag values unless applying true (boolean) to valueless tags
 * If tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT allow reserved tag key prefixes to be used as prefixes for any user-defined tag keys within a prefixless, user-defined tag scheme.  

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -15,17 +15,16 @@ The Tags column adheres to the following requirements:
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * Providers MUST NOT alter Tag values unless applying true (boolean) to valueless tags
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
+* Providers SHOULD publish all provider-specified tag key prefixes within their respective documentation.
 
-
-User-defined Tags additionally adhere to the following requirements:
+User-defined tags additionally adhere to the following requirements:
 
 * When a provider has only 1 user-defined tag scheme, the provider MUST NOT alter any user-defined Tag keys.
-* When a provider has 2 or more user-defined tag schemes, the provider MUST alter all but 1 user-defined tag scheme with unique, provider-defined tag key prefixes.
+* When a provider has 2 or more user-defined tag schemes, the provider MUST alter all but 1 user-defined tag scheme with a predetermined, provider-specified tag key prefix that is unique to each corresponding user-defined tag scheme.
 
-Provider-defined Tags additionally adhere to the following requirements:
+Provider-defined tags additionally adhere to the following requirements:
 
-* Provider-defined tags MUST be prefixed with a provider-specified tag key prefix.
-* Providers SHOULD publish all provider-specified tag key prefixes within their respective documentation.
+* Provider-defined tags MUST be prefixed with a predetermined, provider-specified tag key prefix that is unique to each corresponding provider-specified tag scheme.
 
 ## Provider-Defined vs. User-Defined Tags
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -6,20 +6,21 @@ A tag becomes [*finalized*](#glossary:finalized-tag) when a single value is sele
 
 The Tags column adheres to the following requirements:
 
-* The Tags column MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports setting user or provider-defined tags.
-* The Tags column MUST contain user-defined and provider-defined tags.
-* The Tags column MUST only contain finalized tags.
-* The Tags column MUST be in [KeyValueFormat](#key-valueformat).
+* Tags MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports setting user or provider-defined tags.
+* Tags MUST contain user-defined and provider-defined tags.
+* Tags MUST only contain finalized tags.
+* Tags MUST be in [KeyValueFormat](#key-valueformat).
 * A Tag key with a non-null value for a given resource SHOULD be included in the tags column.
 * A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
-* If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT alter Tag values unless applying true (boolean) to valueless tags
+* If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
+
 
 User-defined Tags additionally adhere to the following requirements:
 
 * When a provider has only 1 user-defined tag scheme, the provider MUST NOT alter any user-defined Tag keys.
-* When a provider has 2 or more user-defined tag scheme, the provider MUST alter all but 1 provider-determined tag scheme with unique, provider-defined prefixes.
+* When a provider has 2 or more user-defined tag schemes, the provider MUST alter all but 1 user-defined tag scheme with unique, provider-defined tag key prefixes.
 
 Provider-defined Tags additionally adhere to the following requirements:
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -20,7 +20,7 @@ The Tags column adheres to the following requirements:
 
 User-defined tags additionally adhere to the following requirements:
 
-* When a provider has only 1 user-defined tag scheme, the provider MUST NOT include a prefix in Tag keys.
+* When a provider has only 1 user-defined tag scheme, the provider MUST NOT include a prefix in tag keys.
 * When a provider has 2 or more user-defined tag schemes, the provider MUST prefix all but 1 user-defined tag scheme with a predetermined, provider-specified tag key prefix that is unique to each corresponding user-defined tag scheme.
 
 Provider-defined tags additionally adhere to the following requirements:

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -39,7 +39,6 @@ The last two tags illustrate examples from two different, provider-defined tag s
         "userDefinedTagScheme3/foo": true,
         "providerDefinedTagScheme1/foo": "bar",
         "providerDefinedTagScheme2/foo": "bar"
-        "baz": true,
     }
 ```
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -14,7 +14,7 @@ The Tags column adheres to the following requirements:
 * A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * Providers MUST NOT alter tag values unless applying true (boolean) to valueless tags
-* If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
+* If tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT allow reserved tag key prefixes to be used as prefixes for any user-defined tag keys within a prefixless, user-defined tag scheme.  
 * Providers SHOULD publish all provider-specified tag key prefixes within their respective documentation.
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -14,7 +14,7 @@ The Tags column adheres to the following requirements:
 * A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
-* Providers MUST NOT alter user-defined Tag keys or values.
+* Providers with two or more user-defined tag schemes MUST ensure that all but one user-defined tag scheme are uniquely identified by a provider-defined prefix, allowing one scheme to remain unprefixed at their discretion.
 
 Provider-defined Tags additionally adhere to the following requirements:
 
@@ -23,12 +23,13 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-This example illustrates three different tagging scenarios. The first two illustrate when the provider supports both keys and values, while the third is for supporting keys only. The first tag is user-defined and doesn't have a provider prefix. The second tag is provider-defined and has a prefix of `acme/`, which is reserved by the provider. The third tag has a tag key of `baz` and its value is assigned the boolean value `true` since the tag doesn't support a value.
+This example illustrates four different tagging scenarios. The first three illustrate when the provider supports both keys and values, while the third is for supporting keys only. The first tag is user-defined and doesn't have a provider prefix. The second and third tags are provider-defined and have prefixes of `scheme2/` & `scheme3/` which are reserved by the provider. The fourth tag has a tag key of `baz` and its value is assigned the boolean value `true` since the tag doesn't support a value.
 
 ```json
     {
         "foo": "bar",
-        "acme/foo": "bar",
+        "scheme2/foo": "bar",
+        "scheme3/foo": "baz",
         "baz": true,
     }
 ```

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -7,7 +7,7 @@ A tag becomes [*finalized*](#glossary:finalized-tag) when a single value is sele
 The Tags column adheres to the following requirements:
 
 * Tags MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports setting user or provider-defined tags.
-* Tags MUST contain user-defined and provider-defined tags.
+* Tags MUST contain all user-defined and provider-defined tags.
 * Tags MUST only contain finalized tags.
 * Tags MUST be in [KeyValueFormat](#key-valueformat).
 * A Tag key with a non-null value for a given resource SHOULD be included in the tags column.

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -15,7 +15,7 @@ The Tags column adheres to the following requirements:
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * Providers MUST NOT alter Tag values unless applying true (boolean) to valueless tags
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
-* Providers SHOULD publish all provider-specified tag key prefixes within their respective documentation.
+* Providers SHOULD publish all provider-specified, reserved tag key prefixes within their respective documentation.
 
 User-defined tags additionally adhere to the following requirements:
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -20,7 +20,7 @@ The Tags column adheres to the following requirements:
 
 User-defined tags additionally adhere to the following requirements:
 
-* When a provider has only 1 user-defined tag scheme, the provider MUST NOT alter any user-defined Tag keys.
+* When a provider has only 1 user-defined tag scheme, the provider MUST NOT include a prefix in Tag keys.
 * When a provider has 2 or more user-defined tag schemes, the provider MUST prefix all but 1 user-defined tag scheme with a predetermined, provider-specified tag key prefix that is unique to each corresponding user-defined tag scheme.
 
 Provider-defined tags additionally adhere to the following requirements:

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -14,7 +14,7 @@ The Tags column adheres to the following requirements:
 * A Tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
-* Providers MUST NOT alter user-defined Tag values
+* Providers MUST NOT alter Tag values unless applying true (boolean) to valueless tags
 
 User-defined Tags additionally adhere to the following requirements:
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -21,7 +21,7 @@ The Tags column adheres to the following requirements:
 User-defined tags additionally adhere to the following requirements:
 
 * When a provider has only 1 user-defined tag scheme, the provider MUST NOT alter any user-defined Tag keys.
-* When a provider has 2 or more user-defined tag schemes, the provider MUST alter all but 1 user-defined tag scheme with a predetermined, provider-specified tag key prefix that is unique to each corresponding user-defined tag scheme.
+* When a provider has 2 or more user-defined tag schemes, the provider MUST prefix all but 1 user-defined tag scheme with a predetermined, provider-specified tag key prefix that is unique to each corresponding user-defined tag scheme.
 
 Provider-defined tags additionally adhere to the following requirements:
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -28,7 +28,7 @@ Provider-defined Tags additionally adhere to the following requirements:
 
 ## Provider-Defined vs. User-Defined Tags
 
-This example illustrates various tags produced from multiple user-defined and provider-defined tag schemes.  The first three tags illustrate examples from three different, user-defined tag schemes, and the provider has predetermined that 1 user-defined tag scheme (i.e. `"foo": "bar"`) does not have a prepended prefix, but the two (i.e. `"userDefinedTagScheme2/foo": "bar"`, `"userDefinedTagScheme3/foo": true`) have predetermined and reserved prefixes.  Additionally, the third tag was produced from a valueless, user-defined tag scheme, so the provider provides `true` as its default value.
+This example illustrates various tags produced from multiple user-defined and provider-defined tag schemes.  The first three tags illustrate examples from three different, user-defined tag schemes. The provider predetermined that 1 user-defined tag scheme (i.e. `"foo": "bar"`) does not have a prepended prefix, but the remaining two user-defined tag schemes (i.e. `"userDefinedTagScheme2/foo": "bar"`, `"userDefinedTagScheme3/foo": true`) do have predefined and reserved prefixes specified by the provider.  Additionally, the third tag was produced from a valueless, user-defined tag scheme, so the provider also applies `true` as its default value.
 
 The last two tags illustrate examples from two different, provider-defined tag schemes, and since all provider-defined tag schemes require a prefix, the provider has prepended prefixes (`providerDefinedTagScheme1/`, `providerDefinedTagScheme2/`) to each tag.
 

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -13,7 +13,7 @@ The Tags column adheres to the following requirements:
 * A tag key with a non-null value for a given resource SHOULD be included in the tags column.
 * A tag key with a null value for a given resource MAY be included in the tags column depending on the provider's tag finalization process.
 * A tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
-* Providers MUST NOT alter tag values unless applying true (boolean) to valueless tags
+* Providers MUST NOT alter tag values unless applying true (boolean) to valueless tags.
 * If tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
 * Providers MUST NOT allow reserved tag key prefixes to be used as prefixes for any user-defined tag keys within a prefixless, user-defined tag scheme.  
 * Providers SHOULD publish all provider-specified tag key prefixes within their respective documentation.

--- a/specification/columns/tags.md
+++ b/specification/columns/tags.md
@@ -15,7 +15,8 @@ The Tags column adheres to the following requirements:
 * A Tag key that does *not* support a corresponding value, MUST have a corresponding true (boolean) value set.
 * Providers MUST NOT alter Tag values unless applying true (boolean) to valueless tags
 * If Tag finalization is supported, providers MUST publish tag finalization methods and semantics within their respective documentation.
-* Providers SHOULD publish all provider-specified, reserved tag key prefixes within their respective documentation.
+* Providers MUST NOT allow reserved tag key prefixes to be used as prefixes for any user-defined tag keys within a prefixless, user-defined tag scheme.  
+* Providers SHOULD publish all provider-specified tag key prefixes within their respective documentation.
 
 User-defined tags additionally adhere to the following requirements:
 


### PR DESCRIPTION
This change address [Issue #540](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/540) and encapsulates the updates to multiple tag schemes in the documentation, decided by a previous survey among the FinOps community.

<img width="1551" alt="image" src="https://github.com/user-attachments/assets/b052bfab-f6c6-4437-9265-55df308095d8" />
