### PR TITLE
AI #872: Revised 1. Introduction

### DIFF
--- a/specification/overview.md
+++ b/specification/overview.md
@@ -2,7 +2,9 @@
 
 *This section is non-normative.*
 
-FOCUS aims to establish a community-driven specification for consumption-based billing data. Due to the lack of a broadly adopted specification, infrastructure and services [*providers*](#glossary:provider) have resorted to proprietary billing schemas and terminology. The lack of conformance amongst the billing data generators has forced FinOps practitioners to employ disparate, best-effort schemes which each *practitioner* must develop individually for each *provider* to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
+FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have resorted to proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments.
+The FOCUS Specification is developed by a global community of practitioners and vendors working collaboratively to define a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability, reduce complexity, and enable transparency in cloud and SaaS cost management.
+The lack of conformance amongst the billing data generators has forced FinOps practitioners to employ disparate, best-effort schemes which each *practitioner* must develop individually for each *provider* to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
 
 The FOCUS specification's schema definition and FinOps-aligned terminology provide a clear guide for producing FinOps-serviceable billing datasets. Datasets conforming to FOCUS enable FinOps practitioners to perform common FinOps capabilities, like the ones mentioned above, using a generic set of instructions, regardless of the origin of the dataset.
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -2,7 +2,7 @@
 
 *This section is non-normative.*
 
-FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have relied on proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments. This lack of conformance has forced FinOps *practitioners* to develop best-effort custom normalization schemes for each provider, in order to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
+FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have relied on proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments. This lack of conformance has forced FinOps [*practitioners*](#glossary:practitioner) to develop best-effort custom normalization schemes for each provider, in order to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
 
 The FOCUS Specification, developed by a global community of practitioners and vendors, defines a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability between providers, reduce operational complexity, and enable greater transparency in cloud and SaaS cost management.
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -3,8 +3,7 @@
 *This section is non-normative.*
 
 FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have relied on proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments.
-The FOCUS Specification is developed by a global community of practitioners and vendors working collaboratively to define a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability, reduce complexity, and enable transparency in cloud and SaaS cost management.
-This lack of conformance has forced FinOps *practitioners* to develop best-effort custom normalization schemes for each provider, in order to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
+The FOCUS Specification is developed by a global community of practitioners and vendors working collaboratively to define a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability, reduce complexity, and enable transparency in cloud and SaaS cost management. This lack of conformance has forced FinOps *practitioners* to develop best-effort custom normalization schemes for each provider, in order to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
 
 The FOCUS Specification, developed by a global community of practitioners and vendors, defines a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability between providers, reduce operational complexity, and enable greater transparency in cloud and SaaS cost management.
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -2,7 +2,7 @@
 
 *This section is non-normative.*
 
-FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have relied on proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments. This lack of conformance has forced FinOps [*practitioners*](#glossary:practitioner) to develop best-effort custom normalization schemes for each provider, in order to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
+FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have relied on proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments. This lack of conformance has forced FinOps [*practitioners*](#glossary:practitioner) to develop best-effort custom normalization schemes for each provider, in order to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
 
 The FOCUS Specification, developed by a global community of practitioners and vendors, defines a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability between providers, reduce operational complexity, and enable greater transparency in cloud and SaaS cost management.
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -2,8 +2,7 @@
 
 *This section is non-normative.*
 
-FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have relied on proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments.
-The FOCUS Specification is developed by a global community of practitioners and vendors working collaboratively to define a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability, reduce complexity, and enable transparency in cloud and SaaS cost management. This lack of conformance has forced FinOps *practitioners* to develop best-effort custom normalization schemes for each provider, in order to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
+FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have relied on proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments. This lack of conformance has forced FinOps *practitioners* to develop best-effort custom normalization schemes for each provider, in order to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
 
 The FOCUS Specification, developed by a global community of practitioners and vendors, defines a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability between providers, reduce operational complexity, and enable greater transparency in cloud and SaaS cost management.
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -2,11 +2,11 @@
 
 *This section is non-normative.*
 
-FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have resorted to proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments.
+FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service [*providers*](#glossary:provider) have relied on proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments.
 The FOCUS Specification is developed by a global community of practitioners and vendors working collaboratively to define a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability, reduce complexity, and enable transparency in cloud and SaaS cost management.
-The lack of conformance amongst the billing data generators has forced FinOps practitioners to employ disparate, best-effort schemes which each *practitioner* must develop individually for each *provider* to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
+This lack of conformance has forced FinOps *practitioners* to develop best-effort custom normalization schemes for each provider, in order to perform essential FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting.
 
-The FOCUS specification's schema definition and FinOps-aligned terminology provide a clear guide for producing FinOps-serviceable billing datasets. Datasets conforming to FOCUS enable FinOps practitioners to perform common FinOps capabilities, like the ones mentioned above, using a generic set of instructions, regardless of the origin of the dataset.
+The FOCUS Specification, developed by a global community of practitioners and vendors, defines a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability between providers, reduce operational complexity, and enable greater transparency in cloud and SaaS cost management.
 
 ## Background and History
 


### PR DESCRIPTION
This PR is related to Action Item #872

Detailed Description
Issue

The first paragraph in section 1. Introduction should be enhanced to make it clear that FOCUS is a Standards Development Organization (SDO).

"FOCUS aims to establish a community-driven specification for consumption-based billing data. ..."
Suggestion under Section 1. Introduction

Replace that statement for something like:

" FOCUS is a standards development organization (SDO) formed to establish an open, consensus-driven standard for consumption-based billing data. In the absence of a broadly adopted standard, infrastructure and service providers have resorted to proprietary billing schemas and inconsistent terminology, making cost data difficult to normalize and act upon across environments.

The FOCUS Specification is developed by a global community of practitioners and vendors working collaboratively to define a consistent, vendor-neutral approach to billing data. It is designed to improve interoperability, reduce complexity, and enable transparency in cloud and SaaS cost management."