### PR TITLE
WI #619: `SKU Size` (previously part of #683)

### DIFF
--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -51,6 +51,7 @@ The FOCUS specification defines a group of columns that provide qualitative valu
 !INCLUDE "skumeter.md",1
 !INCLUDE "skupricedetails.md",1
 !INCLUDE "skupriceid.md",1
+!INCLUDE "skusize.md",1
 !INCLUDE "subaccountid.md",1
 !INCLUDE "subaccountname.md",1
 !INCLUDE "subaccounttype.md",1

--- a/specification/columns/skusize.md
+++ b/specification/columns/skusize.md
@@ -1,0 +1,38 @@
+# SKU Size
+
+The SKU Size column represents the common name for the size and shape of the [*SKU*](#glossary:SKU), where applicable.
+
+It is oftentimes the case that a SKU has a common name to refer to its size and shape. This size may be common across multiple [SKU IDs](#skuid) and [SKU Price IDs](#skupriceid), which are differentiated based on properties other than their size (e.g. [Region Name](#regionname), [Pricing Category](#pricingcategory), etc.). The SKU Size column provides a way to group and aggregate cost and usage data across like sizes.
+
+The SkuSize column adheres to the following requirements:
+
+* The SkuSize column is RECOMMENDED be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset).
+* This column MUST be of type String and MAY contain null values.
+* SkuSize values SHOULD follow a common convention used by the provider and SHOULD be consistent across SkuId and SkuPriceId records of the same size and shape.
+* SkuSize MUST contain null values when SkuId is null or is not associated with a named size.
+
+## Column ID
+
+SkuSize
+
+## Display Name
+
+SKU Size
+
+## Description
+
+A common name for the size and shape of the SKU, where applicable.
+
+## Content Constraints
+
+| Constraint      | Value            |
+| :-------------- | :--------------- |
+| Column type     | Dimension        |
+| Feature level   | Recommended      |
+| Allows nulls    | True             |
+| Data type       | String           |
+| Value format    | \<not specified> |
+
+## Introduced (version)
+
+1.2

--- a/supporting_content/columns/skusize.md
+++ b/supporting_content/columns/skusize.md
@@ -1,0 +1,31 @@
+# Column: SKU Size
+
+## Example provider mappings
+
+Current column mappings found in available data sets:
+
+| Provider | Data set                   | Column |
+| -------- | -------------------------- | ------ |
+| AWS      | CUR                        |        |
+| Azure    | Cost details export or API |        |
+| GCP      | BigQuery Billing Export    |        |
+| OCI      | Cost Reports               |        |
+
+## Example scenarios for current provider data
+
+Current values observed in billing data for various scenarios:
+
+| Provider | Scenario                   | Pattern |
+| -------- | -------------------------- | ------- |
+| AWS      | CUR                        |         |
+| Azure    | Cost Details export or API |         |
+| GCP      | BigQuery Billing Export    |         |
+| OCI      | Cost Reports               |         |
+
+## Discussion / Scratch space
+
+Terms used by different providers:
+
+* Size (AWS EC2, Azure VMs)
+* Shape (OCI)
+* Edition (box products, like SQL Server)


### PR DESCRIPTION
In TF2 today, we agreed to split the new column definition for SkuSize from PR #683