### PR TITLE
Added extra build step for failure

### DIFF
--- a/.github/workflows/candidate_release.yml
+++ b/.github/workflows/candidate_release.yml
@@ -26,6 +26,12 @@ jobs:
         working-directory: ./specification
         run: |
           make STYLE=candidate_release
+      - name: Upload on failure
+        uses: actions/upload-artifact@4.5.0
+        if: ${{ failure()}}
+        with:
+          name: spec.md
+          path: spec.md
       - name: Upload Spec
         uses: actions/upload-artifact@v4.5.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,12 @@ jobs:
         working-directory: ./specification
         run: |
           make STYLE=main
+      - name: Upload on failure
+        uses: actions/upload-artifact@4.5.0
+        if: ${{ failure()}}
+        with:
+          name: spec.md
+          path: spec.md
       - name: Upload Spec
         uses: actions/upload-artifact@v4.5.0
         with:

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -28,6 +28,12 @@ jobs:
         working-directory: ./specification
         run: |
           make STYLE=working_draft
+      - name: Upload on failure
+        uses: actions/upload-artifact@4.5.0
+        if: ${{ failure()}}
+        with:
+          name: spec.md
+          path: spec.md
       - name: Upload Spec
         uses: actions/upload-artifact@v4.5.0
         with:


### PR DESCRIPTION
To assist with debuging build failures the spec.md file will be uploaded to the build job if the build step fails. This can be useful to avoid everyone needing a local development environment.