### PR TITLE
AI #1311: Add Contract columns to Cost and Usage dataset

### DIFF
--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -29,6 +29,7 @@ The FOCUS specification defines a group of columns that provide qualitative valu
 !INCLUDE "consumedunit.md",1
 !INCLUDE "contractedcost.md",1
 !INCLUDE "contractedunitprice.md",1
+!INCLUDE "contractid.md",1
 !INCLUDE "effectivecost.md",1
 !INCLUDE "invoiceid.md",1
 !INCLUDE "invoiceissuer.md",1

--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -28,6 +28,7 @@ The FOCUS specification defines a group of columns that provide qualitative valu
 !INCLUDE "consumedquantity.md",1
 !INCLUDE "consumedunit.md",1
 !INCLUDE "contractappliedcost.md",1
+!INCLUDE "contractappliedquantity.md",1
 !INCLUDE "contractedcost.md",1
 !INCLUDE "contractedunitprice.md",1
 !INCLUDE "contractid.md",1

--- a/specification/columns/columns.mdpp
+++ b/specification/columns/columns.mdpp
@@ -27,6 +27,7 @@ The FOCUS specification defines a group of columns that provide qualitative valu
 !INCLUDE "commitmentdiscountunit.md",1
 !INCLUDE "consumedquantity.md",1
 !INCLUDE "consumedunit.md",1
+!INCLUDE "contractappliedcost.md",1
 !INCLUDE "contractedcost.md",1
 !INCLUDE "contractedunitprice.md",1
 !INCLUDE "contractid.md",1

