### PR TITLE
Maintenance #997: Maintenance builds failing on error about upload artifact

### DIFF
--- a/.github/workflows/candidate_release.yml
+++ b/.github/workflows/candidate_release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           make STYLE=candidate_release BRANCH=candidate_release
       - name: Upload on failure
-        uses: actions/upload-artifact@4
+        uses: actions/upload-artifact@v4
         if: ${{ failure()}}
         with:
           name: spec.md

--- a/.github/workflows/candidate_release.yml
+++ b/.github/workflows/candidate_release.yml
@@ -27,13 +27,13 @@ jobs:
         run: |
           make STYLE=candidate_release BRANCH=candidate_release
       - name: Upload on failure
-        uses: actions/upload-artifact@4.5.0
+        uses: actions/upload-artifact@4
         if: ${{ failure()}}
         with:
           name: spec.md
           path: specification/spec.md
       - name: Upload Spec
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v4
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           make STYLE=main BRANCH=main
       - name: Upload on failure
-        uses: actions/upload-artifact@4
+        uses: actions/upload-artifact@v4
         if: ${{ failure()}}
         with:
           name: spec.md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,13 +27,13 @@ jobs:
         run: |
           make STYLE=main BRANCH=main
       - name: Upload on failure
-        uses: actions/upload-artifact@4.5.0
+        uses: actions/upload-artifact@4
         if: ${{ failure()}}
         with:
           name: spec.md
           path: specification/spec.md
       - name: Upload Spec
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v4
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -29,13 +29,13 @@ jobs:
         run: |
           make STYLE=working_draft BRANCH=${GITHUB_REF_NAME}
       - name: Upload on failure
-        uses: actions/upload-artifact@4.5.0
+        uses: actions/upload-artifact@4
         if: ${{ failure()}}
         with:
           name: spec.md
           path: specification/spec.md
       - name: Upload Spec
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v4
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           make STYLE=working_draft BRANCH=${GITHUB_REF_NAME}
       - name: Upload on failure
-        uses: actions/upload-artifact@4
+        uses: actions/upload-artifact@v4
         if: ${{ failure()}}
         with:
           name: spec.md


### PR DESCRIPTION
Fix for error: `Error: Missing download info for actions/upload-artifact@4.5.0`