### PR TITLE
AI #868: Update copyright year for PDF publication

### DIFF
--- a/specification/versions/candidate_release.md
+++ b/specification/versions/candidate_release.md
@@ -6,7 +6,7 @@ v1.2 Candidate Release
 |:-------------------------------------------------------------------------------|
 | This version is a candidate release but not an official publication            |
 
-Copyright © 2024 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Linux Foundation [trademark](https://www.linuxfoundation.org/legal/trademarks), and document use rules apply.
+Copyright © 2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Linux Foundation [trademark](https://www.linuxfoundation.org/legal/trademarks), and document use rules apply.
 
 ## Status of This Document
 

--- a/specification/versions/main.md
+++ b/specification/versions/main.md
@@ -2,7 +2,7 @@
 
 Publication version 1.2
 
-Copyright © 2024 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Linux Foundation [trademark](https://www.linuxfoundation.org/legal/trademarks), and document use rules apply.
+Copyright © 2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Linux Foundation [trademark](https://www.linuxfoundation.org/legal/trademarks), and document use rules apply.
 
 ## Status of This Document
 

--- a/specification/versions/working_draft.md
+++ b/specification/versions/working_draft.md
@@ -6,7 +6,7 @@ Working Draft (Unversioned)
 |:-------------------------------------------------------------------------------|
 | This version not for publication                                               |
 
-Copyright © 2024 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Linux Foundation [trademark](https://www.linuxfoundation.org/legal/trademarks), and document use rules apply.
+Copyright © 2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Linux Foundation [trademark](https://www.linuxfoundation.org/legal/trademarks), and document use rules apply.
 
 ## Status of This Document
 


### PR DESCRIPTION
Bumped from 2024 to 2025 for publication purposes.