### PR TITLE
FR #962: Requiring Unit Prices when SkuPriceId is not null

### DIFF
--- a/specification/datasets/cost_and_usage/columns/contractedunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/contractedunitprice.md
@@ -11,6 +11,7 @@ The ContractedUnitPrice column adheres to the following requirements:
 * ContractedUnitPrice nullability is defined as follows:
   * ContractedUnitPrice MUST be null when [SkuPriceId](#skupriceid) is null.
   * ContractedUnitPrice MUST be null when [ChargeCategory](#chargecategory) is "Tax".
+  * ContractedUnitPrice MUST NOT be null when [SkuPriceId](#skupriceid) is not null.
   * ContractedUnitPrice MUST NOT be null when ChargeCategory is "Usage" or "Purchase" and [ChargeClass](#chargeclass) is not "Correction".
   * ContractedUnitPrice MAY be null in all other cases.
 * When ContractedUnitPrice is not null, ContractedUnitPrice adheres to the following additional requirements:

--- a/specification/datasets/cost_and_usage/columns/listunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/listunitprice.md
@@ -10,6 +10,7 @@ The ListUnitPrice column adheres to the following requirements:
 * ListUnitPrice nullability is defined as follows:
   * ListUnitPrice MUST be null when [SkuPriceId](#skupriceid) is null.
   * ListUnitPrice MUST be null when [ChargeCategory](#chargecategory) is "Tax".
+  * ListUnitPrice MUST NOT be null when [SkuPriceId](#skupriceid) is not null.
   * ListUnitPrice MUST NOT be null when ChargeCategory is "Usage" or "Purchase" and [ChargeClass](#chargeclass) is not "Correction".
   * ListUnitPrice MAY be null in all other cases.
 * When ListUnitPrice is not null, ListUnitPrice adheres to the following additional requirements:

--- a/specification/datasets/cost_and_usage/columns/pricingcurrencycontractedunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcurrencycontractedunitprice.md
@@ -13,6 +13,7 @@ The PricingCurrencyContractedUnitPrice column adheres to the following requireme
 * PricingCurrencyContractedUnitPrice nullability is defined as follows:
   * PricingCurrencyContractedUnitPrice MUST be null when [SkuPriceId](#skupriceid) is null.
   * PricingCurrencyContractedUnitPrice MUST be null when [ChargeCategory](#chargecategory) is "Tax".
+  * PricingCurrencyContractedUnitPrice MUST NOT be null when [SkuPriceId](#skupriceid) is not null.
   * PricingCurrencyContractedUnitPrice MUST NOT be null when ChargeCategory is "Usage" or "Purchase" and [ChargeClass](#chargeclass) is not "Correction".
   * PricingCurrencyContractedUnitPrice MAY be null in all other cases.
 * When PricingCurrencyContractedUnitPrice is not null, PricingCurrencyContractedUnitPrice adheres to the following additional requirements:

--- a/specification/datasets/cost_and_usage/columns/pricingcurrencylistunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcurrencylistunitprice.md
@@ -13,6 +13,7 @@ The PricingCurrencyListUnitPrice column adheres to the following requirements:
 * PricingCurrencyListUnitPrice nullability is defined as follows:
   * PricingCurrencyListUnitPrice MUST be null when [ChargeCategory](#chargecategory) is "Tax".
   * PricingCurrencyListUnitPrice MUST be null when [SkuPriceId](#skupriceid) is null.
+  * PricingCurrencyListUnitPrice MUST NOT be null when [SkuPriceId](#skupriceid) is not null.
   * PricingCurrencyListUnitPrice MUST NOT be null when ChargeCategory is "Usage" or "Purchase" and [ChargeClass](#chargeclass) is not "Correction".
   * PricingCurrencyListUnitPrice MAY be null in all other cases.
 * When PricingCurrencyListUnitPrice is not null, PricingCurrencyListUnitPrice adheres to the following additional requirements:


### PR DESCRIPTION
Note: This PR addresses part of the scope defined in FR https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/962.

---

A non-null SkuPriceId implies that pricing information is available, so corresponding unit prices must also be explicitly provided to ensure data consistency and completeness.

Unit Price columns in FOCUS version 1.2:

- Contracted Unit Price
- List Unit Price
- Pricing Currency Contracted Unit Price
- Pricing Currency List Unit Price

This PR introduces an additional normative requirement for Unit Price columns in cases where SkuPriceId is provided.

To achieve this, we suggest updating the nullability section of each relevant column as follows:


> - `<UnitPriceMetricId>` MUST be present in a FOCUS dataset when the provider ...
> - ...
> - `<UnitPriceMetricId>` nullability is defined as follows:  
>   - ...
>   - `<UnitPriceMetricId>` **MUST NOT be null** when `SkuPriceId` is not null. ***<-- NEW***
>   - ...

***Note:** Requirements related to Pricing Units remain unchanged. This rule only applies if the relevant unit price column is already included in the dataset.*