### PR TITLE
AI #864: Strike extra row in Billing Account Type and Sub Account Type

### DIFF
--- a/specification/columns/billingaccounttype.md
+++ b/specification/columns/billingaccounttype.md
@@ -30,7 +30,6 @@ A provider-assigned identifier for the type of *billing account* applied to the 
 | :-------------- | :--------------- |
 | Column type     | Dimension        |
 | Feature level   | Conditional      |
-| Column required | True             |
 | Allows nulls    | False            |
 | Data type       | String           |
 | Value format    | \<not specified> |

--- a/specification/columns/subaccounttype.md
+++ b/specification/columns/subaccounttype.md
@@ -30,7 +30,6 @@ A provider-assigned identifier for the type of *sub account* applied to the *row
 | :-------------- | :--------------- |
 | Column type     | Dimension        |
 | Feature level   | Conditional      |
-| Column required | True             |
 | Allows nulls    | True             |
 | Data type       | String           |
 | Value format    | \<not specified> |


### PR DESCRIPTION
The Content Constraints table had an extra row in both Billing Account Type and Sub Account Type compared to the other columns.  These have now been struck.