### PR TITLE
WI #616: Addition of five columns related to `Pricing Currency`

### DIFF
--- a/specification/attributes/attributes.mdpp
+++ b/specification/attributes/attributes.mdpp
@@ -6,7 +6,7 @@ for data granularity, recency, frequency, etc. Requirements defined in attribute
 [FinOps capabilities][FODOFC] accurately using a standard set of instructions regardless of the origin of the data.
 
 !INCLUDE "column_naming_and_ordering.md",1
-!INCLUDE "currency_code_format.md",1
+!INCLUDE "currency_format.md",1
 !INCLUDE "datetime_format.md",1
 !INCLUDE "discount_handling.md",1
 !INCLUDE "key_value_format.md",1

--- a/specification/attributes/currency_format.md
+++ b/specification/attributes/currency_format.md
@@ -1,16 +1,21 @@
-# Currency Code Format
+# Currency Format
 
 Columns that contain currency information in cost data following a consistent format reduce friction for FinOps practitioners who consume the data for analysis, reporting, and other use cases.
+
+A currency may be one of the following currency types:
+
+* National currency (e.g. USD, EUR).
+* Virtual currency (e.g. tokens, credits).
 
 All columns capturing a currency value, defined in the FOCUS specification, MUST follow the requirements listed below. Custom currency-related columns SHOULD also follow the same formatting requirements.
 
 ## Attribute ID
 
-CurrencyCodeFormat
+CurrencyFormat
 
 ## Attribute Name
 
-Currency Code Format
+Currency Format
 
 ## Description
 
