### PR TITLE
Update FOCUS trademark reference

### DIFF
--- a/RELEASE-PLANNING.md
+++ b/RELEASE-PLANNING.md
@@ -9,34 +9,9 @@ This section outlines the planned release schedule and key milestones for the FO
         <th>Version</th>
         <th>Release By</th>
         <th>Scope | High-Level System Requirements</th>
-    </tr>
-        <tr>
-        <td>v1.2</td>
-        <td>Jun 2025</td>
-        <td>
-            <strong>Initial Software as a Service (SaaS) Support</strong>
-            <ul>
-                <li>Addition of columns to support SaaS-centric concepts and billing models
-                </li>
-            </ul>
-            <strong>Continued expansion of Cloud Service Provider concepts</strong>
-            <ul>
-                <li>Addition of Invoice ID to support invoice reconciliation use cases
-                </li>
-                <li>Addition of SKU properties that are prominent / common across providers
-                </li>                
-                <li>Addition of Commitment Discount Unit Price and Cost
-                </li>
-            </ul>
-            <strong>Fixes and clarifications</strong>
-            <ul>
-                <li>Revisions of existing specification content to increase consistency and reduce ambiguity</li>
-            </ul>
-        </td>
-    </tr>
     <tr>
         <td>v1.3</td>
-        <td>Late 2025</td>
+        <td>Dec 2025</td>
         <td>
             TBD
         </td>
@@ -88,8 +63,92 @@ This section outlines the planned release schedule and key milestones for the FO
             </ul>
         </td>
     </tr>
-
+    </tr>
+        <tr>
+        <td>v1.2</td>
+        <td>Jun 2025</td>
+        <td>
+            <strong>Initial Software as a Service (SaaS) Support</strong>
+            <ul>
+                <li>Addition of columns to support SaaS-centric concepts and billing models
+                </li>
+            </ul>
+            <strong>Continued expansion of Cloud Service Provider concepts</strong>
+            <ul>
+                <li>Addition of Invoice ID to support invoice reconciliation use cases
+                </li>
+                <li>Addition of SKU properties that are prominent / common across providers
+                </li>                
+            </ul>
+            <strong>Fixes and clarifications</strong>
+            <ul>
+                <li>Revisions of existing specification content to increase consistency and reduce ambiguity</li>
+            </ul>
+        </td>
+    </tr>
 </table>
+
+### Estimated Timeline for v1.3
+This table displays key milestones and dates related to the development of FOCUS Release v1.3 Specification.
+
+  <table>
+    <thead>
+      <tr>
+        <th width="22%">Date</th>
+        <th width="30%">Milestone</th>
+        <th>Comments</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>24-Apr-25</td>
+        <td>Start IPR Review v1.2</td>
+        <td>The start of Rel v1.2 IPR Review triggers the start of Rel v1.3.</td>
+      </tr>
+      <tr>
+        <td>24-Apr-25 to 17-Jul-25</td>
+        <td>Work Item Creation v1.3</td>
+        <td>12 weeks (vs 6 weeks in v1.2). Define the scope and create Work Items for v1.3.</td>
+      </tr>
+      <tr>
+        <td>17-Jul-25 to 16-Oct-25</td>
+        <td>Development Phase</td>
+        <td>*13 weeks (vs 19 weeks in v1.2). Begin developing the v1.3 specification.<br>
+            <em>* Work Items agreed by the Members Group and ratified by the Steering Committee can start development before the July 17 milestone.</em>
+        </td>
+      </tr>
+      <tr>
+        <td>16-30-Oct-25</td>
+        <td>Final Consistency Review</td>
+        <td>2 weeks. Ensure alignment and consistency of specification.</td>
+      </tr>
+      <tr>
+        <td>30-Oct-25</td>
+        <td>Prepare Baseline for IPR Review</td>
+        <td>6 days. Get ready for the Intellectual Property Rights review.</td>
+      </tr>
+      <tr>
+        <td>5-Nov-25 to 4-Dec-25</td>
+        <td>Start / End IPR Review v1.3</td>
+        <td>30-day IPR review period for essential claims review. Triggers the start of Release v1.4.</td>
+      </tr>
+      <tr>
+        <td>4-Dec-25</td>
+        <td>Working Group (WG) Approval of v1.3</td>
+        <td>WG approves the v1.3 Release Candidate.</td>
+      </tr>
+      <tr>
+        <td>4-Dec-25</td>
+        <td>SC Ratification of v1.3</td>
+        <td>The Steering Committee ratifies the v1.3 release.</td>
+      </tr>
+      <tr>
+        <td>10-Dec-25</td>
+        <td>Announcement</td>
+        <td>FinOps announcement of FOCUS Release v1.3.</td>
+      </tr>
+    </tbody>
+  </table>
 
 ### Estimated Timeline for v1.2
 
@@ -97,8 +156,8 @@ This table displays key milestones and dates related to the development of FOCUS
 
 <table>
   <tr>
-    <th>Date</th>
-    <th>Milestone</th>
+    <th width="22%">Date</th>
+    <th width="30%">Milestone</th>
     <th>Comment</th>
   </tr>
   <tr>
@@ -165,8 +224,8 @@ FOCUS Release V1.1 was announced during the FinOps XE event in Barcelona on Nove
 <table>
     <thead>
         <tr>
-            <th>Date</th>
-            <th>Milestone</th>
+            <th width="22%">Date</th>
+            <th width="30%">Milestone</th>
             <th>Comment</th>
         </tr>
     </thead>
@@ -226,8 +285,8 @@ FOCUS Release V1.0 was announced during the FinOpsX event in San Diego on June 2
 <table>
     <thead>
         <tr>
-            <th>Date</th>
-            <th>Tasks</th>
+            <th width="22%">Date</th>
+            <th width="30%">Tasks</th>
             <th>Comments</th>
         </tr>
     </thead>

--- a/specification/versions/candidate_release.md
+++ b/specification/versions/candidate_release.md
@@ -6,7 +6,7 @@ v1.2 Candidate Release
 |:-------------------------------------------------------------------------------|
 | This version is a candidate release but not an official publication            |
 
-Copyright © 2023-2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Linux Foundation [trademark](https://www.linuxfoundation.org/legal/trademarks), and document use rules apply.
+Copyright © 2023-2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
 
 ## Status of This Document
 

--- a/specification/versions/main.md
+++ b/specification/versions/main.md
@@ -2,7 +2,7 @@
 
 Publication version 1.2
 
-Copyright © 2023-2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Linux Foundation [trademark](https://www.linuxfoundation.org/legal/trademarks), and document use rules apply.
+Copyright © 2023-2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
 
 ## Status of This Document
 

--- a/specification/versions/working_draft.md
+++ b/specification/versions/working_draft.md
@@ -6,7 +6,7 @@ Working Draft (Unversioned)
 |:-------------------------------------------------------------------------------|
 | This version not for publication                                               |
 
-Copyright © 2023-2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Linux Foundation [trademark](https://www.linuxfoundation.org/legal/trademarks), and document use rules apply.
+Copyright © 2023-2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
 
 ## Status of This Document
 


### PR DESCRIPTION
This PR clarifies that FOCUS is a Joint Development Foundation trademark and provides a link to the trademark policy, https://jointdevelopment.org/policies/trademark-policy/