### PR TITLE
[Maintenance] Updated GitHub actions to use Ubuntu 24.04 due to deprecation notice.

### DIFF
--- a/.github/workflows/candidate_release.yml
+++ b/.github/workflows/candidate_release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # The job that will use the container image you just pushed to ghcr.io
   gen_pdf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: pandoc/extra:latest-ubuntu
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # The job that will use the container image you just pushed to ghcr.io
   gen_pdf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: pandoc/extra:latest-ubuntu
     steps:

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # The job that will use the container image you just pushed to ghcr.io
   gen_pdf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: pandoc/extra:latest-ubuntu
     steps:


### PR DESCRIPTION
Tested on a repository fork. Build process appears to work fine with Ubuntu 24.04. Pushing this fix to move all branches to use Ubuntu 24.04 instead of the current 20.04 which is nearing EOL.