@@ -18,7 +23,8 @@ Formatting for currency columns appearing in a [*FOCUS dataset*](#glossary:FOCUS
 
 ## Requirements
 
-Currency-related columns MUST be represented as a three-letter alphabetic code as dictated in the governing document [ISO 4217:2015](https://www.iso.org/standard/64758.html).
+* Currency-related columns MUST conform to [String Handling](#stringhandling) requirements when [ChargeCategory] is not "Purchase" and the provider presents prices in a virtual currency (e.g. credits, tokens).
+* Currency-related columns MUST be represented as a three-letter alphabetic code as dictated in the governing document [ISO 4217:2015](https://www.iso.org/standard/64758.html) in all other cases.
 
 ## Exceptions
 

--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -35,6 +35,8 @@ The FOCUS specification defines a group of columns that provide qualitative valu
 !INCLUDE "listcost.md",1
 !INCLUDE "listunitprice.md",1
 !INCLUDE "pricingcategory.md",1
+!INCLUDE "pricingcurrency.md",1
+!INCLUDE "pricingtobillingexchangerate.md", 1
 !INCLUDE "pricingquantity.md",1
 !INCLUDE "pricingunit.md",1
 !INCLUDE "provider.md",1

--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -34,9 +34,12 @@ The FOCUS specification defines a group of columns that provide qualitative valu
 !INCLUDE "invoiceissuer.md",1
 !INCLUDE "listcost.md",1
 !INCLUDE "listunitprice.md",1
+!INCLUDE "pricedcost.md",1
 !INCLUDE "pricingcategory.md",1
 !INCLUDE "pricingcurrency.md",1
-!INCLUDE "pricingtobillingexchangerate.md", 1
+!INCLUDE "pricingcurrencycontractedunitprice.md",1
+!INCLUDE "pricingcurrencylistunitprice.md",1
+!INCLUDE "pricingtobillingexchangerate.md",1
 !INCLUDE "pricingquantity.md",1
 !INCLUDE "pricingunit.md",1
 !INCLUDE "provider.md",1

--- a/specification/columns/pricedcost.md
+++ b/specification/columns/pricedcost.md
@@ -1,0 +1,42 @@
+# Priced Cost
+
+The Priced Cost represents the cost of the [*charge*](#glossary:charge) after applying all reduced rates, discounts, and the applicable portion of relevant, prepaid purchases (one-time or recurring) that covered this charge, as denominated in [Pricing Currency](#pricingcurrency).  Priced Cost can be denominated in [Billing Currency](#billingcurrency) by multiplying by the [Pricing to Billing Exchange Rate](#pricingtobillingexchangerate).  This allows the practitioner to perform a conversion from either 1) a [*national currency*](#glossary:nationalcurrency) to a [*virtual currency*](#glossary:virtualcurrency) (e.g. tokens to USD), or 2) one national currency to another (e.g. EUR to USD).
+
+The PricedCost column adheres to the following requirements:
+
+* PricedCost presence in a [*FOCUS dataset*](#glossary:FOCUS-dataset) is defined as follows:
+  * PricedCost MUST be present in a FOCUS dataset when the provider presents prices in a virtual currency (e.g. credits, tokens).
+  * PricedCost MUST be present in a FOCUS dataset when the provider presents prices and bills in different national currencies (e.g. priced in USD and billed in EUR).
+  * PricedCost MAY be present in a FOCUS dataset in all other cases.
+* PricedCost MUST be of type Decimal.
+* PricedCost MUST conform to [NumericFormat](#numericformat) requirements.
+* PricedCost MUST NOT be null.
+* PricedCost MUST be a valid decimal value.
+* PricedCost MUST be denominated in the [PricingCurrency](#pricingcurrency).
+
+## Column ID
+
+PricedCost
+
+## Display Name
+
+Priced Cost
+
+## Description
+
+The cost of the [*charge*](#glossary:charge) as denominated in [Pricing Currency](#pricingcurrency),
+
+## Content Constraints
+
+|    Constraint   |      Value              |
+|:----------------|:------------------------|
+| Column type     | Metric                  |
+| Feature level   | Conditional             |
+| Allows nulls    | True                    |
+| Data type       | Decimal                 |
+| Value format    | [Numeric Format](#numericformat) |
+| Number range    | Any valid decimal value |
+
+## Introduced (version)
+
+1.2

--- a/specification/columns/pricingcurrency.md
+++ b/specification/columns/pricingcurrency.md
@@ -1,0 +1,42 @@
+# Pricing Currency
+
+[*Pricing Currency*](#glossary:pricing-currency) is a value that represents the denomination in which a charge for [*resources*](#glossary:resource) or [*services*](#glossary:service) was priced. Pricing Currency is commonly used in scenarios where costs need to be grouped or aggregated by some combination of the following currency types:
+
+* National currency (e.g. USD, EUR).
+* Virtual currency (e.g. tokens, credits).
+
+The PricingCurrency column adheres to the following requirements:
+
+* PricingCurrency presence in a [*FOCUS dataset*](#glossary:FOCUS-dataset) is defined as follows:
+  * PricingCurrency MUST be present in a FOCUS dataset when the provider presents prices in a virtual currency (e.g. credits, tokens).
+  * PricingCurrency MUST be present in a FOCUS dataset when the provider presents prices and bills in different fiat currencies (e.g. priced in USD and billed in EUR).
+  * PricingCurrency MAY be present in a FOCUS dataset in all other cases.
+* PricingCurrency MUST be of type String.
+* PricingCurrency MUST conform to [Currency Format](#currencyformat) requirements.
+* PricingCurrency MUST NOT be null.
+
+## Column ID
+
+PricingCurrency
+
+## Display Name
+
+Pricing Currency
+
+## Description
+
+Represents the unit of measure in which a charge was priced.
+
+## Content Constraints
+
+| Constraint      | Value                               |
+|:----------------|:------------------------------------|
+| Column type     | Dimension                           |
+| Feature level   | Conditional                         |
+| Allows nulls    | True                                |
+| Data type       | String                              |
+| Value format    | [Currency Format](#currencyformat) |
+
+## Introduced (version)
+
+1.2

--- a/specification/columns/pricingcurrencycontractedunitprice.md
+++ b/specification/columns/pricingcurrencycontractedunitprice.md
@@ -1,0 +1,53 @@
+# Pricing Currency Contracted Unit Price
+
+The Pricing Currency Contracted Unit Price represents the agreed-upon unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, inclusive of [*negotiated discounts*](#glossary:negotiated-discount), if present, while excluding negotiated [*commitment discounts*](#glossary:commitment-discount) or any other discounts. This price is denominated in the [Pricing Currency](#pricingcurrency). The Pricing Currency Contracted Unit Price is commonly used for calculating savings based on negotiation activities. If negotiated discounts are not applicable, the Pricing Currency Contracted Unit Price defaults to the [Pricing Currency List Unit Price](#pricingcurrencylistunitprice).
+
+The PricingCurrencyContractedUnitPrice column adheres to the following requirements:
+
+* PricingCurrencyContractedUnitPrice presence in a [*FOCUS dataset*](#glossary:FOCUS-dataset) is defined as follows:
+  * PricingCurrencyContractedUnitPrice MUST be present in a FOCUS dataset when the provider presents prices in a virtual currency (e.g. credits, tokens).
+  * PricingCurrencyContractedUnitPrice MUST be present in a FOCUS dataset when the provider presents prices and bills in different national currencies (e.g. priced in USD and billed in EUR).
+  * PricingCurrencyContractedUnitPrice MAY be present in a FOCUS dataset in all other cases.
+* PricingCurrencyContractedUnitPrice adheres to the following additional requirements:
+* PricingCurrencyContractedUnitPrice MUST be of type Decimal.
+* PricingCurrencyContractedUnitPrice MUST conform to [NumericFormat](#numericformat) requirements.
+* PricingCurrencyContractedUnitPrice nullability is defined as follows:
+  * PricingCurrencyContractedUnitPrice MUST be null when [ChargeCategory](#chargecategory) is "Tax".
+  * PricingCurrencyContractedUnitPrice MUST NOT be null when ChargeCategory is "Usage" or "Purchase" and [ChargeClass](#chargeclass) is not "Correction".
+  * PricingCurrencyContractedUnitPrice MAY be null in all other cases.
+* When PricingCurrencyContractedUnitPrice is not null, PricingCurrencyContractedUnitPrice adheres to the following additional requirements:
+  * PricingCurrencyContractedUnitPrice MUST be a non-negative decimal value.
+  * PricingCurrencyContractedUnitPrice MUST be denominated in the BillingCurrency.
+  * The product of PricingCurrencyContractedUnitPrice and [PricingQuantity](#pricingquantity) MUST match the [ContractedCost](#contractedcost) when PricingQuantity is not null and ChargeClass is not "Correction".
+* Discrepancies in PricingCurrencyContractedUnitPrice, ContractedCost, or PricingQuantity MAY be addressed independently when ChargeClass is "Correction".
+
+## Column ID
+
+PricingCurrencyContractedUnitPrice
+
+## Display Name
+
+Pricing Currency Contracted Unit Price
+
+## Description
+
+The agreed-upon unit price for a single Pricing Unit of the associated SKU, inclusive of negotiated discounts, if present, while excluding negotiated commitment discounts or any other discounts, and expressed in Pricing Currency.
+
+## Usability Constraints
+
+**Aggregation:** Column values should only be viewed in the context of their row and not aggregated to produce a total.
+
+## Content Constraints
+
+| Constraint      | Value                                |
+|:----------------|:-------------------------------------|
+| Column type     | Metric                               |
+| Feature level   | Conditional                          |
+| Allows nulls    | True                                 |
+| Data type       | Decimal                              |
+| Value format    | [Numeric Format](#numericformat)     |
+| Number range    | Any valid non-negative decimal value |
+
+## Introduced (version)
+
+1.0

--- a/specification/columns/pricingcurrencylistunitprice.md
+++ b/specification/columns/pricingcurrencylistunitprice.md
@@ -1,0 +1,52 @@
+# Pricing Currency List Unit Price
+
+The Pricing Currency List Unit Price represents the suggested provider-published unit price for a single [Pricing Unit](#pricingunit) of the associated SKU, exclusive of any discounts. This price is denominated in the [Pricing Currency](#pricingcurrency). The Pricing Currency List Unit Price is commonly used for calculating savings based on various rate optimization activities.
+
+The PricingCurrencyListUnitPrice column adheres to the following requirements:
+
+* PricingCurrency presence in a [*FOCUS dataset*](#glossary:FOCUS-dataset) is defined as follows:
+  * PricingCurrency MUST be present in a FOCUS dataset when the provider presents prices in a virtual currency (e.g. credits, tokens).
+  * PricingCurrency MUST be present in a FOCUS dataset when the provider presents prices and bills in different fiat currencies (e.g. priced in USD and billed in EUR).
+  * PricingCurrency MAY be present in a FOCUS dataset in all other cases.
+* PricingCurrencyListUnitPrice MUST be of type Decimal.
+* PricingCurrencyListUnitPrice MUST conform to [NumericFormat](#numericformat) requirements.
+* PricingCurrencyListUnitPrice nullability is defined as follows:
+  * PricingCurrencyListUnitPrice MUST be null when [ChargeCategory](#chargecategory) is "Tax".
+  * PricingCurrencyListUnitPrice MUST NOT be null when ChargeCategory is "Usage" or "Purchase" and [ChargeClass](#chargeclass) is not "Correction".
+  * PricingCurrencyListUnitPrice MAY be null in all other cases.
+* When PricingCurrencyListUnitPrice is not null, ListUnitPrice adheres to the following additional requirements:
+  * PricingCurrencyListUnitPrice MUST be a non-negative decimal value.
+  * PricingCurrencyListUnitPrice MUST be denominated in the BillingCurrency.
+  * The product of PricingCurrencyListUnitPrice and [PricingQuantity](#pricingquantity) MUST match the [ListCost](#listcost) when PricingQuantity is not null and ChargeClass is not "Correction".
+  * Discrepancies in PricingCurrencyListUnitPrice, ListCost, or PricingQuantity MAY be addressed independently when ChargeClass is "Correction".
+
+## Column ID
+
+PricingCurrencyListUnitPrice
+
+## Display Name
+
+Pricing Currency List Unit Price
+
+## Description
+
+The suggested provider-published unit price for a single Pricing Unit of the associated SKU, exclusive of any discounts and expressed in Pricing Currency.
+
+## Usability Constraints
+
+**Aggregation:** Column values should only be viewed in the context of their row and not aggregated to produce a total.
+
+## Content Constraints
+
+| Constraint      | Value                                |
+|:----------------|:-------------------------------------|
+| Column type     | Metric                               |
+| Feature level   | Conditional                          |
+| Allows nulls    | True                                 |
+| Data type       | Decimal                              |
+| Value format    | [Numeric Format](#numericformat)     |
+| Number range    | Any valid non-negative decimal value |
+
+## Introduced (version)
+
+1.2

--- a/specification/columns/pricingcurrencylistunitprice.md
+++ b/specification/columns/pricingcurrencylistunitprice.md
@@ -4,10 +4,10 @@ The Pricing Currency List Unit Price represents the suggested provider-published
 
 The PricingCurrencyListUnitPrice column adheres to the following requirements:
 
-* PricingCurrency presence in a [*FOCUS dataset*](#glossary:FOCUS-dataset) is defined as follows:
-  * PricingCurrency MUST be present in a FOCUS dataset when the provider presents prices in a virtual currency (e.g. credits, tokens).
-  * PricingCurrency MUST be present in a FOCUS dataset when the provider presents prices and bills in different fiat currencies (e.g. priced in USD and billed in EUR).
-  * PricingCurrency MAY be present in a FOCUS dataset in all other cases.
+* PricingCurrencyListUnitPrice presence in a [*FOCUS dataset*](#glossary:FOCUS-dataset) is defined as follows:
+  * PricingCurrencyListUnitPrice MUST be present in a FOCUS dataset when the provider presents prices in a virtual currency (e.g. credits, tokens).
+  * PricingCurrencyListUnitPrice MUST be present in a FOCUS dataset when the provider presents prices and bills in different national currencies (e.g. priced in USD and billed in EUR).
+  * PricingCurrencyListUnitPrice MAY be present in a FOCUS dataset in all other cases.
 * PricingCurrencyListUnitPrice MUST be of type Decimal.
 * PricingCurrencyListUnitPrice MUST conform to [NumericFormat](#numericformat) requirements.
 * PricingCurrencyListUnitPrice nullability is defined as follows:

--- a/specification/columns/pricingtobillingexchangerate.md
+++ b/specification/columns/pricingtobillingexchangerate.md
@@ -1,0 +1,50 @@
+# Pricing to Billing Exchange Rate
+
+A Pricing to Billing Exchange Rate represents the conversion factor from [Pricing Currency](#pricingcurrency) to [Billing Currency](#billingcurrency).  Pricing to Billing Exchange Rate is commonly used in scenarios where costs need to be grouped or aggregated by some combination of the following currency types:
+
+* National currency (e.g. USD, EUR).
+* Virtual currency (e.g. tokens, credits).
+
+The PricingToBillingExchangeRate column adheres to the following requirements:
+
+* PricingToBillingExchangeRate presence in a [*FOCUS dataset*](#glossary:FOCUS-dataset) is defined as follows:
+  * PricingToBillingExchangeRate MUST be present in a FOCUS dataset when the provider presents prices in a virtual currency (e.g. credits, tokens).
+  * PricingToBillingExchangeRate MUST be present in a FOCUS dataset when the provider presents prices and bills in different national currencies (e.g. priced in USD and billed in EUR).
+  * PricingToBillingExchangeRate MAY be present in a FOCUS dataset in all other cases.
+* PricingToBillingExchangeRate MUST be of type Decimal.
+* PricingToBillingExchangeRate MUST conform to [Numeric Format](#numericformat) requirements.
+* PricingToBillingExchangeRate MUST NOT be null.
+* PricingToBillingExchangeRate MUST be a non-negative decimal value.
+* PricingToBillingExchangeRate MUST represent the conversion factor from [Pricing Currency](#pricingcurrency) to [Billing Currency](#billingcurrency).
+* PricingToBillingExchangeRate MUST equal 1 when the Pricing Currency and Billing Currency are the same value.
+
+## Column ID
+
+PricingToBillingExchangeRate
+
+## Display Name
+
+Pricing to Billing Exchange Rate
+
+## Description
+
+The conversion factor from Pricing Currency to Billing Currency.
+
+## Usability Constraints
+
+**Aggregation:** Column values should only be viewed in the context of their row and not aggregated to produce a total.
+
+## Content Constraints
+
+| Constraint      | Value                                |
+|:----------------|:-------------------------------------|
+| Column type     | Metric                               |
+| Feature level   | Conditional                          |
+| Allows nulls    | True                                 |
+| Data type       | Decimal                              |
+| Value format    | [Numeric Format](#numericformat)     |
+| Number range    | Any valid non-negative decimal value |
+
+## Introduced (version)
+
+1.2

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -140,6 +140,10 @@ An individual who performs FinOps within an organization to maximize the busines
 
 A comprehensive list of prices offered by a provider.
 
+<a name="glossary:pricing-currency"><b>Pricing Currency</b></a>
+
+An identifier that represents the currency that a charge for resources and/or services was priced in.
+
 <a name="glossary:provider"><b>Provider</b></a>
 
 An entity that made internal or 3rd party resources and/or services available for purchase.

--- a/supporting_content/columns/pricingcurrency.md
+++ b/supporting_content/columns/pricingcurrency.md
@@ -1,0 +1,20 @@
+# Column: PricingCurrency
+
+## Example provider mappings
+
+Current column mappings found in available data sets:
+
+| Provider  | Data set                     | Column                   |
+|:----------|:-----------------------------|:-------------------------|
+| AWS       | Cost and Usage Report        | n/a |
+| GCP       | BigQuery Billing Export      | n/a |
+| Microsoft | Cost Details                 | PricingCurrency |
+| OCI       | Cost and Usage Report        | n/a |
+
+## References and Resources
+
+`<<TBD>>`
+
+## Discussion / Scratch space
+
+[This spreadsheet](https://docs.google.com/spreadsheets/d/1H69HmngVv-mKpFR-sveY-fSAdR49syqQd7AKOPPQ64A/edit?gid=0#gid=0) was used for generating data samples and building consensus across the various SaaS providers (e.g. Datadog, MongoDB, Domo, Twilio).


### PR DESCRIPTION
This pull request replaces #799, which proposed adding two columns `PricingCurrency` and `PricingToBillingExchangeRate` to the FOCUS specification.  The issues with that PR as expressed async in Slack and reiterated during the Mar 14 TF3 call were:

* Expression of existing Unit Price columns (e.g. List Unit Price) in Pricing Currency is a non-starter for some of the group
* These two columns alone do not go far enough to be considered a "SaaS MVP", as all SaaS providers would need to answer the question: 
  * `How much of the virtual currency did the charge consume?`
* If we do not allow Unit Price columns to be denominated in Pricing Currency, then we shall still need to facilitate practitioners answering the following questions:
  * `What was the public rate for the relevant virtual currency?`
  * `What was the negotiated rate for the relevant virtual currency?`

Therefore, this PR adds three more columns to the original two, resulting in a net addition of five columns:

 * `PricingCurrency`: virtual currency (e.g. tokens, credits) for providers with virtual currency usage charges, and national currency (e.g. USD, EUR) otherwise
 * `PricingToBillingExchangeRate`: the conversion factor from Pricing Currency to Billing Currency
 * `PricedCost`: the cost of the charge as expressed in Pricing Currency
 * `PricingCurrencyListUnitPrice`: the List Unit Price as expressed in Pricing Currency
 * `PricingCurrencyContractedUnitPrice`: the Contracted Unit Price as expressed in Pricing Currency

**Unlike #799, this PR makes no change to the definition of existing columns.**  For example, `List Unit Price` remains denominated in Billing Currency.  Stated another way: these revisions to facilitate SaaS support are now fully decoupled from existing column definitions.

As with #799, this PR also makes the following changes:

* Renamed attribute `CurrencyFormat` from `CurrencyCodeFormat` and expanded definition to include both national currencies and virtual currencies
* Added an entry for `Pricing Currency` in the glossary.
