### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @FinOps-Open-Cost-and-Usage-Spec/maintainer
+*       @FinOps-Open-Cost-and-Usage-Spec/admins


### PR DESCRIPTION
The CODEOWNERS file must be changed, now that we have renamed the Maintainer team to Admins.

For more information on codeowners, please see [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).