### PR TITLE
FR #1090: New table demo - Option 2

### DIFF
--- a/specification/attributes/attributes.mdpp
+++ b/specification/attributes/attributes.mdpp
@@ -1,6 +1,6 @@
 # Attributes
 
-Attributes are requirements that apply across a [*FOCUS dataset*](#glossary:FOCUS-dataset) instead of an individual column level. Requirements on data content can include naming
+Attributes are requirements that apply across all FOCUS datasets ([*primary*](#glossary:FOCUS-dataset) and [*adjacent*](#glossary:FOCUS-adjacent-dataset)) instead of an individual column level. Requirements on data content can include naming
 conventions, data types, formatting standardizations, etc. Attributes may introduce high-level requirements
 for data granularity, recency, frequency, etc. Requirements defined in attributes are necessary for servicing
 [FinOps capabilities][FODOFC] accurately using a standard set of instructions regardless of the origin of the data.

--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -1,6 +1,6 @@
 # Columns
 
-The FOCUS specification defines a group of columns that provide qualitative values (such as dates, resource, and provider information) categorized as "dimensions" and quantitative values (numeric values) categorized as "metrics" that can be used for performing various [FinOps capabilities][FODOFC]. Metrics are commonly used for aggregations (sum, multiplication, averaging etc.) and statistical operations within the dataset. Dimensions are commonly used to categorize, filter, and reveal details in your data when combined with metrics. The Columns are presented in Alphabetical order.
+The FOCUS specification defines a group of columns that provide qualitative values (such as dates, resource, and provider information) categorized as "dimensions" and quantitative values (numeric values) categorized as "metrics" that can be used for performing various [FinOps capabilities][FODOFC]. Metrics are commonly used for aggregations (sum, multiplication, averaging etc.) and statistical operations within the dataset. Dimensions are commonly used to categorize, filter, and reveal details in your data when combined with metrics. The Columns are presented in Alphabetical order. Every column present in a FOCUS dataset shall correspond to a definition in this Columns section of the specification. 
 
 !INCLUDE "availabilityzone.md",1
 !INCLUDE "billedcost.md",1

--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -1,6 +1,6 @@
 # Columns
 
-The FOCUS specification defines a group of columns that provide qualitative values (such as dates, resource, and provider information) categorized as "dimensions" and quantitative values (numeric values) categorized as "metrics" that can be used for performing various [FinOps capabilities][FODOFC]. Metrics are commonly used for aggregations (sum, multiplication, averaging etc.) and statistical operations within the dataset. Dimensions are commonly used to categorize, filter, and reveal details in your data when combined with metrics. The Columns are presented in Alphabetical order. Every column present in a FOCUS dataset shall correspond to a definition in this Columns section of the specification. 
+The FOCUS specification defines a group of columns that provide qualitative values (such as dates, resource, and provider information) categorized as "dimensions" and quantitative values (numeric values) categorized as "metrics" that can be used for performing various [FinOps capabilities][FODOFC]. Metrics are commonly used for aggregations (sum, multiplication, averaging etc.) and statistical operations within the dataset. Dimensions are commonly used to categorize, filter, and reveal details in your data when combined with metrics. The Columns are presented in Alphabetical order. Every column present in a FOCUS dataset shall correspond to a definition in this Columns section of the specification.
 
 !INCLUDE "availabilityzone.md",1
 !INCLUDE "billedcost.md",1

--- a/specification/datasets/datasets.mdpp
+++ b/specification/datasets/datasets.mdpp
@@ -1,0 +1,5 @@
+# Datasets
+
+FOCUS defines many individual datasets made up of a selected set of Columns which abide by the Attributes outlined in this FOCUS Specification.
+
+!INCLUDE "focus.md",1

--- a/specification/datasets/focus.md
+++ b/specification/datasets/focus.md
@@ -1,0 +1,65 @@
+# FOCUS
+
+The FOCUS dataset is the primary dataset for FOCUS cost and usage data.
+
+## Dataset Columns
+
+| Column ID                                      | Column Name                          |
+|-----------------------------------------------|--------------------------------------|
+| [AvailabilityZone](#availabilityzone)         | Availability Zone                    |
+| [BilledCost](#billedcost)                     | Billed Cost                          |
+| [BillingAccountId](#billingaccountid)         | Billing Account ID                   |
+| [BillingAccountName](#billingaccountname)     | Billing Account Name                 |
+| [BillingAccountType](#billingaccounttype)     | Billing Account Type                 |
+| [BillingCurrency](#billingcurrency)           | Billing Currency                     |
+| [BillingPeriodEnd](#billingperiodend)         | Billing Period End                   |
+| [BillingPeriodStart](#billingperiodstart)     | Billing Period Start                 |
+| [CapacityReservationId](#capacityreservationid)| Capacity Reservation ID              |
+| [CapacityReservationStatus](#capacityreservationstatus) | Capacity Reservation Status     |
+| [ChargeCategory](#chargecategory)             | Charge Category                      |
+| [ChargeClass](#chargeclass)                   | Charge Class                         |
+| [ChargeDescription](#chargedescription)       | Charge Description                   |
+| [ChargeFrequency](#chargefrequency)           | Charge Frequency                     |
+| [ChargePeriodEnd](#chargeperiodend)           | Charge Period End                    |
+| [ChargePeriodStart](#chargeperiodstart)       | Charge Period Start                  |
+| [CommitmentDiscountCategory](#commitmentdiscountcategory) | Commitment Discount Category   |
+| [CommitmentDiscountId](#commitmentdiscountid) | Commitment Discount ID               |
+| [CommitmentDiscountName](#commitmentdiscountname) | Commitment Discount Name         |
+| [CommitmentDiscountQuantity](#commitmentdiscountquantity) | Commitment Discount Quantity   |
+| [CommitmentDiscountStatus](#commitmentdiscountstatus) | Commitment Discount Status     |
+| [CommitmentDiscountType](#commitmentdiscounttype) | Commitment Discount Type         |
+| [CommitmentDiscountUnit](#commitmentdiscountunit) | Commitment Discount Unit         |
+| [ConsumedQuantity](#consumedquantity)         | Consumed Quantity                    |
+| [ConsumedUnit](#consumedunit)                 | Consumed Unit                        |
+| [ContractedCost](#contractedcost)             | Contracted Cost                      |
+| [ContractedUnitPrice](#contractedunitprice)   | Contracted Unit Price                |
+| [EffectiveCost](#effectivecost)               | Effective Cost                       |
+| [InvoiceId](#invoiceid)                       | Invoice ID                           |
+| [InvoiceIssuer](#invoiceissuer)               | Invoice Issuer                       |
+| [ListCost](#listcost)                         | List Cost                            |
+| [ListUnitPrice](#listunitprice)               | List Unit Price                      |
+| [PricingCategory](#pricingcategory)           | Pricing Category                     |
+| [PricingCurrency](#pricingcurrency)           | Pricing Currency                     |
+| [PricingCurrencyContractedUnitPrice](#pricingcurrencycontractedunitprice) | Pricing Currency Contracted Unit Price |
+| [PricingCurrencyEffectiveCost](#pricingcurrencyeffectivecost) | Pricing Currency Effective Cost |
+| [PricingCurrencyListUnitPrice](#pricingcurrencylistunitprice) | Pricing Currency List Unit Price |
+| [PricingQuantity](#pricingquantity)           | Pricing Quantity                     |
+| [PricingUnit](#pricingunit)                   | Pricing Unit                         |
+| [ProviderName](#provider)                     | Provider                             |
+| [PublisherName](#publisher)                   | Publisher                            |
+| [RegionId](#regionid)                         | Region ID                            |
+| [RegionName](#regionname)                     | Region Name                          |
+| [ResourceId](#resourceid)                     | Resource ID                          |
+| [ResourceName](#resourcename)                 | Resource Name                        |
+| [ResourceType](#resourcetype)                 | Resource Type                        |
+| [ServiceCategory](#servicecategory)           | Service Category                     |
+| [ServiceName](#servicename)                   | Service Name                         |
+| [ServiceSubcategory](#servicesubcategory)     | Service Subcategory                  |
+| [SkuId](#skuid)                               | SKU ID                               |
+| [SkuMeter](#skumeter)                         | SKU Meter                            |
+| [SkuPriceDetails](#skupricedetails)           | SKU Price Details                    |
+| [SkuPriceId](#skupriceid)                     | SKU Price ID                         |
+| [SubAccountId](#subaccountid)                 | Sub Account ID                       |
+| [SubAccountName](#subaccountname)             | Sub Account Name                     |
+| [SubAccountType](#subaccounttype)             | Sub Account Type                     |
+| [Tags](#tags)                                 | Tags                                 |

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -94,7 +94,19 @@ An open-source specification that defines requirements for billing data.
 
 <a name="glossary:FOCUS-dataset"><b>FOCUS Dataset</b></a>
 
-A structured collection of cost and usage data that meets the [BCP14](https://tools.ietf.org/html/bcp14) criteria defined by FOCUS. In addition to FOCUS columns, the dataset should include custom provider columns (prefixed with `x_`) when these columns provide additional information not captured by the existing FOCUS columns. If introducing a custom column could result in splitting original charge records into multiple entries, the data generator is responsible for ensuring that the FOCUS dataset fully conforms to all aggregation-related requirements for metric columns, particularly those concerning costs and quantities.
+The FOCUS dataset is the primary dataset defined in the specification for capturing cost and usage information. It is one of several dataset types outlined in the FOCUS specification but serves as the central dataset for reporting normalized cost and usage records.
+
+A FOCUS dataset is a structured collection of records that conforms to the BCP14 criteria established by FOCUS. All columns included must be defined in the FOCUS Columns section of the specification.
+
+In addition to these standardized columns, data generators may include custom provider-specific columns (prefixed with x_) where additional context is needed beyond what is captured in the defined FOCUS columns. If such custom columns introduce record-splitting (i.e., a single original charge results in multiple rows), the data generator is responsible for ensuring that all cost and quantity metrics still meet the aggregation and consistency rules required by the specification.
+
+<a name="glossary:FOCUS-adjactent-dataset"><b>FOCUS Adjacent Dataset</b></a>
+
+A FOCUS Adjacent Dataset is any dataset defined within the FOCUS specification that supports or augments the primary FOCUS dataset, but does not itself contain normalized cost and usage records.
+
+These datasets are designed to provide additional context, metadata, mapping, or enrichment information that enhances the interpretability or completeness of the FOCUS dataset. Examples include datasets for pricing reference data, commitment discount mapping, or region definitions.
+
+FOCUS Adjacent Datasets follow the same principles of structure and consistency defined by the specification, including column naming conventions and formatting expectations.
 
 <a name="glossary:inclusivestartbound"><b>Inclusive Start Bound</b></a>
 

--- a/specification/spec.mdpp
+++ b/specification/spec.mdpp
@@ -33,6 +33,8 @@ FOCUS is an open specification for billing data. It defines a common schema for 
 
 <div style="page-break-after: always"></div>
 
+!INCLUDE "datasets/datasets.mdpp",1
+
 !INCLUDE "columns/columns.mdpp",1
 
 !INCLUDE "attributes/attributes.mdpp",1


### PR DESCRIPTION
This is (Option 2) in the proposal for including adjacent datasets into FOCUS, which defines tables as a collection of columns from the column definitions inside the FOCUS document, leaving a single column dictionary and a selection of dataset definitions in the FOCUS specification.
