### PR TITLE
WI #643: Add supported feature for resource usage

### DIFF
--- a/specification/supported_features/resource_usage.md
+++ b/specification/supported_features/resource_usage.md
@@ -4,21 +4,20 @@
 1.0
 
 ## Description
-FOCUS enables tracking of resource consumption through billing data. By recording what resources were used, in what quantities, and with what units of measure, practitioners can identify anomalies in usage patterns and optimize workloads.
+FOCUS enables tracking of resource consumption by providing information about which resources were used, in what quantities, and with what units of measure.
 
 ## Directly Dependent Columns
+* ConsumedQuantity
+* ConsumedUnit
+* ResourceId
+* SkuId
+
+## Supporting Columns
 * ChargeCategory
 * ChargePeriodEnd
 * ChargePeriodStart
-* ConsumedQuantity
-* ConsumedUnit
 * ProviderName
-* ResourceId
 * ServiceName
-* SkuId
-
-## Indirectly Dependent Columns
-
 
 ## Example SQL Query
 ```

--- a/specification/supported_features/resource_usage.md
+++ b/specification/supported_features/resource_usage.md
@@ -1,0 +1,41 @@
+# Resource Usage
+
+## Introduced Version
+1.0
+
+## Description
+FOCUS standardizes tracking of cloud resource consumption through billing data. By recording what resources were used, in what quantities, and with what units of measure, practitioners can detect anomalies in usage patterns and optimize workloads.
+
+## Directly Dependent Columns
+* ChargeCategory
+* ChargePeriodEnd
+* ChargePeriodStart
+* ConsumedQuantity
+* ConsumedUnit
+* ProviderName
+* ResourceId
+* ServiceName
+* SkuId
+
+## Indirectly Dependent Columns
+
+
+## Example SQL Query
+```
+SELECT
+  ProviderName,
+  ServiceName,
+  ResourceId,
+  SkuId,
+  ConsumedUnit,
+  SUM(ConsumedQuantity) AS TotalQuantity
+FROM focus_data_table
+WHERE ChargeCategory='Usage'
+  AND ChargePeriodStart >= ? AND ChargePeriodEnd <= ?
+GROUP BY
+  ProviderName,
+  ServiceName,
+  ResourceId,
+  SkuId,
+  ConsumedUnit
+``` 

--- a/specification/supported_features/resource_usage.md
+++ b/specification/supported_features/resource_usage.md
@@ -4,7 +4,7 @@
 1.0
 
 ## Description
-FOCUS standardizes tracking of cloud resource consumption through billing data. By recording what resources were used, in what quantities, and with what units of measure, practitioners can detect anomalies in usage patterns and optimize workloads.
+FOCUS enables tracking of resource consumption through billing data. By recording what resources were used, in what quantities, and with what units of measure, practitioners can identify anomalies in usage patterns and optimize workloads.
 
 ## Directly Dependent Columns
 * ChargeCategory

--- a/specification/supported_features/supported_features.mdpp
+++ b/specification/supported_features/supported_features.mdpp
@@ -6,4 +6,5 @@ The FOCUS specification is designed to meet the needs of FinOps practitioners in
 !INCLUDE "invoice_cost_and_time_period.md",1
 !INCLUDE "compare_billed_cost_per_subaccount_to_budget.md",1
 !INCLUDE "compare_billed_and_effective_costs.md",1
+!INCLUDE "resource_usage.md",1
 


### PR DESCRIPTION
Related to #765 

@rileyjenk, I skipped adding the "Use Case ID" field as outlined in the [template](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/supported_feature_resource_usage/specification/supported_features/supported_feature_template.md?plain=1#L5) because I didn't see it being used in the other supported features that were already drafted.