### PR TITLE
AI #880: Change open-source to open

### DIFF
--- a/specification/spec.mdpp
+++ b/specification/spec.mdpp
@@ -11,7 +11,7 @@ pagetitle: FinOps Open Cost and Usage Specification
 
 ## Abstract
 
-FOCUS is an open-standard specification for billing data. It defines a common schema for billing data, aligns terminology with the FinOps Framework and defines a minimum set of requirements for billing data. The specification provides clear guideline for billing data generators to produce FinOps-serviceable data. The specification enables FinOps practitioners to perform common FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting etc. using a generic set of instructions, regardless of the origin of the FOCUS compatible dataset.
+FOCUS is an open specification for billing data. It defines a common schema for billing data, aligns terminology with the FinOps Framework and defines a minimum set of requirements for billing data. The specification provides clear guideline for billing data generators to produce FinOps-serviceable data. The specification enables FinOps practitioners to perform common FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting etc. using a generic set of instructions, regardless of the origin of the FOCUS compatible dataset.
 
 <div style="page-break-after: always"></div>
 

--- a/specification/spec.mdpp
+++ b/specification/spec.mdpp
@@ -11,7 +11,7 @@ pagetitle: FinOps Open Cost and Usage Specification
 
 ## Abstract
 
-FOCUS is an open-source specification for billing data. It defines a common schema for billing data, aligns terminology with the FinOps Framework and defines a minimum set of requirements for billing data. The specification provides clear guideline for billing data generators to produce FinOps-serviceable data. The specification enables FinOps practitioners to perform common FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting etc. using a generic set of instructions, regardless of the origin of the FOCUS compatible dataset.
+FOCUS is an open-standard specification for billing data. It defines a common schema for billing data, aligns terminology with the FinOps Framework and defines a minimum set of requirements for billing data. The specification provides clear guideline for billing data generators to produce FinOps-serviceable data. The specification enables FinOps practitioners to perform common FinOps capabilities such as chargeback, cost allocation, budgeting and forecasting etc. using a generic set of instructions, regardless of the origin of the FOCUS compatible dataset.
 
 <div style="page-break-after: always"></div>
 


### PR DESCRIPTION
Linked to AI #880 

### Detailed Description

## "1.3 Scope" 
In this section, we indicate that FOCUS is an **open-source** project, but FOCUS is an **open-standard** project. 

> **1.3. Scope**
> The FOCUS working group will develop an open-source specification for billing data. The schema will
define data [dimensions](), [metrics](), a set of attributes about billing data, and a common lexicon for
describing billing data.

### Rationale Why FOCUS is an Open Standards Project
FOCUS is an open standard because it defines a shared, vendor-neutral specification for consumption-based billing data, enabling interoperability and transparency and not delivering executable code. It complements open-source tools but is governed, developed, and maintained as a standard in service of the broader FinOps and cloud ecosystem.
* **1. Nature of the Deliverable: Specification, Not Software**
   * FOCUS produces a normative specification (billing and usage data)
   * It does not produce executable software or codebases for deployment

* **2. Purpose: Interoperability Across Systems**
   * Open standards exist to create consistency and interoperability across different ecosystems.
   * The FOCUS specifications enables multiple providers and tools to align to a common data model.

* **3. Governance: Consensus-Driven and Neutral**
   * FOCUS is governed by a consensus-based process
   * Decisions are made based on broad agreement, not by a single maintainer or corporate sponsor
* **4. Licensing and Intent: Open Use, No Code Reuse**
   * The specification is openly licensed for adoption.
   * However, it is not a code artifact intended for reuse or extension, as is typical in open source software libraries.

