### PR TITLE
Scrub of Supported Features

### DIFF
--- a/specification/supported_features/account_structures.md
+++ b/specification/supported_features/account_structures.md
@@ -1,9 +1,5 @@
 # Account Structures
 
-## Introduced Version
-
-0.5
-
 ## Description
 
 Different providers have different account constructs that FinOps practitioners use for allocation, reporting, and more. Organizations may have one or many accounts within one or more providers and FinOps practitioners may need to review the cost broken down by each account. FOCUS has two types of accounts: a billing account and a sub account.
@@ -41,3 +37,7 @@ GROUP BY
   BillingAccountId,
   SubAccountId
 ```
+
+## Introduced (Version)
+
+0.5

--- a/specification/supported_features/billed_cost_and_invoice_alignment.md
+++ b/specification/supported_features/billed_cost_and_invoice_alignment.md
@@ -26,7 +26,7 @@ SELECT
   InvoiceId,
   SUM(BilledCost)
 FROM focus_data_table
-Group by
+GROUP BY
   BillingPeriodStart,
   BillingPeriodEnd,
   InvoiceId

--- a/specification/supported_features/billed_cost_and_invoice_alignment.md
+++ b/specification/supported_features/billed_cost_and_invoice_alignment.md
@@ -1,9 +1,5 @@
 # Billed Cost and Invoice Alignment
 
-## Introduced Version
-
-0.5
-
 ## Description
 
 FOCUS data should be consistent with the costs indicated on payable invoices. This is relevant to the total cost of the invoice, as well as the period of time the invoice covers.
@@ -35,3 +31,7 @@ Group by
   BillingPeriodEnd,
   InvoiceId
 ```
+
+## Introduced (Version)
+
+0.5

--- a/specification/supported_features/charge_categorization.md
+++ b/specification/supported_features/charge_categorization.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The FOCUS spec supports the categorization of charges including purchases, usage, tax, credits and adjustments. It includes classification on frequency. It includes classification on correction vs normal entries
+FOCUS supports the categorization of charges including purchases, usage, tax, credits and adjustments. It includes classification on frequency. It includes classification on correction vs normal entries
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/charge_categorization.md
+++ b/specification/supported_features/charge_categorization.md
@@ -1,9 +1,5 @@
 # Charge Categorization
 
-## Introduced Version
-
-1.0
-
 ## Description
 
 The FOCUS spec supports the categorization of charges including purchases, usage, tax, credits and adjustments. It includes classification on frequency. It includes classification on correction vs normal entries
@@ -97,3 +93,7 @@ GROUP BY
   CommitmentDiscountType,
   ChargeFrequency
 ```
+
+## Introduced (Version)
+
+1.0

--- a/specification/supported_features/commit_usage_and_under_usage.md
+++ b/specification/supported_features/commit_usage_and_under_usage.md
@@ -61,3 +61,7 @@ GROUP BY
   CapacityReservationId,
   CapacityReservationStatus
 ```
+
+## Introduced (Version)
+
+1.0

--- a/specification/supported_features/commit_usage_and_under_usage.md
+++ b/specification/supported_features/commit_usage_and_under_usage.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The FOCUS spec supports the tracking of commitment discounts usage and underusage, which can come in the form of commitment discounts or capacity reservations.
+FOCUS supports the tracking of commitment discounts usage and under usage, which can come in the form of commitment discounts or capacity reservations.
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/commit_usage_and_under_usage.md
+++ b/specification/supported_features/commit_usage_and_under_usage.md
@@ -1,12 +1,8 @@
 # Commit Usage and Under Usage
 
-## Introduced Version
-
-1.0
-
 ## Description
 
