### PR TITLE
AI #967: Revise existing issue type templates and add a Feature Request issue type template

### DIFF
--- a/.github/ISSUE_TEMPLATE/action-item.yml
+++ b/.github/ISSUE_TEMPLATE/action-item.yml
@@ -19,3 +19,12 @@ body:
       placeholder: "Explain why this action is needed and any dependencies."
     validations:
       required: false
+
+  - type: textarea
+    id: definition_of_done
+    attributes:
+      label: Definition of Done
+      description: "Describe what must be completed in order for this action item to be closed."
+      placeholder: "A description of what must be completed in order for this action item to be closed."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,22 +1,3 @@
-# FOCUS Feature Request
-### Metadata (for FOCUS Staff or Maintainers)
-```
-Recommended Labels: use case, needs triage
-Suggested Assignee: @matt-cowsert
-```
-_Use this template to propose a new attribute, refinement, or data structure for the FOCUS Specification. Please do **not** include personal information (PII)._
-
----
-
-### 🏢 Submitter Context
-**Submitting Organization:**  
-`[Your company or organization name]`
-
-**Submitting on Behalf Of (Optional):**  
-`Avoid PII. Describe the role and organization only, e.g., "FinOps Lead at GlobalCloudCorp".`
-
----
-
 ### 🧠 Problem Statement
 Describe the problem, issue, or opportunity this feature addresses. Include practitioner quotes or real-world examples if available.
 
