### PR TITLE
Update amortizationclass.md

### DIFF
--- a/specification/columns/amortizationclass.md
+++ b/specification/columns/amortizationclass.md
@@ -7,7 +7,7 @@ The AmortizationClass column adheres to the following requirements:
 * AmortizationClass column MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports *amortization*.
 * AmortizationClass MUST be of type String.
 * AmortizationClass MUST be "Principal" when the row represents an original charge that is amortized across multiple other rows.
-* AmortizationClass MUST be "Amortized Charge" when the row represents a result of *amortization* from a previous charge.
+* AmortizationClass MUST be "Amortized Charge" when the row includes *amortization* from a previous charge.
 * AmortizationClass MUST be null when it is not the original, principal charge or the effective, amortized charge after *amortization* is applied.
 
 ## Column ID


### PR DESCRIPTION
For AWS, EC2 Capacity Block for ML has the following behavior -- 

For the upfront charge, billed cost >0, effective cost =0
For the hourly charge, billed cost >0 (if the instance is using a paid OS, the billed cost represents the OS licensing fee), effective cost >0 (OS licensing fee + amortization of upfront Capacity Block for ML payment)

Need to clarify what does "represents a result of" in the proposal.