-The FOCUS spec supports the tracking of committed use discounts usage and underusage, which can come in the form of commitment discounts or capacity reservations.
+The FOCUS spec supports the tracking of commitment discounts usage and underusage, which can come in the form of commitment discounts or capacity reservations.
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/cost_and_usage_attribution.md
+++ b/specification/supported_features/cost_and_usage_attribution.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Many providers have features that allow Finops practitioners to enrich cost and usage data with metadata, that is addition to provider defined data, in order to analyze Finops data using organizational, deployment, or other structures. These features may take the form of directly applied metadata or inherited metadata. The FOCUS spec facilitates the inclusion of this metadata at a row level.  
+Many providers have features that allow Finops practitioners to enrich cost and usage data with metadata, that is addition to provider defined data, in order to analyze Finops data using organizational, deployment, or other structures. These features may take the form of directly applied metadata or inherited metadata. FOCUS facilitates the inclusion of this metadata at a row level.  
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/cost_and_usage_attribution.md
+++ b/specification/supported_features/cost_and_usage_attribution.md
@@ -1,9 +1,5 @@
 # Cost and Usage Attribution
 
-## Introduced Version
-
-1.0
-
 ## Description
 
 Many providers have features that allow Finops practitioners to enrich cost and usage data with metadata, that is addition to provider defined data, in order to analyze Finops data using organizational, deployment, or other structures. These features may take the form of directly applied metadata or inherited metadata. The FOCUS spec facilitates the inclusion of this metadata at a row level.  
@@ -34,3 +30,7 @@ GROUP BY
   tags,
   ConsumedUnit
 ```
+
+## Introduced (Version)
+
+1.0

--- a/specification/supported_features/cost_comparison.md
+++ b/specification/supported_features/cost_comparison.md
@@ -1,9 +1,5 @@
 # Cost Comparison
 
-## Introduced Version
-
-0.5
-
 ## Description
 
 FOCUS supports the comparison of cost columns in order to identify savings, amortization, or other constructs.
@@ -71,3 +67,7 @@ SELECT ProviderName,
     1 - (TotalEffectiveCost / NULLIF(TotalListCost, 0)) * 100 AS EffectiveDiscount
 FROM AggregatedData
 ```
+
+## Introduced (Version)
+
+0.5

--- a/specification/supported_features/custom_columns.md
+++ b/specification/supported_features/custom_columns.md
@@ -1,9 +1,5 @@
 # Custom Columns
 
-## Introduced Version
-
-0.5
-
 ## Description
 
 The FOCUS spec supports the inclusion of custom columns to facilitate reporting capability that is not covered by the columns included in the specification.
@@ -27,3 +23,7 @@ GROUP BY
   x_CustomColumn
 ORDER BY MonthlyCost DESC
 ```
+
+## Introduced (Version)
+
+0.5

--- a/specification/supported_features/custom_columns.md
+++ b/specification/supported_features/custom_columns.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The FOCUS spec supports the inclusion of custom columns to facilitate reporting capability that is not covered by the columns included in the specification.
+FOCUS supports the inclusion of custom columns to facilitate reporting capability that is not covered by the columns included in the specification.
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/data_granularity.md
+++ b/specification/supported_features/data_granularity.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The FOCUS spec supports multiple levels of cost and usage data granularity. This includes the ability to report on a daily, hourly, or other time period basis. Focus also supports the ability for cost and usage data to be provided for high granularity scenarios, such as down to the individual resources. It also supports high level granularity cost and usage data, such as account level, or service level charges.
+FOCUS supports multiple levels of cost and usage data granularity. This includes the ability to report on a daily, hourly, or other time period basis. Focus also supports the ability for cost and usage data to be provided for high granularity scenarios, such as down to the individual resources. It also supports high level granularity cost and usage data, such as account level, or service level charges.
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/data_granularity.md
+++ b/specification/supported_features/data_granularity.md
@@ -1,9 +1,5 @@
 # Data Granularity
 
-## Introduced Version
-
-0.5
-
 ## Description
 
 The FOCUS schema supports multiple levels of cost and usage data granularity. This includes the ability to report on a daily, hourly, or other time period basis. Focus also supports the ability for cost and usage data to be provided for high granularity scenarios, such as down to the individual resources. It also supports high level granularity cost and usage data, such as account level, or service level charges.
@@ -39,3 +35,7 @@ Group by
   ChargePeriodEnd,
   ResourceId
 ```
