### PR TITLE
AI #764 Adding commit usage and under usage supported feature

### DIFF
--- a/specification/supported_features/commit_usage_and_under_usage.md
+++ b/specification/supported_features/commit_usage_and_under_usage.md
@@ -1,0 +1,59 @@
+# Commit Usage and Under Usage
+
+## Introduced Version
+1.0
+
+## Description
+The FOCUS spec supports the tracking of committed use discounts usage and underusage, which can come in the form of commitment discounts, or capacity reservations. 
+
+## Directly Dependent Columns
+* Provider
+* BillingAccountID
+* CommitmentDiscountID / CapacityReservationID
+* CommitmentDiscountType / CapacityReservationType
+* CommitmentDiscountStatus / CapactityReservationStatus
+* ServiceCategory
+* BilledCost
+* EffectiveCost
+* ChargePeriodStart
+* ChargePeriodEnd
+
+## Supporting Columns
+
+## Example SQL Query for Commitment Discounts
+```SELECT
+  ProviderName,
+  BillingAccountId,
+  CommitmentDiscountId,
+  CommitmentDiscountType,
+  CommitmentDiscountStatus,
+  SUM(BilledCost) AS TotalBilledCost,
+  SUM(EffectiveCost) AS TotalEffectiveCost
+FROM focus_data_table
+WHERE ChargePeriodStart >= ? AND ChargePeriodEnd < ?
+  AND CommitmentDiscountStatus = 'Unused'
+GROUP BY
+  ProviderName,
+  BillingAccountId,
+  CommitmentDiscountId,
+  CommitmentDiscountType
+```
+
+## Example SQL Query for Capacity Reservations
+```
+SELECT
+  ProviderName,
+  BillingAccountId,
+  CapacityReservationId,
+  CapacityReservationStatus,
+  SUM(BilledCost) AS TotalBilledCost,
+  SUM(EffectiveCost) AS TotalEffectiveCost
+FROM focus_data_table
+WHERE ChargePeriodStart >= ? AND ChargePeriodEnd < ?
+  AND CapacityReservationStatus = 'Unused'
+GROUP BY
+  ProviderName,
+  BillingAccountId,
+  CapacityReservationId,
+  CapacityReservationStatus
+  ```

--- a/specification/supported_features/commit_usage_and_under_usage.md
+++ b/specification/supported_features/commit_usage_and_under_usage.md
@@ -7,18 +7,20 @@
 The FOCUS spec supports the tracking of committed use discounts usage and underusage, which can come in the form of commitment discounts, or capacity reservations. 
 
 ## Directly Dependent Columns
-* Provider
-* BillingAccountID
-* CommitmentDiscountID / CapacityReservationID
-* CommitmentDiscountType / CapacityReservationType
-* CommitmentDiscountStatus / CapactityReservationStatus
+* CommitmentDiscountID
+* CapacityReservationID
+* CommitmentDiscountType
+* CapacityReservationType
+* CommitmentDiscountStatus
+* CapactityReservationStatus
+
+
+## Supporting Columns
 * ServiceCategory
 * BilledCost
 * EffectiveCost
 * ChargePeriodStart
 * ChargePeriodEnd
-
-## Supporting Columns
 
 ## Example SQL Query for Commitment Discounts
 ```SELECT

--- a/specification/supported_features/supported_features.mdpp
+++ b/specification/supported_features/supported_features.mdpp
@@ -9,3 +9,4 @@ The FOCUS specification is designed to meet the needs of FinOps practitioners in
 !INCLUDE "resource_usage.md",1
 !INCLUDE "service_categorization.md",1
 !INCLUDE "location.md",1
+!INCLUDE "commit_usage_and_underusage.md",1


### PR DESCRIPTION
A few things I noticed:

- [ ] This supports analysis by ServiceCategory (Compute), but I don't include it in an example query. 
- [ ] I also had to include two different queries since commits are of two kinds in the spec. 
- [ ] I added "Supporting Columns", instead of "Indirectly dependent" columns, but I didn't add anything. 
- [ ] I'm not sure when this was introduced, which version - I guessed for the 1.0 spec. 
- [ ] Should we simplify the queries a bit?