--- a/specification/columns/contractappliedcost.md
+++ b/specification/columns/contractappliedcost.md
@@ -1,0 +1,39 @@
+# Contract Applied Cost
+
+Contract Applied Cost represents the cost of the charge applied to the contract.  Contract Applied Cost is applied to the contract via [Contract ID](#contractid).  Contract Applied Cost is commonly used for monitoring the progress towards fulfilling contractual commitments that facilitate discounts for [*resources*](#glossary:resource) or [*services*](#glossary:service) as negotiated between a provider and a customer.
+
+The ContractAppliedCost column adheres to the following requirements:
+
+* ContractAppliedCost MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports *negotiated discounts*.
+* ContractAppliedCost MUST be of type Decimal.
+* ContractAppliedCost MUST conform to [NumericFormat](#numericformat) requirements.
+* ContractAppliedCost MUST NOT be null when [Contract ID](#contractid) is not null.
+* ContractAppliedCost MUST be a valid decimal value.
+* ContractAppliedCost MUST be denominated in the BillingCurrency.
+
+## Column ID
+
+ContractAppliedCost
+
+## Display Name
+
+Contract Applied Cost
+
+## Description
+
+Cost calculated by multiplying *contracted unit price* and the corresponding Pricing Quantity.
+
+## Content Constraints
+
+| Constraint      | Value                   |
+|:----------------|:------------------------|
+| Column type     | Metric                  |
+| Feature level   | Conditional             |
+| Allows nulls    | True                    |
+| Data type       | Decimal                 |
+| Value format    | [Numeric Format](#numericformat) |
+| Number range    | Any valid decimal value |
+
+## Introduced (version)
+
+1.3

--- a/specification/columns/contractappliedcost.md
+++ b/specification/columns/contractappliedcost.md
@@ -7,7 +7,9 @@ The ContractAppliedCost column adheres to the following requirements:
 * ContractAppliedCost MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports *negotiated discounts*.
 * ContractAppliedCost MUST be of type Decimal.
 * ContractAppliedCost MUST conform to [NumericFormat](#numericformat) requirements.
-* ContractAppliedCost MUST NOT be null when [Contract ID](#contractid) is not null.
+* ContractAppliedCost nullability is defined as follows:
+  * ContractAppliedCost MUST be null when [Contract ID](#contractid) is null.
+  * ContractAppliedCost MUST NOT be null when [Contract ID](#contractid) is not null.
 * ContractAppliedCost MUST be a valid decimal value.
 * ContractAppliedCost MUST be denominated in the BillingCurrency.
 
@@ -21,7 +23,7 @@ Contract Applied Cost
 
 ## Description
 
-Cost calculated by multiplying *contracted unit price* and the corresponding Pricing Quantity.
+The cost of the *charge* applied to the contract.
 
 ## Content Constraints
 

--- a/specification/columns/contractappliedquantity.md
+++ b/specification/columns/contractappliedquantity.md
@@ -1,0 +1,40 @@
+# Contract Applied Quantity
+
+Contract Applied Quantity represents the quantity of the charge applied to the contract.  Contract Applied Quantity is applied to the contract via [Contract ID](#contractid).  Contract Applied Quantity is commonly used for monitoring the progress towards fulfilling contractual commitments that facilitate discounts for [*resources*](#glossary:resource) or [*services*](#glossary:service) as negotiated between a provider and a customer.
+
+The ContractAppliedQuantity column adheres to the following requirements:
+
+* ContractAppliedQuantity MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports *negotiated discounts*.
+* ContractAppliedQuantity MUST be of type Decimal.
+* ContractAppliedQuantity MUST conform to [NumericFormat](#numericformat) requirements.
+* ContractAppliedQuantity nullability is defined as follows:
+  * ContractAppliedQuantity MUST be null when [Contract ID](#contractid) is null.
+  * ContractAppliedQuantity MUST NOT be null when [Contract ID](#contractid) is not null.
+* ContractAppliedQuantity MUST be a valid decimal value.
+
+## Column ID
+
+ContractAppliedQuantity
+
+## Display Name
+
+Contract Applied Quantity
+
+## Description
+
+The quantity of the *charge* applied to the contract.
+
+## Content Constraints
+
+| Constraint      | Value                   |
+|:----------------|:------------------------|
+| Column type     | Metric                  |
+| Feature level   | Conditional             |
+| Allows nulls    | True                    |
+| Data type       | Decimal                 |
+| Value format    | [Numeric Format](#numericformat) |
+| Number range    | Any valid decimal value |
+
+## Introduced (version)
+
+1.3

--- a/specification/columns/contractid.md
+++ b/specification/columns/contractid.md
@@ -1,6 +1,6 @@
 # Contract ID
 
-A Contract ID is a provider-assigned identifier for a contract describing the terms of one or more [*negotiated discounts*](#glossary:negotiated-discount) between a provider and a customer. Such discounts are typically the result of a customer committing to a certain amount of spend or usage over an agreed period of time.
+A Contract ID is a provider-assigned identifier for a contract describing the agreed terms of one or more [*negotiated discounts*](#glossary:negotiated-discount) between a provider and a customer. Such discounts are typically the result of a customer committing to a certain amount of spend or usage over an agreed period of time.
 
 The ContractId column adheres to the following requirements:
 

--- a/specification/columns/contractid.md
+++ b/specification/columns/contractid.md
@@ -1,6 +1,6 @@
 # Contract ID
 
-A Contract ID is a provider-assigned identifier for a contract describing the agreed terms of one or more [*negotiated discounts*](#glossary:negotiated-discount) between a provider and a customer. Such discounts are typically the result of a customer committing to a certain amount of spend or usage over an agreed period of time.
+A Contract ID is a provider-assigned identifier for a contract describing the agreed terms between a provider and a customer.  Contracts often describe one or more [*negotiated discounts*](#glossary:negotiated-discount). Contracts can include commitment to a certain amount of spend or usage over an agreed period of time.
 
 The ContractId column adheres to the following requirements:
 

--- a/specification/columns/contractid.md
+++ b/specification/columns/contractid.md
@@ -1,0 +1,41 @@
+# Contract ID
+
+A Contract ID is a provider-assigned identifier for a contract describing the terms of one or more [*negotiated discounts*](#glossary:negotiated-discount) between a provider and a customer. Such discounts are typically the result of a customer committing to a certain amount of spend or usage over an agreed period of time.
+
+The ContractId column adheres to the following requirements:
+
+* ContractId MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports *negotiated discounts*.
+* ContractId MUST be of type String.
+* ContractId MUST conform to [StringHandling](#stringhandling) requirements.
+* ContractId nullability is defined as follows:
+  * ContractId MUST be null when a [*charge*](#glossary:charge) is not related to a *negotiated discount*.
+  * ContractId MUST NOT be null when a *charge* is related to a *negotiated discount*.
+* When ContractId is not null, ContractId adheres to the following additional requirements:
+  * ContractId MUST be a unique identifier within the provider.
+  * ContractId SHOULD be a fully-qualified identifier.
+
+## Column ID
+
+ContractId
+
+## Display Name
+
+Contract ID
+
+## Description
+
+The identifier assigned to a contract describing the terms of one or more *negotiated discounts* between the provider and the customer.
+
+## Content constraints
+
+|    Constraint   |      Value       |
+|:----------------|:-----------------|
+| Column type     | Dimension        |
+| Feature level   | Conditional      |
+| Allows nulls    | True             |
+| Data type       | String           |
+| Value format    | \<not specified> |
+
+## Introduced (version)
+
+1.3


### PR DESCRIPTION
This PR adds the following columns to the Cost and Usage dataset:

 * `Contract ID`: the unique identifier of the contract representing one or more commitments associated with discounts negotiated between the provider and the customer
 * `Contract Applied Cost`: the cost of the charge applied to the contract
 * `Contract Applied Quantity`: the quantity of the charge applied to the contract


The scope of FR #1070 also includes the creation of a separate dataset representing Contracts.  That shall be surfaced as a separate pull request, as it is not yet clear whether we shall proceed with the addition of multiple datasets in FOCUS 1.3.  The full vision is described in [this spreadsheet](https://docs.google.com/spreadsheets/d/1l42uPa_XhHTgnaOW1tFHQBGL7dEIss3-onsSuY5qVuc/edit?gid=1641662850#gid=1641662850).