+
+## Introduced (Version)
+
+0.5

--- a/specification/supported_features/data_granularity.md
+++ b/specification/supported_features/data_granularity.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-FOCUS supports multiple levels of cost and usage data granularity. This includes the ability to report on a daily, hourly, or other time period basis. Focus also supports the ability for cost and usage data to be provided for high granularity scenarios, such as down to the individual resources. It also supports high level granularity cost and usage data, such as account level, or service level charges.
+FOCUS supports multiple levels of cost and usage data granularity. This includes the ability to report on a daily, hourly, or other time period basis. FOCUS also supports the ability for cost and usage data to be provided for high granularity scenarios, such as down to the individual resources. It also supports high level granularity cost and usage data, such as account level, or service level charges.
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/data_granularity.md
+++ b/specification/supported_features/data_granularity.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The FOCUS schema supports multiple levels of cost and usage data granularity. This includes the ability to report on a daily, hourly, or other time period basis. Focus also supports the ability for cost and usage data to be provided for high granularity scenarios, such as down to the individual resources. It also supports high level granularity cost and usage data, such as account level, or service level charges.
+The FOCUS spec supports multiple levels of cost and usage data granularity. This includes the ability to report on a daily, hourly, or other time period basis. Focus also supports the ability for cost and usage data to be provided for high granularity scenarios, such as down to the individual resources. It also supports high level granularity cost and usage data, such as account level, or service level charges.
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/effective_cost.md
+++ b/specification/supported_features/effective_cost.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The FOCUS spec EffectiveCost enabled practitioners to analyze costs without having to distribute upfront fees and discounts.  representing costs taking into account discounts and the amortization of upfront fees paid for services. This column represents cost after negotiated discounts, commitment discounts, and the applicable portion of relevant, prepaid purchases (one-time or recurring) that covered this charge. Effective Cost is commonly utilized to track and analyze spending trends.
+FOCUS enables practitioners to analyze costs without having to distribute upfront fees and discounts, taking discounts and the amortization of upfront fees paid for services into account. The EffectiveCost column represents cost after negotiated discounts, commitment discounts, and the applicable portion of relevant, prepaid purchases (one-time or recurring) that covered this charge. EffectiveCost is commonly utilized to track and analyze spending trends.
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/effective_cost.md
+++ b/specification/supported_features/effective_cost.md
@@ -1,9 +1,5 @@
 # Effective Cost
 
-## Introduced Version
-
-0.5
-
 ## Description
 
 The FOCUS spec EffectiveCost enabled practitioners to analyze costs without having to distribute upfront fees and discounts.  representing costs taking into account discounts and the amortization of upfront fees paid for services. This column represents cost after negotiated discounts, commitment discounts, and the applicable portion of relevant, prepaid purchases (one-time or recurring) that covered this charge. Effective Cost is commonly utilized to track and analyze spending trends.
@@ -52,3 +48,7 @@ GROUP BY
   RegionName,
   PricingUnit
 ``` 
+
+## Introduced (Version)
+
+0.5

--- a/specification/supported_features/effective_cost.md
+++ b/specification/supported_features/effective_cost.md
@@ -1,4 +1,4 @@
-# Effective Cost
+# Effective Cost Analysis
 
 ## Description
 

--- a/specification/supported_features/location.md
+++ b/specification/supported_features/location.md
@@ -1,9 +1,5 @@
 # Location
 
-## Introduced Version
-
-1.0
-
 ## Description
 
 FOCUS provides structured location data through region and availability zone information. By documenting geographic deployment locations, practitioners can organize and analyze costs based on where resources and services are deployed. This standardized location data helps practitioners understand the geographical distribution of infrastructure across providers.
@@ -35,3 +31,7 @@ GROUP BY
   RegionName,
   AvailabilityZone
 ``` 