@@ -67,7 +48,7 @@ List one or more organizations who have requested or explicitly supported this r
 ### 🌐 FinOps Scope Alignment (Optional)
 Does this request align with one or more of the following [FinOps Scopes](https://www.finops.org/framework/scopes/)?
 
-- [ ] Public Cloud – AWS, Azure, GCP, etc.
+- [ ] Public Cloud – e.g., AWS, Azure, GCP, OCI
 - [ ] Software-as-a-Service (SaaS) – e.g., Salesforce, Snowflake
 - [ ] Data Center – on-prem compute and infrastructure
 - [ ] Licensing – subscription or usage-based licensing models *(under development)*
@@ -126,24 +107,3 @@ If your organization supports this request or has a similar use case:
   - A **brief explanation** of why this is important to you (e.g., use case, urgency)
 - FOCUS Staff & Maintainers will aggregate supporting orgs over time.
 
-_You can also submit support via [Google Form link] if you don’t have a GitHub account._
-
----
-
-### 🔄 Maintainers Only
-_To be filled in by the FOCUS Staff or Maintainers._
-
-**Theme Association:**  
-`[Optional grouping context]`
-
-**Work Item ID:**  
-`[Linked ID if applicable]`
-
-**Status (select one):**
-- `Submitted` — newly filed, awaiting triage
-- `Needs More Info` — request needs clarification or detail before evaluation
-- `Under Consideration for Next Release` — being actively evaluated for upcoming spec work
-- `In Consideration for Future Releases` — valid idea, may be revisited later
-- `In Development` — linked to a work item and in progress
-- `Implemented` — published in a formal release of the spec
-- `Closed (Not Pursuing)` — out of scope, infeasible, or superseded

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,3 +1,22 @@
+# FOCUS Feature Request
+### Metadata (for FOCUS Staff or Maintainers)
+```
+Recommended Labels: use case, needs triage
+Suggested Assignee: @matt-cowsert
+```
+_Use this template to propose a new attribute, refinement, or data structure for the FOCUS Specification. Please do **not** include personal information (PII)._
+
+---
+
+### 🏢 Submitter Context
+**Submitting Organization:**  
+`[Your company or organization name]`
+
+**Submitting on Behalf Of (Optional):**  
+`Avoid PII. Describe the role and organization only, e.g., "FinOps Lead at GlobalCloudCorp".`
+
+---
+
 ### 🧠 Problem Statement
 Describe the problem, issue, or opportunity this feature addresses. Include practitioner quotes or real-world examples if available.
 
@@ -48,7 +67,7 @@ List one or more organizations who have requested or explicitly supported this r
 ### 🌐 FinOps Scope Alignment (Optional)
 Does this request align with one or more of the following [FinOps Scopes](https://www.finops.org/framework/scopes/)?
 
-- [ ] Public Cloud – e.g., AWS, Azure, GCP, OCI
+- [ ] Public Cloud – AWS, Azure, GCP, etc.
 - [ ] Software-as-a-Service (SaaS) – e.g., Salesforce, Snowflake
 - [ ] Data Center – on-prem compute and infrastructure
 - [ ] Licensing – subscription or usage-based licensing models *(under development)*
@@ -107,3 +126,24 @@ If your organization supports this request or has a similar use case:
   - A **brief explanation** of why this is important to you (e.g., use case, urgency)
 - FOCUS Staff & Maintainers will aggregate supporting orgs over time.
 
+_You can also submit support via [Google Form link] if you don’t have a GitHub account._
+
+---
+
+### 🔄 Maintainers Only
+_To be filled in by the FOCUS Staff or Maintainers._
+
+**Theme Association:**  
+`[Optional grouping context]`
+
+**Work Item ID:**  
+`[Linked ID if applicable]`
+
+**Status (select one):**
+- `Submitted` — newly filed, awaiting triage
+- `Needs More Info` — request needs clarification or detail before evaluation
+- `Under Consideration for Next Release` — being actively evaluated for upcoming spec work
+- `In Consideration for Future Releases` — valid idea, may be revisited later
+- `In Development` — linked to a work item and in progress
+- `Implemented` — published in a formal release of the spec
+- `Closed (Not Pursuing)` — out of scope, infeasible, or superseded

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,22 +1,3 @@
-# FOCUS Feature Request
-### Metadata (for FOCUS Staff or Maintainers)
-```
-Recommended Labels: use case, needs triage
-Suggested Assignee: @matt-cowsert
-```
-_Use this template to propose a new attribute, refinement, or data structure for the FOCUS Specification. Please do **not** include personal information (PII)._
-
----
-
-### 🏢 Submitter Context
-**Submitting Organization:**  
-`[Your company or organization name]`
-
-**Submitting on Behalf Of (Optional):**  
-`Avoid PII. Describe the role and organization only, e.g., "FinOps Lead at GlobalCloudCorp".`
-
----
-
 ### 🧠 Problem Statement
 Describe the problem, issue, or opportunity this feature addresses. Include practitioner quotes or real-world examples if available.
 
@@ -67,7 +48,7 @@ List one or more organizations who have requested or explicitly supported this r
 ### 🌐 FinOps Scope Alignment (Optional)
 Does this request align with one or more of the following [FinOps Scopes](https://www.finops.org/framework/scopes/)?
 
-- [ ] Public Cloud – AWS, Azure, GCP, etc.
+- [ ] Public Cloud – e.g., AWS, Azure, GCP, OCI
 - [ ] Software-as-a-Service (SaaS) – e.g., Salesforce, Snowflake
 - [ ] Data Center – on-prem compute and infrastructure
 - [ ] Licensing – subscription or usage-based licensing models *(under development)*
@@ -125,25 +106,3 @@ If your organization supports this request or has a similar use case:
   - Your **organization**
   - A **brief explanation** of why this is important to you (e.g., use case, urgency)
 - FOCUS Staff & Maintainers will aggregate supporting orgs over time.
-
-_You can also submit support via [Google Form link] if you don’t have a GitHub account._
-
----
-
-### 🔄 Maintainers Only
-_To be filled in by the FOCUS Staff or Maintainers._
-
-**Theme Association:**  
-`[Optional grouping context]`
-
-**Work Item ID:**  
-`[Linked ID if applicable]`
-
-**Status (select one):**
-- `Submitted` — newly filed, awaiting triage
-- `Needs More Info` — request needs clarification or detail before evaluation
-- `Under Consideration for Next Release` — being actively evaluated for upcoming spec work
-- `Accepted in Scope` -- accepted for development in next release
-- `In Development` — linked to a work item and in progress
-- `Implemented` — published in a formal release of the spec
-- `Closed (Not Pursuing)` — out of scope, infeasible, or superseded

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,149 @@
+# FOCUS Feature Request
+### Metadata (for FOCUS Staff or Maintainers)
+```
+Recommended Labels: use case, needs triage
+Suggested Assignee: @matt-cowsert
+```
+_Use this template to propose a new attribute, refinement, or data structure for the FOCUS Specification. Please do **not** include personal information (PII)._
+
+---
+
+### 🏢 Submitter Context
+**Submitting Organization:**  
+`[Your company or organization name]`
+
+**Submitting on Behalf Of (Optional):**  
+`Avoid PII. Describe the role and organization only, e.g., "FinOps Lead at GlobalCloudCorp".`
+
+---
+
+### 🧠 Problem Statement
+Describe the problem, issue, or opportunity this feature addresses. Include practitioner quotes or real-world examples if available.
+
+```
+[Write your problem statement here.]
+```
+
+---
+
+### 🧪 Use Case
+Provide 1–2 sentences describing how this feature will be used in practice. You may skip this if it is already clearly explained in the problem statement. 
+
+**Example format:** `As a FinOps practitioner, I want to [behavior], so that [desired outcome].`
+
+```
+[Write your use case here.]
+```
+
+---
+
+### 🎯 Desired Outcome / Practitioner Impact
+Define the expected outcome, how success will be measured, and how this benefits FinOps practitioners.
+
+```
+[Write your objective and KPIs here.]
+```
+
+---
+
+### 📨 Type of Request
+How would you categorize this request? Select the option that best describes the novelty or source of the idea.
+
+- [ ] Refinement of an existing FOCUS attribute
+- [ ] Addition of a provider-supported field not yet in FOCUS
+- [ ] Net-new concept (not currently supported by providers or FOCUS)
+
+---
+
+### 🏛️ Organizations Requesting or Supporting This Feature
+List one or more organizations who have requested or explicitly supported this request (including your own, if applicable).
+
+```
+[e.g., BigCloud Inc, Acme Corp]
+```
+
+---
+
+### 🌐 FinOps Scope Alignment (Optional)
+Does this request align with one or more of the following [FinOps Scopes](https://www.finops.org/framework/scopes/)?
+
+- [ ] Public Cloud – AWS, Azure, GCP, etc.
+- [ ] Software-as-a-Service (SaaS) – e.g., Salesforce, Snowflake
+- [ ] Data Center – on-prem compute and infrastructure
+- [ ] Licensing – subscription or usage-based licensing models *(under development)*
+- [ ] AI – cost and usage for AI models and platforms *(under development)*
+- [ ] Custom – internal tooling, specialized infra *(under development)*
+
+---
+
+### 📊 Impacted Parties
+Which roles or systems would be directly affected by this request? (Check all that apply)
+
+- [ ] FinOps Practitioner – end users who analyze or act on the data
+- [ ] FOCUS Data Generator – providers generating output aligned to the spec
+- [ ] Vendor Supporting FOCUS – vendors or tools ingesting the spec or using the spec language in their UI
+- [ ] Other (please explain in comments)
+
+---
+
+### 🌫️ Level of Ambiguity
+How clearly defined is the request? Rate from 1 to 5:
+- 1 = very well-defined, low complexity
+- 3 = moderately scoped, some ambiguity
+- 5 = vague, high complexity or conceptual
+
+```
+[e.g., 2]
+```
+
+---
+
+### 📂 Supporting Documentation
+Include links to data samples, relevant PRs, GitHub discussions, or implementation references.
+
+> 🔐 **Reminder:** Please ensure any linked documents are accessible to maintainers and collaborators. If access is restricted, your request may be delayed.
+
+```
+[Paste links here.]
+```
+
+---
+
+### 🛠️ Proposed Solution / Approach
+Share initial ideas, constraints, and feasibility considerations.
+
+```
+[Your proposal goes here.]
+```
+
+---
+
+### 💬 Community Support (Add Your Voice)
+If your organization supports this request or has a similar use case:
+
+- Add a **comment** below including:
+  - Your **organization**
+  - A **brief explanation** of why this is important to you (e.g., use case, urgency)
+- FOCUS Staff & Maintainers will aggregate supporting orgs over time.
+
+_You can also submit support via [Google Form link] if you don’t have a GitHub account._
+
+---
+
+### 🔄 Maintainers Only
+_To be filled in by the FOCUS Staff or Maintainers._
+
+**Theme Association:**  
+`[Optional grouping context]`
+
+**Work Item ID:**  
+`[Linked ID if applicable]`
+
+**Status (select one):**
+- `Submitted` — newly filed, awaiting triage
+- `Needs More Info` — request needs clarification or detail before evaluation
+- `Under Consideration for Next Release` — being actively evaluated for upcoming spec work
+- `In Consideration for Future Releases` — valid idea, may be revisited later
+- `In Development` — linked to a work item and in progress
+- `Implemented` — published in a formal release of the spec
+- `Closed (Not Pursuing)` — out of scope, infeasible, or superseded

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -143,7 +143,7 @@ _To be filled in by the FOCUS Staff or Maintainers._
 - `Submitted` — newly filed, awaiting triage
 - `Needs More Info` — request needs clarification or detail before evaluation
 - `Under Consideration for Next Release` — being actively evaluated for upcoming spec work
-- `In Consideration for Future Releases` — valid idea, may be revisited later
+- `Accepted in Scope` -- accepted for development in next release
 - `In Development` — linked to a work item and in progress
 - `Implemented` — published in a formal release of the spec
 - `Closed (Not Pursuing)` — out of scope, infeasible, or superseded

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: "FOCUS Feature Request"
 description: Propose a new attribute, refinement, or data structure for the FOCUS Specification.
-title: "[Feature] <Short description>"
+title: "[FR] <Short description>"
 labels: ["use case", "needs triage"]
 assignees: ["matt-cowsert"]
 body:
@@ -71,7 +71,7 @@ body:
     attributes:
       label: FinOps Scope Alignment (Optional)
       options:
-        - label: Public Cloud – AWS, Azure, GCP, etc.
+        - label: Public Cloud – e.g., AWS, Azure, GCP
         - label: Software-as-a-Service (SaaS) – e.g., Salesforce, Snowflake
         - label: Data Center – on-prem compute and infrastructure
         - label: Licensing – subscription or usage-based licensing *(under development)*

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,140 @@
+name: "FOCUS Feature Request"
+description: Propose a new attribute, refinement, or data structure for the FOCUS Specification.
+title: "[Feature] <Short description>"
+labels: ["use case", "needs triage"]
+assignees: ["matt-cowsert"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        _Use this template to propose changes to the FOCUS Spec. Do not include personal information (PII)._
+
+        ⚠️ **If your suggestion is a minor correction or formatting fix, use the General Feedback template instead.**
+
+  - type: input
+    id: org
+    attributes:
+      label: Submitting Organization
+      placeholder: e.g., BigCloud Inc.
+    validations:
+      required: true
+
+  - type: input
+    id: behalf
+    attributes:
+      label: Submitting on Behalf Of (Optional)
+      description: Avoid PII. Provide role and org only.
+      placeholder: e.g., FinOps Lead at GlobalCloudCorp
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Describe the issue or opportunity. Include real-world quotes if available.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case (Optional)
+      description: Provide 1–2 sentences describing usage. Example: As a FinOps practitioner, I want to [...], so that [...].
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired Outcome / Practitioner Impact
+      description: Describe expected result, KPIs, and impact on FinOps users.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: request_type
+    attributes:
+      label: Type of Request
+      description: Select the best fit for the novelty of this request.
+      options:
+        - Refinement of an existing FOCUS attribute
+        - Addition of a provider-supported field not yet in FOCUS
+        - Net-new concept (not currently supported by providers or FOCUS)
+    validations:
+      required: true
+
+  - type: textarea
+    id: org_support
+    attributes:
+      label: Organizations Requesting or Supporting This Feature
+      description: List known supporting orgs.
+
+  - type: checkboxes
+    id: finops_scope
+    attributes:
+      label: FinOps Scope Alignment (Optional)
+      options:
+        - label: Public Cloud – AWS, Azure, GCP, etc.
+        - label: Software-as-a-Service (SaaS) – e.g., Salesforce, Snowflake
+        - label: Data Center – on-prem compute and infrastructure
+        - label: Licensing – subscription or usage-based licensing *(under development)*
+        - label: AI – cost and usage for AI models and platforms *(under development)*
+        - label: Custom – internal tooling, specialized infra *(under development)*
+
+  - type: checkboxes
+    id: impacted_parties
+    attributes:
+      label: Impacted Parties
+      description: Which roles or systems are affected?
+      options:
+        - label: FinOps Practitioner – end users who analyze or act on the data
+        - label: FOCUS Data Generator – providers generating aligned output
+        - label: Vendor Supporting FOCUS – tools or platforms using the spec
+        - label: Other (please explain in comments)
+
+  - type: input
+    id: ambiguity
+    attributes:
+      label: Level of Ambiguity (1–5)
+      description: 1 = well defined, 3 = moderately scoped, 5 = highly complex
+      placeholder: e.g., 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: docs
+    attributes:
+      label: Supporting Documentation
+      description: Include links to data, GitHub issues, or spec references. Ensure access is open.
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution / Approach
+      description: Initial ideas, feasibility notes, or references.
+
+  - type: markdown
+    attributes:
+      value: |
+        ### 💬 Community Support (Add Your Voice)
+        If your organization supports this request or has a similar use case:
+        - Comment below with your **organization** and a **brief explanation** of its relevance or urgency.
+        - FOCUS Staff & Maintainers will aggregate support.
+
+        _No GitHub account? Submit support via [Google Form link]._
+
+  - type: markdown
+    attributes:
+      value: |
+        ### 🔄 Maintainers Only
+        _To be completed by the FOCUS Staff or Maintainers._
+
+        **Theme Association:** [Optional grouping]
+
+        **Work Item ID:** [If applicable]
+
+        **Status (select one):**
+        - `Submitted` — awaiting triage
+        - `Needs More Info` — requires clarification
+        - `Under Consideration for Next Release` — being evaluated for current cycle
+        - `In Consideration for Future Releases` — valid idea, future potential
+        - `In Development` — work item in progress
+        - `Implemented` — included in spec release
+        - `Closed (Not Pursuing)` — not actionable or out of scope

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: "FOCUS Feature Request"
 description: Propose a new attribute, refinement, or data structure for the FOCUS Specification.
-title: "[Feature] <Short description>"
+title: "[FR]"
 labels: ["use case", "needs triage"]
 assignees: ["matt-cowsert"]
 body:
@@ -10,21 +10,6 @@ body:
         _Use this template to propose changes to the FOCUS Spec. Do not include personal information (PII)._
 
         ⚠️ **If your suggestion is a minor correction or formatting fix, use the General Feedback template instead.**
-
-  - type: input
-    id: org
-    attributes:
-      label: Submitting Organization
-      placeholder: e.g., BigCloud Inc.
-    validations:
-      required: true
-
-  - type: input
-    id: behalf
-    attributes:
-      label: Submitting on Behalf Of (Optional)
-      description: Avoid PII. Provide role and org only.
-      placeholder: e.g., FinOps Lead at GlobalCloudCorp
 
   - type: textarea
     id: problem
@@ -71,7 +56,7 @@ body:
     attributes:
       label: FinOps Scope Alignment (Optional)
       options:
-        - label: Public Cloud – AWS, Azure, GCP, etc.
+        - label: Public Cloud – e.g., AWS, Azure, GCP, OCI
         - label: Software-as-a-Service (SaaS) – e.g., Salesforce, Snowflake
         - label: Data Center – on-prem compute and infrastructure
         - label: Licensing – subscription or usage-based licensing *(under development)*
@@ -118,23 +103,5 @@ body:
         - Comment below with your **organization** and a **brief explanation** of its relevance or urgency.
         - FOCUS Staff & Maintainers will aggregate support.
 
-        _No GitHub account? Submit support via [Google Form link]._
 
-  - type: markdown
-    attributes:
-      value: |
-        ### 🔄 Maintainers Only
-        _To be completed by the FOCUS Staff or Maintainers._
-
-        **Theme Association:** [Optional grouping]
-
-        **Work Item ID:** [If applicable]
-
-        **Status (select one):**
-        - `Submitted` — awaiting triage
-        - `Needs More Info` — requires clarification
-        - `Under Consideration for Next Release` — being evaluated for current cycle
-        - `In Consideration for Future Releases` — valid idea, future potential
-        - `In Development` — work item in progress
-        - `Implemented` — included in spec release
-        - `Closed (Not Pursuing)` — not actionable or out of scope
+  

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -11,21 +11,6 @@ body:
 
         ⚠️ **If your suggestion is a minor correction or formatting fix, use the General Feedback template instead.**
 
-  - type: input
-    id: org
-    attributes:
-      label: Submitting Organization
-      placeholder: e.g., BigCloud Inc.
-    validations:
-      required: true
-
-  - type: input
-    id: behalf
-    attributes:
-      label: Submitting on Behalf Of (Optional)
-      description: Avoid PII. Provide role and org only.
-      placeholder: e.g., FinOps Lead at GlobalCloudCorp
-
   - type: textarea
     id: problem
     attributes:
@@ -64,14 +49,14 @@ body:
     id: org_support
     attributes:
       label: Organizations Requesting or Supporting This Feature
-      description: List known supporting orgs.
+      description: List one or more organizations who have requested or explicitly supported this request (including your own, if applicable).
 
   - type: checkboxes
     id: finops_scope
     attributes:
       label: FinOps Scope Alignment (Optional)
       options:
-        - label: Public Cloud – e.g., AWS, Azure, GCP
+        - label: Public Cloud – e.g., AWS, Azure, GCP, OCI
         - label: Software-as-a-Service (SaaS) – e.g., Salesforce, Snowflake
         - label: Data Center – on-prem compute and infrastructure
         - label: Licensing – subscription or usage-based licensing *(under development)*
@@ -117,24 +102,3 @@ body:
         If your organization supports this request or has a similar use case:
         - Comment below with your **organization** and a **brief explanation** of its relevance or urgency.
         - FOCUS Staff & Maintainers will aggregate support.
-
-        _No GitHub account? Submit support via [Google Form link]._
-
-  - type: markdown
-    attributes:
-      value: |
-        ### 🔄 Maintainers Only
-        _To be completed by the FOCUS Staff or Maintainers._
-
-        **Theme Association:** [Optional grouping]
-
-        **Work Item ID:** [If applicable]
-
-        **Status (select one):**
-        - `Submitted` — awaiting triage
-        - `Needs More Info` — requires clarification
-        - `Under Consideration for Next Release` — being evaluated for current cycle
-        - `In Consideration for Future Releases` — valid idea, future potential
-        - `In Development` — work item in progress
-        - `Implemented` — included in spec release
-        - `Closed (Not Pursuing)` — not actionable or out of scope

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: "FOCUS Feature Request"
 description: Propose a new attribute, refinement, or data structure for the FOCUS Specification.
-title: "[FR]"
+title: "[Feature] <Short description>"
 labels: ["use case", "needs triage"]
 assignees: ["matt-cowsert"]
 body:
@@ -10,6 +10,21 @@ body:
         _Use this template to propose changes to the FOCUS Spec. Do not include personal information (PII)._
 
         ⚠️ **If your suggestion is a minor correction or formatting fix, use the General Feedback template instead.**
+
+  - type: input
+    id: org
+    attributes:
+      label: Submitting Organization
+      placeholder: e.g., BigCloud Inc.
+    validations:
+      required: true
+
+  - type: input
+    id: behalf
+    attributes:
+      label: Submitting on Behalf Of (Optional)
+      description: Avoid PII. Provide role and org only.
+      placeholder: e.g., FinOps Lead at GlobalCloudCorp
 
   - type: textarea
     id: problem
@@ -56,7 +71,7 @@ body:
     attributes:
       label: FinOps Scope Alignment (Optional)
       options:
-        - label: Public Cloud – e.g., AWS, Azure, GCP, OCI
+        - label: Public Cloud – AWS, Azure, GCP, etc.
         - label: Software-as-a-Service (SaaS) – e.g., Salesforce, Snowflake
         - label: Data Center – on-prem compute and infrastructure
         - label: Licensing – subscription or usage-based licensing *(under development)*
@@ -103,5 +118,23 @@ body:
         - Comment below with your **organization** and a **brief explanation** of its relevance or urgency.
         - FOCUS Staff & Maintainers will aggregate support.
 
+        _No GitHub account? Submit support via [Google Form link]._
 
-  
+  - type: markdown
+    attributes:
+      value: |
+        ### 🔄 Maintainers Only
+        _To be completed by the FOCUS Staff or Maintainers._
+
+        **Theme Association:** [Optional grouping]
+
+        **Work Item ID:** [If applicable]
+
+        **Status (select one):**
+        - `Submitted` — awaiting triage
+        - `Needs More Info` — requires clarification
+        - `Under Consideration for Next Release` — being evaluated for current cycle
+        - `In Consideration for Future Releases` — valid idea, future potential
+        - `In Development` — work item in progress
+        - `Implemented` — included in spec release
+        - `Closed (Not Pursuing)` — not actionable or out of scope

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,78 +1,65 @@
-# Feedback on Unsupported Features, Use Cases, and Existing FOCUS Spec.
-description: Provide feedback on unsupported FinOps features, use cases, or scenarios, as well as on the existing FOCUS specification content. Avoid sharing proprietary information.  
-title: "[FEEDBACK]"  
-labels: ["feedback"]  
-assignees: [shawnalpay, jpradocueva]  
+## General Feedback
+
+### Metadata (for FOCUS Staff or Maintainers)
+```
+Recommended Labels: feedback, needs triage
+Suggested Assignee: @matt-cowsert
+```
+
+_Use this template to report small corrections or suggestions that improve clarity, accuracy, or consistency in the FOCUS Specification._
+
+> ⚠️ **Not sure which template to use?**
+> If your suggestion involves **adding, changing, or removing a data field, label, or structure**, please submit a [Feature Request](../feature_request_template.md) instead.
 
 ---
 
-### **Template Usage Notes**:
-1. All fields marked as **mandatory** [*] must be filled before submission.
-2. For **Supporting Data/Documentation**, ensure that linked files are accessible to relevant stakeholders.
+### 🏢 Submitting Organization (Optional)
+If you're submitting on behalf of an organization, list it here.
 
-## 1. **Problem statement**
-Describe the problem or opportunity that this issue addresses. Explain the context and why it needs resolution.
+```
+e.g., BigCloud Inc.
+```
 
-**Summary: [*]**  
-_Briefly describe the problem or opportunity that this issue addresses and why it needs resolution._  
-> **Placeholder:** Briefly describe the problem or opportunity that needs resolution.
+---
 
-**Which area does this issue relate to? [*]**  
-_Select one of the provided options:_  
-- A: Missing FinOps feature, use case, or scenario
-- B: Existing FOCUS specification content
-- C: Other
+### ✏️ Feedback Summary
+Describe the issue or suggestion. Be specific and actionable.
 
-**Detailed Description [*]:**  
-_Provide a detailed description of the problem or opportunity. Add context or any other relevant information that may help in addressing this issue._  
-> **Placeholder:** Provide a comprehensive description of the problem or opportunity, including context and any relevant details.
+```
+e.g., Typo in field `skuDescription` definition — should say "metered" instead of "metred".
+```
 
-## 2. **Use Cases**
-Please describe the use cases, whether FinOps-related or otherwise, that cannot be performed with the existing specification unless this issue is addressed.  Review https://focus.finops.org/use-cases/ for examples of existing use cases.
+---
 
-**What use cases, FinOps or others, can't be performed with the existing specification unless this issue is addressed? [*]**  
-_Provide detailed descriptions of the use cases that can't be performed unless this issue is addressed._  
-> **Placeholder:** List the specific use cases that can't be performed due to the existing limitations.
+### 📂 Type of Feedback
+Select the category that best describes your suggestion:
 
-## 3. **FinOps Personas**
-List the FinOps personas this issue relates to.
+- [ ] Typo or grammar  
+  _e.g., spelling, punctuation, or wording errors_
+- [ ] Clarity improvement  
+  _e.g., a confusing explanation, unclear table header, ambiguous instruction_
+- [ ] Field naming or label inconsistency  
+  _e.g., same concept referred to as `region` in one section and `location` in another_
+- [ ] Definition or behavior inconsistency  
+  _e.g., a metric described differently across two pages or files_
+- [ ] Minor correction (non-breaking)  
+  _e.g., formatting tweaks, broken links, outdated references_
+- [ ] Other (please explain)
 
-**Which FinOps personas does this issue relate to? [*]**  
-_Indicate which FinOps personas this issue relates to._  
-> **Placeholder:** e.g., Practitioner, Executive, Finance, Engineering, Procurement, Operations, etc.
+---
 
-## 4. **Providers**
-List provider groups or specific providers this issue relates to.
+### 📍 Affected Section or Field (Optional)
+If known, indicate where the issue appears (file path, section, or data field name).
 
-**Which provider groups or specific providers does this issue relate to? [*]**  
-_List provider groups (e.g., CSPs, SaaS) separated by semicolons (`;`), and specific providers within those groups separated by commas (`,`). If the issue applies to all providers within a group, you can simply specify the group name (e.g., 'All CSPs')._  
-> **Placeholder:** e.g., All CSPs; SaaS: Snowflake, Salesforce
+```
+e.g., /definitions/UsageRecord or spec.md#sku-capacity
+```
 
-## 5. **Criticality Scale**
-Indicate how critical this issue or feature request is for your organization using the scale provided below.
+---
 
-**On a scale of 1 - 4, how critical is this for your organization? [*]**  
-_Select one of the provided options:_  
-- 1: Critical - Blocks my organization from adopting FOCUS
-- 2: Important - Ideally resolved within the next 3-6 months
-- 3: Important - Ideally resolved within the next 6-12 months
-- 4: Suggestion - Resolution not urgent
+### 💬 Additional Notes (Optional)
+Include any extra context, examples, or links that may help maintainers understand the issue.
 
-## 6. **Objective**
-State the objective of this feedback. 
-- What outcome is expected?
-- Define how success will be measured (e.g., metrics and KPIs).
-
-**Objective:**  
-_Outline the expected outcome and success criteria._  
-> **Placeholder:** Outline the desired outcome and any metrics or KPIs to measure success.
-
-## 7. **Supporting Data/Documentation**
-
-**Data Examples:**  
-_Provide links to relevant sample data or attach data extracts that support your feedback. Ensure data is anonymized and does not include sensitive or proprietary information._  
-> **Placeholder:** Add link(s) to sample data or attach extracts that support your feedback.
-
-**Issues, PRs, or Other References:**  
-_Provide links to any relevant GitHub issues, pull requests, or other applicable references._  
-> **Placeholder:** Add links to any relevant GitHub issues, pull requests, or other applicable references.
+```
+Anything else worth sharing?
+```

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,158 +1,60 @@
-name: "Feature Request and Use Case Feedback"
-description: "Provide feedback on unsupported FinOps features, use cases, or scenarios, as well as on the existing FOCUS specification content. Avoid sharing proprietary information."
-title: "[FEEDBACK]: "
-labels:
-  - "feedback"
-type: "Feedback"
-assignees:
-  - "shawnalpay"
-  - "jpradocueva"
+name: "General Feedback"
+description: Suggest minor corrections, clarity improvements, or inconsistencies in the FOCUS Specification.
+title: "[Feedback] <Brief description of issue>"
+labels: ["feedback", "needs triage"]
+assignees: ["matt-cowsert"]
 body:
   - type: markdown
     attributes:
       value: |
-        ---
-        ### **Template Usage Notes**:
-        1. All fields marked as **mandatory** [*] must be filled before submission.
-        2. For **Supporting Data/Documentation**, ensure that linked files are accessible to relevant stakeholders.
+        _Use this form to report small corrections or suggestions that improve clarity, accuracy, or consistency._
 
+        ⚠️ **Feature-related suggestions should be submitted via the Feature Request template instead.**
 
-  - type: markdown
+  - type: input
+    id: organization
     attributes:
-      value: |
-        ## 1. **Problem statement**
-        Describe the problem or opportunity that this issue addresses. Explain the context and why it needs resolution.
-
-  - type: textarea
-    id: issue-summary
-    attributes:
-      label: Summary
-      description: "Briefly describe the problem or opportunity that this issue addresses and why it needs resolution."
-      placeholder: "Briefly describe the problem or opportunity that needs resolution."
-    validations:
-      required: true
-
-  - type: dropdown
-    id: issue-area
-    attributes:
-      label: Which area does this issue relate to?
-      description: "Select one of the provided options:"
-      options:
-        - 'A: Missing FinOps feature, use case, or scenario'
-        - 'B: Existing FOCUS specification content'
-        - 'C: Other'
-    validations:
-      required: true
-
-  - type: textarea
-    id: issue-description
-    attributes:
-      label: Detailed Description
-      description: "Provide a detailed description of the problem or opportunity. Add context or any other relevant information that may help in addressing this issue."
-      placeholder: "Provide a comprehensive description of the the problem or opportunity, including context and any relevant details"
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 2. **Use Cases**
-        Please describe the use cases, whether FinOps-related or otherwise, that cannot be performed with the existing specification unless this issue is addressed.  Review https://focus.finops.org/use-cases/ for examples of existing use cases.
-
-  - type: textarea
-    id: use_cases
-    attributes:
-      label: What use cases, FinOps or others, can't be performed with the existing specification unless this issue is addressed?
-      description: "Provide detailed descriptions of the use cases that can't be performed unless this issue is addressed."
-      placeholder: "List the specific use cases that can't be performed due to the existing limitations."
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 3. **FinOps Personas**
-        List the FinOps personas this issue relates to.
-
-  - type: textarea
-    id: finops-personas
-    attributes:
-      label: Which FinOps personas does this issue relate to?
-      description: "Indicate which FinOps personas this issue relates to."
-      placeholder: "e.g., Practitioner, Executive, Finance, Engineering, Procurement, Operations, etc."
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 4. **Providers**
-        List provider groups or specific providers this issue relates to.
-
-  - type: textarea
-    id: providers
-    attributes:
-      label: Which provider groups or specific providers does this issue relate to?
-      description: "List provider groups (e.g., CSPs, SaaS) separated by semicolons (`;`), and specific providers within those groups separated by commas (`,`). If the issue applies to all providers within a group, you can simply specify the group name (e.g., 'All CSPs')."
-      placeholder: "e.g., All CSPs; SaaS: Snowflake, Salesforce"
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 5. **Criticality Scale**
-        Indicate how critical this issue or feature request is for your organization using the scale provided below.
-
-  - type: dropdown
-    id: criticality-scale
-    attributes:
-      label: On a scale of 1 - 4, how critical is this for your organization? 
-      description: "Select one of the provided options."
-      options:
-        - '1: Blocks my organization from adopting FOCUS'
-        - '2: Important for adoption in the next 3-6 months'
-        - '3: Important for adoption in the next 6-12 months'
-        - '4: Suggestion, not planning to use FOCUS soon'
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 6. **Objective**
-        State the objective of this feedback. 
-        - What outcome is expected?
-        - Define how success will be measured (e.g., metrics and KPIs).
-
-  - type: textarea
-    id: objective
-    attributes:
-      label: "Objective"
-      description: "Outline the expected outcome and success criteria."
-      placeholder: "Outline the desired outcome and any metrics or KPIs to measure success."
-    validations:
-      required: false
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 7. **Supporting Data/Documentation**
-
-  - type: textarea
-    id: data_examples
-    attributes:
-      label: "Data Examples"
-      description: "Provide links to relevant sample data or attach data extracts that support your feedback. Ensure data is anonymized and does not include sensitive or proprietary information."
-      placeholder: "Add link(s) to sample data or attach extracts that support your feedback."
+      label: Submitting Organization (Optional)
+      description: If submitting on behalf of a company, enter it here.
+      placeholder: e.g., BigCloud Inc.
     validations:
       required: false
 
   - type: textarea
-    id: issue_pr_references
+    id: feedback_summary
     attributes:
-      label: "Issues, PRs, or Other References"
-      description: "Provide links to any relevant GitHub issues, pull requests, or other applicable references."
-      placeholder: "Add links to any relevant GitHub issues, pull requests, or other applicable references."
+      label: Feedback Summary
+      description: Be specific and actionable.
+      placeholder: e.g., Typo in field `skuDescription` — should say "metered" instead of "metred".
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: feedback_type
+    attributes:
+      label: Type of Feedback
+      description: Select the option that best describes your suggestion.
+      options:
+        - label: Typo or grammar
+        - label: Clarity improvement
+        - label: Field naming or label inconsistency
+        - label: Definition or behavior inconsistency
+        - label: Minor correction (non-breaking)
+        - label: Other
+
+  - type: input
+    id: affected_section
+    attributes:
+      label: Affected Section or Field (Optional)
+      placeholder: e.g., /definitions/UsageRecord or spec.md#sku-capacity
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_notes
+    attributes:
+      label: Additional Notes (Optional)
+      description: Add any extra context, examples, or links here.
+      placeholder: Anything else worth sharing?
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/work-item.md
+++ b/.github/ISSUE_TEMPLATE/work-item.md
@@ -1,6 +1,6 @@
-# Work Item Issue Template
+# Work Item
 description:
-title: "[Work_Item]"
+title: "[WI]"
 labels: ["work item"]
 assignees: [shawnalpay, jpradocueva]
 
@@ -15,7 +15,6 @@ assignees: [shawnalpay, jpradocueva]
 Describe the problem, issue, use case, or opportunity that this work item addresses.
 Include practitioner quotes illustrating real examples a) of questions being asked by practitioners and b) value unlocked by answering these questions, if available.
 - **What is the problem?**: Explain the context and why it needs resolution.
-- **What is the use case?**: Write the use case(s) this provides using the format "As a <FinOps persona> I want to <elaborate on the use case>" OR a 1 to 2 sentences detailing the use case(s).
 - **Impact**: Describe how the problem affects users, systems, or the project.
 
 Your input ...
@@ -48,13 +47,3 @@ Outline any proposed solutions, approaches, or potential paths forward.  Do not 
 - **Benchmarks**: Are there established best practices for solving this problem available to practitioners today (e.g. mappings from existing CSP exports that are widely used)?
 
 Your input ...
-
-## 6. **Epic or Theme Association**
-> This section will be completed by the Maintainers.
-> - **Epic**: [Epic Name]
-> - **Theme**: [Theme Name, if applicable]
-
-## 7. **Stakeholders** *
-List the main stakeholders for this issue.
-- **Primary Stakeholders**: [Name/Role]
-- **Other Involved Parties**: [Names/Roles]

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,6 +1,6 @@
-name: "Work Item Issue Template"
-description: "Template for creating new work item issues"
-title: "[Work_Item]"
+name: "Work Item"
+description: "Template for creating new Work Items"
+title: "[WI]"
 labels: 
   - "work item"
 type: "Work Item"
@@ -100,33 +100,3 @@ body:
       label: "Proposed Solution / Approach"
       description: "Outline potential solutions or approaches."
       placeholder: "Summarize the proposed solution or approach."
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 6. **Epic or Theme Association**
-        > This section will be completed by the Maintainers.
-        > - **Epic**: [Epic Name]
-        > - **Theme**: [Theme Name, if applicable]
-
-  - type: textarea
-    id: epic_theme
-    attributes:
-      label: "Epic or Theme Association"
-      description: "Provide potential epics or themes"
-      placeholder: "Provide the rational for the Epic or Theme."
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 7. **Stakeholders**
-        List the main stakeholders for this issue.
-        - **Primary Stakeholder**: [Name/Role]
-        - **Other Involved Parties**: [Names/Roles]
-
-  - type: textarea
-    id: stakeholders
-    attributes:
-      label: "Stakeholders"
-      description: "List the main stakeholders for this work item."
-      placeholder: "Provide names and roles of key stakeholders."

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -2,7 +2,7 @@ name: "Work Item"
 description: "Template for creating new Work Items"
 title: "[WI]"
 labels: 
-  - "work item"
+  - "work item", "needs backlog review"
 type: "Work Item"
 assignees: 
   - "shawnalpay"


### PR DESCRIPTION
This PR updates the existing GitHub Feedback issue template and adds a "Feature Request" issue template to improve contributor experience and ensure consistency:

- Simplified Feedback Template
- Feature Request Template
- Standardized field labels and formatting
- Clarified prompts and descriptions to guide requestors (e.g., general feedback vs. feature request)
- Improved alignment with the FOCUS feedback review process
- Adjusted labels and assignees for review and triage

These updates aim to streamline issue triage, reduce ambiguity, and ensure submitted requests are actionable.