### PR TITLE
WI #534: Add Commitment Discount Unit Price and Cost columns

### DIFF
--- a/specification/appendix/commitment_discounts.md
+++ b/specification/appendix/commitment_discounts.md
@@ -21,7 +21,7 @@ For example, if a customer buys a 1-year, spend-based *commitment discount* with
 
 ## Usage
 
-Commitment discounts follow a "use-it-or-lose-it" model where the [*amortization*](#glossary:amortization) of a *commitment discount's* purchase applies evenly to eligible *resources* over each [*charge period*](#glossary:charge-period) of the *term*.
+Commitment discounts follow a "use-it-or-lose-it" model where the [*amortization*](#glossary:amortization) of a *commitment discount's* purchase applies evenly to eligible *resources* over each [*charge period*](#glossary:chargeperiod) of the *term*.
 
 For example, if a customer buys a spend-based *commitment discount* with a &dollar;1.00 hourly commit in January (31 days), only &dollar;1.00 is eligible for consumption for each hourly *charge period*. If a customer has eligible *resources* running during this *charge period*, an amount of up to &dollar;1.00 will be allocated to these *resources*. Conversely, if a customer does have eligible *resources* running that fully take advantage of this &dollar;1.00 during this *charge period*, then some or all of this amount will go to waste.
 

--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -19,12 +19,14 @@ The FOCUS specification defines a group of columns that provide qualitative valu
 !INCLUDE "chargeperiodend.md",1
 !INCLUDE "chargeperiodstart.md",1
 !INCLUDE "commitmentdiscountcategory.md",1
+!INCLUDE "commitmentdiscountcost.md",1
 !INCLUDE "commitmentdiscountid.md",1
 !INCLUDE "commitmentdiscountname.md",1
 !INCLUDE "commitmentdiscountquantity.md",1
 !INCLUDE "commitmentdiscountstatus.md",1
 !INCLUDE "commitmentdiscounttype.md",1
 !INCLUDE "commitmentdiscountunit.md",1
+!INCLUDE "commitmentdiscountunitprice.md",1
 !INCLUDE "consumedquantity.md",1
 !INCLUDE "consumedunit.md",1
 !INCLUDE "contractedcost.md",1

--- a/specification/columns/commitmentdiscountcost.md
+++ b/specification/columns/commitmentdiscountcost.md
@@ -1,6 +1,6 @@
 # Commitment Discount Cost
 
-Commitment Discount Cost represents the cost calculated by multiplying the [Commitment Discount Unit Price](#glossary:commitmentdiscountunitprice) and the corresponding [Pricing Quantity](#pricingquantity). Commitment Discount Cost is denominated in the [Billing Currency](#billingcurrency) and is commonly used to calculate savings incurred by [*commitment discounts*](#commitment-discount).
+Commitment Discount Cost represents the cost calculated by multiplying the [Commitment Discount Unit Price](#glossary:commitmentdiscountunitprice) and the corresponding [Pricing Quantity](#pricingquantity) inclusive of any [*negotiated discounts*](#glossary:negotated-discount) that may apply. Commitment Discount Cost is denominated in the [Billing Currency](#billingcurrency) and is commonly used to calculate savings incurred by [*commitment discounts*](#commitment-discount).
 
 The CommitmentDiscountCost column adheres to the following requirements:
 
@@ -10,20 +10,16 @@ The CommitmentDiscountCost column adheres to the following requirements:
 * CommitmentDiscountCost MUST be denominated in the *BillingCurrency*.
 * CommitmentDiscountCost MUST be present when [*CommitmentDiscountId*](#glossary:commitmentdiscountid) is present.
 * CommitmentDiscountCost MUST equal [*PricingQuantity*](#pricingquantity) * ([*CommitmentDiscountUnitPrice*](#commitmentdiscountunitprice) - ([*ListUnitPrice*](#listunitprice) - [*ContractedUnitPrice*](#contractedunitprice))).
+* CommitmentDiscountCost MUST equal the [*covering cost*](#glossary:coveringcost) for all [*rows*](#glossary:row) of the same [*charge period*](#glossary:chargeperiod) and [*CommitmentDiscountID*](#commitmentdiscountid) before any applicable [*negotiated discounts*](#glossary:negotiateddiscount) when [*ChargeCategory*](#chargecategory) is "Usage", [*PricingCategory*](#pricingcategory) is "Committed", and [*ChargeClass*](#chargeclass) is not "Correction".
+* CommitmentDiscountCost MAY equal the *covering cost* before any applicable *negotiated discounts* when [*ChargeCategory*](#chargecategory) is "Purchase", depending on the payment schedule of the *commitment discount*.
 * [*BilledCost*](#billedcost) MUST equal CommitmentDiscountCost when [*ChargeCategory*](#chargecategory) is "Purchase" and *ChargeClass* is not "Correction".
 * [*EffectiveCost*](#billedcost) MUST equal CommitmentDiscountCost when *ChargeCategory* is "Usage" and *ChargeClass* is not "Correction".
 * CommitmentDiscountCost MAY be null or any valid decimal value if *ChargeClass* is "Correction".
 
-When [*CommitmentDiscountCategory*](#commitmentdiscountcategory) is "Spend" and *ChargeClass* is not "Correction", the following applies:
+When a provider supports [*commitment discount flexibility*](glossary:commitment-discount-flexibility) for a [*CommitmentDiscountType*](#commitmentdiscounttype) and *ChargeClass* is not "Correction", the following applies:
 
-* When [*ChargeCategory*](#chargecategory)] is "Purchase", CommitmentDiscountCost MUST be the predefined amount of spend committed for each [*charge period*](glossary:chargeperiod) of the *commitment discount's* [*term*].
-* When *ChargeCategory* is "Usage", CommitmentDiscountUnitPrice MUST be the [*effective unit price*](glossary:effective-unit-price) of the covering resource's SKU.
-
-When *CommitmentDiscountCategory* is "Usage" and *ChargeClass* is not "Correction", the following applies:
-
-* CommitmentDiscountUnitPrice MUST be the *effective unit price* of the preselected SKU.
-* When [*commitment discount flexibility*](glossary:commitment-discount-flexibility) applies, the CommitmentDiscountCost of the covering resource's SKU MAY be calculated from a different *CommitmentDiscountUnitPrice* than the purchasing SKU.
-* When *commitment discount flexibility* does not apply, the CommitmentDiscountCost of the covering resource's SKU MUST be calculated from the same *CommitmentDiscountUnitPrice* as the purchasing SKU.
+* When *commitment discount flexibility* applies, the CommitmentDiscountCost of the covering resource's [*SkuId*](#skuid) MAY be calculated from a different *CommitmentDiscountUnitPrice* than the purchasing *SkuId*.
+* When *commitment discount flexibility* does not apply, the CommitmentDiscountCost of the covering resource's *SkuId* MUST be calculated from the same *CommitmentDiscountUnitPrice* as the purchasing *SkuId*.
 
 ## Column ID
 
@@ -35,7 +31,7 @@ Commitment Discount Cost
 
 ## Description
 
-Cost calculated by multiplying Commitment Discount Unit Price and the corresponding Pricing Quantity.
+Cost calculated by multiplying Commitment Discount Unit Price and the corresponding Pricing Quantity inclusive of any *negotiated discounts* that may apply.
 
 ## Usability Constraints
 

--- a/specification/columns/commitmentdiscountcost.md
+++ b/specification/columns/commitmentdiscountcost.md
@@ -1,0 +1,57 @@
+# Commitment Discount Cost
+
+Commitment Discount Cost represents the cost calculated by multiplying the [Commitment Discount Unit Price](#glossary:commitmentdiscountunitprice) and the corresponding [Pricing Quantity](#pricingquantity). Commitment Discount Cost is denominated in the [Billing Currency](#billingcurrency) and is commonly used to calculate savings incurred by [*commitment discounts*](#commitment-discount).
+
+The CommitmentDiscountCost column adheres to the following requirements:
+
+* CommitmentDiscountCost MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports *commitment discounts*.
+* CommitmentDiscountCost MUST be of type Decimal.
+* CommitmentDiscountCost MUST conform to [Numeric Format](#numericformat) requirements.
+* CommitmentDiscountCost MUST be denominated in the *BillingCurrency*.
+* CommitmentDiscountCost MUST be present when [*CommitmentDiscountId*](#glossary:commitmentdiscountid) is present.
+* CommitmentDiscountCost MUST equal [*PricingQuantity*](#pricingquantity) * ([*CommitmentDiscountUnitPrice*](#commitmentdiscountunitprice) - ([*ListUnitPrice*](#listunitprice) - [*ContractedUnitPrice*](#contractedunitprice))).
+* [*BilledCost*](#billedcost) MUST equal CommitmentDiscountCost when [*ChargeCategory*](#chargecategory) is "Purchase" and *ChargeClass* is not "Correction".
+* [*EffectiveCost*](#billedcost) MUST equal CommitmentDiscountCost when *ChargeCategory* is "Usage" and *ChargeClass* is not "Correction".
+* CommitmentDiscountCost MAY be null or any valid decimal value if *ChargeClass* is "Correction".
+
+When [*CommitmentDiscountCategory*](#commitmentdiscountcategory) is "Spend" and *ChargeClass* is not "Correction", the following applies:
+
+* When [*ChargeCategory*](#chargecategory)] is "Purchase", CommitmentDiscountCost MUST be the predefined amount of spend committed for each [*charge period*](glossary:chargeperiod) of the *commitment discount's* [*term*].
+* When *ChargeCategory* is "Usage", CommitmentDiscountUnitPrice MUST be the [*effective unit price*](glossary:effective-unit-price) of the covering resource's SKU.
+
+When *CommitmentDiscountCategory* is "Usage" and *ChargeClass* is not "Correction", the following applies:
+
+* CommitmentDiscountUnitPrice MUST be the *effective unit price* of the preselected SKU.
+* When [*commitment discount flexibility*](glossary:commitment-discount-flexibility) applies, the CommitmentDiscountCost of the covering resource's SKU MAY be calculated from a different *CommitmentDiscountUnitPrice* than the purchasing SKU.
+* When *commitment discount flexibility* does not apply, the CommitmentDiscountCost of the covering resource's SKU MUST be calculated from the same *CommitmentDiscountUnitPrice* as the purchasing SKU.
+
+## Column ID
+
+CommitmentDiscountCost
+
+## Display Name
+
+Commitment Discount Cost
+
+## Description
+
+Cost calculated by multiplying Commitment Discount Unit Price and the corresponding Pricing Quantity.
+
+## Usability Constraints
+
+**Aggregation:** When aggregating Commitment Discount Cost for savings calculations, it's important to exclude *commitment discount* purchases (i.e. when *ChargeCategory* is "Purchase") that are paid to cover future eligible charges (e.g., *commitment discount*). Otherwise, when accounting for all upfront or accrued purchases, it's important to exclude *commitment discount* usage (i.e. when *ChargeCategory* is "Usage"). This exclusion helps prevent double counting of these quantities in the aggregation.
+
+## Content Constraints
+
+| Constraint      | Value            |
+|:----------------|:-----------------|
+| Column type     | Metric           |
+| Feature level   | Conditional      |
+| Allows nulls    | True             |
+| Data type       | Decimal          |
+| Value format    | [Numeric Format](#numericformat) |
+| Number range    | Any valid decimal value |
+
+## Introduced (version)
+
+1.2

--- a/specification/columns/commitmentdiscountunitprice.md
+++ b/specification/columns/commitmentdiscountunitprice.md
@@ -1,0 +1,55 @@
+# Commitment Discount Unit Price
+
+Commitment Discount Unit Price represents the [*effective unit price*](#glossary:effectiveunitprice) for a single [Pricing Unit](#pricingunit) of the associated [*commitment discount's*](#glossary:commitmentdiscount) purchase or utilizing resource's SKU, exclusive of any [*negotiated discounts*](#negotiated-discount]). This price is denominated in the [Billing Currency](#billingcurrency) and is commonly used to calculate the discounted cost of a purchase or resource utilizing the *commitment discount*.
+
+The CommitmentDiscountUnitPrice column adheres to the following requirements:
+
+* CommitmentDiscountUnitPrice MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports *commitment discounts*.
+* CommitmentDiscountUnitPrice MUST be a Decimal within the range of non-negative decimal values.
+* CommitmentDiscountUnitPrice MUST conform to [Numeric Format](#numericformat) requirements.
+* CommitmentDiscountUnitPrice MUST be denominated in the [*BillingCurrency*](#billingcurrency).
+* CommitmentDiscountUnitPrice MUST be present when [*CommitmentDiscountId*](#commitmentdiscountid) is present.
+* CommitmentDiscountUnitPrice MUST NOT include [*negotiated discounts*](#glossary:negotiated-discount)
+* CommitmentDiscountUnitPrice MAY be null or any valid decimal value if [*ChargeClass*](#chargeclass) is "Correction".
+
+When [*CommitmentDiscountCategory*](#commitmentdiscountcategory) is "Spend" and *ChargeClass* is not "Correction", the following applies:
+
+* When [*ChargeCategory*](#chargecategory) is "Purchase", CommitmentDiscountUnitPrice MUST be the predefined amount of spend committed for each [*charge period*](glossary:chargeperiod) of the *commitment discount's* [*term*](glossary:term).
+* When *ChargeCategory* is "Usage", CommitmentDiscountUnitPrice MUST be the *effective unit price* of the covering resource's SKU.
+
+When *CommitmentDiscountCategory* is "Usage" and *ChargeClass* is not "Correction", the following applies:
+
+* CommitmentDiscountUnitPrice MUST be the *effective unit price* for the preselected SKU.
+* When *commitment discount flexibility* applies, the CommitmentDiscountUnitPrice of the covering resource's SKU MAY be different than the purchasing SKU.
+* When [*commitment discount flexibility*](glossary:commitment-discount-flexibility) does not apply, the CommitmentDiscountUnitPrice of the covering resource's SKU MUST match the purchasing SKU.
+
+## Column ID
+
+CommitmentDiscountUnitPrice
+
+## Display Name
+
+Commitment Discount Unit Price
+
+## Description
+
+The *effective unit price* for a single Pricing Unit of the associated *commitment discount's* purchase or covering resource's SKU, exclusive of any *negotiated discounts*.
+
+## Usability Constraints
+
+**Aggregation:** Column values should only be viewed in the context of their row and not aggregated to produce a total.
+
+## Content Constraints
+
+| Constraint      | Value                                |
+|:----------------|:-------------------------------------|
+| Column type     | Metric                               |
+| Feature level   | Conditional                          |
+| Allows nulls    | True                                 |
+| Data type       | Decimal                              |
+| Value format    | [Numeric Format](#numericformat)     |
+| Number range    | Any valid non-negative decimal value |
+
+## Introduced (version)
+
+1.2

--- a/specification/columns/commitmentdiscountunitprice.md
+++ b/specification/columns/commitmentdiscountunitprice.md
@@ -1,6 +1,6 @@
 # Commitment Discount Unit Price
 
-Commitment Discount Unit Price represents the [*effective unit price*](#glossary:effectiveunitprice) for a single [Pricing Unit](#pricingunit) of the associated [*commitment discount's*](#glossary:commitmentdiscount) purchase or utilizing resource's SKU, exclusive of any [*negotiated discounts*](#negotiated-discount]). This price is denominated in the [Billing Currency](#billingcurrency) and is commonly used to calculate the discounted cost of a purchase or resource utilizing the *commitment discount*.
+Commitment Discount Unit Price represents the [*covering cost*](#glossary:coveringcost) of the associated [*commitment discount's*](#glossary:commitmentdiscount) purchase or discounted unit price of a utilizing resource's [Sku Id](#skuid) before any applicable [*negotiated discounts*](#negotiated-discount]). This price is denominated in the [Billing Currency](#billingcurrency) and is commonly used to calculate the discounted cost of a purchase or resource utilizing the *commitment discount*.
 
 The CommitmentDiscountUnitPrice column adheres to the following requirements:
 
@@ -9,19 +9,19 @@ The CommitmentDiscountUnitPrice column adheres to the following requirements:
 * CommitmentDiscountUnitPrice MUST conform to [Numeric Format](#numericformat) requirements.
 * CommitmentDiscountUnitPrice MUST be denominated in the [*BillingCurrency*](#billingcurrency).
 * CommitmentDiscountUnitPrice MUST be present when [*CommitmentDiscountId*](#commitmentdiscountid) is present.
-* CommitmentDiscountUnitPrice MUST NOT include [*negotiated discounts*](#glossary:negotiated-discount)
+* CommitmentDiscountUnitPrice MUST NOT include *negotiated discounts*
 * CommitmentDiscountUnitPrice MAY be null or any valid decimal value if [*ChargeClass*](#chargeclass) is "Correction".
 
-When [*CommitmentDiscountCategory*](#commitmentdiscountcategory) is "Spend" and *ChargeClass* is not "Correction", the following applies:
+When [*CommitmentDiscountCategory*](#commitmentdiscountcategory) is "Spend", *ChargeClass* is not "Correction", and before any applicable *negotiated discounts*, the following applies:
 
-* When [*ChargeCategory*](#chargecategory) is "Purchase", CommitmentDiscountUnitPrice MUST be the predefined amount of spend committed for each [*charge period*](glossary:chargeperiod) of the *commitment discount's* [*term*](glossary:term).
-* When *ChargeCategory* is "Usage", CommitmentDiscountUnitPrice MUST be the *effective unit price* of the covering resource's SKU.
+* When [*ChargeCategory*](#chargecategory) is "Purchase", CommitmentDiscountUnitPrice MUST equal the *covering cost* associated with the *commitment discount*.
+* When *ChargeCategory* is "Usage", [*CommitmentDiscountCost*](#commitmentdiscountcost) across all [*rows*](#glossary:row) of the same [*charge period*](#glossary:chargeperiod) and [*CommitmentDiscountId*](#commitmentdiscountid) MUST equal the *covering cost* associated with the *commitment discount*.
 
-When *CommitmentDiscountCategory* is "Usage" and *ChargeClass* is not "Correction", the following applies:
+When *CommitmentDiscountCategory* is "Usage", *ChargeClass* is not "Correction", and before any applicable *negotiated discounts*, the following applies:
 
-* CommitmentDiscountUnitPrice MUST be the *effective unit price* for the preselected SKU.
-* When *commitment discount flexibility* applies, the CommitmentDiscountUnitPrice of the covering resource's SKU MAY be different than the purchasing SKU.
-* When [*commitment discount flexibility*](glossary:commitment-discount-flexibility) does not apply, the CommitmentDiscountUnitPrice of the covering resource's SKU MUST match the purchasing SKU.
+* CommitmentDiscountUnitPrice MUST equal the *covering cost* of the preselected [*SkuId*](#skuid).
+* When *commitment discount flexibility* applies, the CommitmentDiscountUnitPrice of the covering resource's *SkuId* MAY be different than the purchasing *SkuId*.
+* When [*commitment discount flexibility*](glossary:commitment-discount-flexibility) does not apply, the CommitmentDiscountUnitPrice of the covering resource's *SkuId* MUST match the purchasing *SkuId*.
 
 ## Column ID
 
@@ -33,7 +33,7 @@ Commitment Discount Unit Price
 
 ## Description
 
-The *effective unit price* for a single Pricing Unit of the associated *commitment discount's* purchase or covering resource's SKU, exclusive of any *negotiated discounts*.
+The *covering cost* of the associated *commitment discount's* purchase or discounted unit price of a utilizing resource's *SkuId* before any *negotiated discounts* are applied.
 
 ## Usability Constraints
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -68,6 +68,10 @@ The agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the asso
 
 A specification-defined categorical attribute that provides context or categorization to billing data.
 
+<a name="glossary:effective-unit-price">Effective Unit Price</a>
+
+The discounted rate or predefined amount of spend associated with a [*commitment discount*](#glossary:commitment-discount) and derived as the committed purchase amount divided by the number of [*charge periods*](glossary:chargeperiod) within its [*term*](glossary:term).
+
 <a name="glossary:effective-cost"><b>Effective Cost</b></a>
 
 The amortized cost of the charge after applying all reduced rates, discounts, and the applicable portion of relevant, prepaid purchases (one-time or recurring) that covered this charge.

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -64,13 +64,13 @@ A feature of [*commitment discounts*](#glossary:commitment-discount) that may fu
 
 The agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, inclusive of negotiated discounts, if present, and exclusive of any other discounts. This price is denominated in the [Billing Currency](#glossary:billingcurrency).
 
+<a name="glossary:covering-cost">Covering Cost</a>
+
+The amount of spend applied to each [*charge period*] derived as the total committed purchase amount divided by the number of [*charge periods*](glossary:chargeperiod) within a [*commitment discount's*](#glossary:commitment-discount) [*term*](#glossary:term).
+
 <a name="glossary:dimension"><b>Dimension</b></a>
 
 A specification-defined categorical attribute that provides context or categorization to billing data.
-
-<a name="glossary:effective-unit-price">Effective Unit Price</a>
-
-The discounted rate or predefined amount of spend associated with a [*commitment discount*](#glossary:commitment-discount) and derived as the committed purchase amount divided by the number of [*charge periods*](glossary:chargeperiod) within its [*term*](glossary:term).
 
 <a name="glossary:effective-cost"><b>Effective Cost</b></a>
 


### PR DESCRIPTION
Authored by @qquigley and @cnharris10.

This pull request proposes adding columns, `CommitmentDiscountUnitPrice` and `CommitmentDiscountCost`, to help practitioners better understand the breakdown of pre/post-negotiated, discounted rates/costs and to use this information to better forecast future cost and usage trends.

Example `CommitmentDiscountUnitPrice` and `CommitmentDiscountCost` data can be found [here](https://docs.google.com/spreadsheets/d/1AYDPZ4rl90PPEbyQJUaGCUSwZ4s_sfy-8sO2KyNq0aM/edit?pli=1&gid=1712247049#gid=1712247049).

<img width="747" alt="image" src="https://github.com/user-attachments/assets/e47a9fab-62da-4de7-a88d-f74b8e20c09b" />