+
+## Introduced (Version)
+
+1.0

--- a/specification/supported_features/marketplace_purchases.md
+++ b/specification/supported_features/marketplace_purchases.md
@@ -1,12 +1,8 @@
 # Marketplace Purchases
 
-## Introduced Version
-
-1.0
-
 ## Description
 
-The FOCUS specification support cost and usage data for Marketplace purchases and their associated costs. It also supports the reporting of EffectiveCost for usage from the Provider.  
+The FOCUS specification supports cost and usage data for marketplace purchases and their associated costs. It also supports the reporting of EffectiveCost for usage from the provider.  
 
 ## Directly Dependent Columns
 
@@ -52,3 +48,7 @@ GROUP BY
   ChargePeriodEnd,
   ResourceId
 ``` 
+
+## Introduced (Version)
+
+1.0

--- a/specification/supported_features/marketplace_purchases.md
+++ b/specification/supported_features/marketplace_purchases.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The FOCUS specification supports cost and usage data for marketplace purchases and their associated costs. It also supports the reporting of EffectiveCost for usage from the provider.  
+FOCUS supports the analysis of cost and usage data for marketplace purchases and their associated costs. It also supports the reporting of EffectiveCost for usage from the provider.  
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/provider_services.md
+++ b/specification/supported_features/provider_services.md
@@ -1,9 +1,5 @@
 # Provider Services
 
-## Introduced Version
-
-0.5
-
 ## Description
 
 The FOCUS spec supports providers specifying the services and product offerings that they provide their customers that align with the names practitioners are familiar with. This empowers practitioners to analyze cost by service, report service costs by subaccount, forecast based on historical trends by service, and verify accuracy of services charged across providers.
@@ -41,3 +37,7 @@ GROUP BY
   ServiceName
 ORDER BY MonthlyCost DESC
 ```
+
+## Introduced (Version)
+
+0.5

--- a/specification/supported_features/provider_services.md
+++ b/specification/supported_features/provider_services.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The FOCUS spec supports providers specifying the services and product offerings that they provide their customers that align with the names practitioners are familiar with. This empowers practitioners to analyze cost by service, report service costs by subaccount, forecast based on historical trends by service, and verify accuracy of services charged across providers.
+FOCUS supports providers specifying the services and product offerings that they provide their customers that align with the names practitioners are familiar with. This empowers practitioners to analyze cost by service, report service costs by subaccount, forecast based on historical trends by service, and verify accuracy of services charged across providers.
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/resource_usage.md
+++ b/specification/supported_features/resource_usage.md
@@ -1,12 +1,8 @@
 # Resource Usage
 
-## Introduced Version
-
-1.0
-
 ## Description
 
-FOCUS enables tracking of resource consumption by providing information about which resources were used, in what quantities, and with what units of measure.
+The FOCUS spec enables tracking of resource consumption by providing information about which resources were used, in what quantities, and with what units of measure.
 
 ## Directly Dependent Columns
 
@@ -43,3 +39,7 @@ GROUP BY
   SkuId,
   ConsumedUnit
 ``` 
+
+## Introduced (Version)
+
+1.0

--- a/specification/supported_features/resource_usage.md
+++ b/specification/supported_features/resource_usage.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The FOCUS spec enables tracking of resource consumption by providing information about which resources were used, in what quantities, and with what units of measure.
+FOCUS enables tracking of resource consumption by providing information about which resources were used, in what quantities, and with what units of measure.
 
 ## Directly Dependent Columns
 

--- a/specification/supported_features/schema_metadata.md
+++ b/specification/supported_features/schema_metadata.md
@@ -1,9 +1,5 @@
 # Schema Metadata
 
-## Introduced Version
-
-1.1
-
 ## Description
 
 This FOCUS schema metadata facilitates both the provider and consumer in communication of important attributes about the data, facilitating notification about changing structure and database table creation. This includes column names, data types, and any other relevant information about the data schema. It also includes information as to the version of FOCUS and Data Generator versioning that the data uses.
@@ -12,3 +8,7 @@ This FOCUS schema metadata facilitates both the provider and consumer in communi
 
 * Schema
   * Column Definition
+
+## Introduced (Version)
+
+1.1

--- a/specification/supported_features/schema_metadata.md
+++ b/specification/supported_features/schema_metadata.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This FOCUS schema metadata facilitates both the provider and consumer in communication of important attributes about the data, facilitating notification about changing structure and database table creation. This includes column names, data types, and any other relevant information about the data schema. It also includes information as to the version of FOCUS and Data Generator versioning that the data uses.
+FOCUS supports communication of important attributes about the data, facilitating notifications about changing structure and database table creation between provider and consumer. This includes column names, data types, and any other relevant information about the data schema. It also includes information as to the version of FOCUS and Data Generator versioning that the data uses.
 
 ## Applicable Metadata
 

--- a/specification/supported_features/schema_metadata.md
+++ b/specification/supported_features/schema_metadata.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-FOCUS supports communication of important attributes about the data, facilitating notifications about changing structure and database table creation between provider and consumer. This includes column names, data types, and any other relevant information about the data schema. It also includes information as to the version of FOCUS and Data Generator versioning that the data uses.
+FOCUS' schema metadata supports communication of important attributes about the data, facilitating notifications about changing structure and database table creation between provider and consumer. This includes column names, data types, and any other relevant information about the data schema. It also includes information as to the version of FOCUS and Data Generator versioning that the data uses.
 
 ## Applicable Metadata
 

--- a/specification/supported_features/service_categorization.md
+++ b/specification/supported_features/service_categorization.md
@@ -1,9 +1,5 @@
 # Service Categorization
 
-## Introduced Version
-
-1.1
-
 ## Description
 
 FOCUS provides a structure for categorizing services based on their core functions. By classifying services into high-level categories and more granular subcategories, practitioners can organize costs according to functional areas. This standardized categorization provides data that practitioners can use in their cost management processes and decision making.
@@ -45,3 +41,7 @@ GROUP BY
   ServiceName,
   BillingCurrency
 ```
+
+## Introduced (Version)
+
+1.1

--- a/specification/supported_features/verify_compare_track_unit_prices.md
+++ b/specification/supported_features/verify_compare_track_unit_prices.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-When a provider supports unit pricing concepts, The FOCUS Specification allows practitioners to:
+When a provider supports unit pricing concepts, FOCUS allows practitioners to:
 
 * Verify that the correct List Unit Prices and Contracted Unit Prices are applied.
 * Compare applied Contracted Unit Prices across different billing accounts and with applied List Unit Prices at specific points in time.

--- a/specification/supported_features/verify_compare_track_unit_prices.md
+++ b/specification/supported_features/verify_compare_track_unit_prices.md
@@ -1,9 +1,5 @@
 # Verification, Comparison, and Fluctuation Tracking of Unit Prices
 
-## Introduced Version
-
-1.0
-
 ## Description
 
 When a provider supports unit pricing concepts, The FOCUS Specification allows practitioners to:
@@ -46,3 +42,7 @@ WHERE
   AND ChargePeriodStart >= ?
   AND ChargePeriodEnd < ?
 ```
+
+## Introduced (Version)
+
+1.0


### PR DESCRIPTION
For each supported feature:

 * Moved `Introduced Version` from the beginning to the end of the section, and renamed to `Introduced (Version)`.  This follows the standard set by the Columns, Attributes, and Metadata sections.
 * Made consistent use of the term "FOCUS".  Various entries used the terms "FOCUS", "the FOCUS spec", and "the FOCUS specification".
 * Fixed grammar where appropriate.