### PR TITLE
AI #1278: Create Conformance Rules for ChargePeriodEnd

### DIFF
--- a/specification/conformance/conformance_datasets.json
+++ b/specification/conformance/conformance_datasets.json
@@ -8,6 +8,7 @@
         "BillingAccountType-C-000-M",
         "BillingPeriodStart-C-000-M",
         "BillingPeriodEnd-C-000-M",
+        "ChargePeriodEnd-C-000-M",
         "ListUnitPrice-C-000-C"
       ]
     }

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -9,7 +9,7 @@
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "",
-            "Keyword": "",
+            "Keyword": "MUST",
             "Requirement": {
               "CheckFunction": "AND",
               "Items": [
@@ -35,11 +35,11 @@
                }
               ]
             },
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
     },
     "ChargePeriodEnd-C-001-M": {
@@ -54,15 +54,15 @@
             "MustSatisfy": "ChargePeriodEnd MUST be present in a FOCUS dataset.",
             "Keyword": "MUST",
             "Requirement": {},
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
     },
     "ChargePeriodEnd-C-002-M": {
-        "Function": "DataType",
+        "Function": "Format",
         "Reference": "Charge Period End",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
@@ -73,11 +73,11 @@
             "MustSatisfy": "ChargePeriodEnd MUST be of type Data/DateTime.",
             "Keyword": "MUST",
             "Requirement": {},
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
     },
     "ChargePeriodEnd-C-003-M": {
@@ -90,20 +90,20 @@
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodEnd MUST conform to DateTimeFormat requirements.",
-            "Keyword": "",
+            "Keyword": "MUST",
             "Requirement": {
-              "CheckFunction": "DateTimeFormat:CR",
+              "CheckFunction": "FormatDateTime",
               "ColumnName": "ChargePeriodEnd"
             },
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
     },
     "ChargePeriodEnd-C-004-M": {
-        "Function": "NullabilityRules",
+        "Function": "Validation",
         "Reference": "Charge Period End",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
@@ -112,13 +112,16 @@
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodEnd MUST NOT be null",
-            "Keyword": "MUST NOT",
-            "Requirement": {},
-            "Condition":"All Rows",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "CheckNotValue",
+                "ColumnName": "ChargePeriodEnd"
+            },
+            "Condition":{},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": "Cross-column reference: DateTimeFormat"
     },
   "ChargePeriodEnd-C-005-M": {
@@ -133,11 +136,11 @@
             "MustSatisfy": "ChargePeriodEnd MUST be the exclusive end bound of the effective period of the charge.",
             "Keyword": "MUST",
             "Requirement": {},
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
-    },  
+    }  
 }

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -59,7 +59,7 @@
     },
     "ChargePeriodEnd-C-002-M": {
         "Function": "Format",
-        "Reference": "Charge Period End",
+        "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
             "All Rows"

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -100,9 +100,7 @@
         "Function": "Validation",
         "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodEnd MUST NOT be null",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -13,11 +13,26 @@
             "Requirement": {
               "CheckFunction": "AND",
               "Items": [
-                "ChargePeriodEnd-D-001-M",
-                "ChargePeriodEnd-C-002-M",
-                "ChargePeriodEnd-C-003-M",
-                "ChargePeriodEnd-C-004-M",
-                "ChargePeriodEnd-C-005-M"
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-D-001-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-002-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-003-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-004-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-005-M"
+               }
               ]
             },
             "Condition":"All Rows",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -114,7 +114,7 @@
         },
         "CRVersionIntroduced": "1.2",
         "Status": "Active",
-        "Notes": "Cross-column reference: DateTimeFormat"
+        "Notes": ""
     },
   "ChargePeriodEnd-C-005-M": {
         "Function": "Validation",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -1,7 +1,7 @@
 {
     "ChargePeriodEnd-C-000-M": {
         "Function": "Composite",
-        "Reference": "Charge Period End",
+        "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
             "All Rows"

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -120,9 +120,7 @@
         "Function": "Validation",
         "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodEnd MUST be the exclusive end bound of the effective period of the charge.",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -98,7 +98,7 @@
     },
     "ChargePeriodEnd-C-004-M": {
         "Function": "Validation",
-        "Reference": "Charge Period End",
+        "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
             "All Rows"

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -118,7 +118,7 @@
     },
   "ChargePeriodEnd-C-005-M": {
         "Function": "Validation",
-        "Reference": "Charge Period End",
+        "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
             "All Rows"

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -80,9 +80,7 @@
         "Function": "Format",
         "Reference": "Charge Period End",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodEnd MUST conform to DateTimeFormat requirements.",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -42,7 +42,7 @@
     },
     "ChargePeriodEnd-C-001-M": {
         "Function": "Presence",
-        "Reference": "Charge Period End",
+        "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
         "ApplicabilityCriteria": [],
         "Type": "Static",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -44,9 +44,7 @@
         "Function": "Presence",
         "Reference": "Charge Period End",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "Dataset includes ChargePeriodEnd column"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodEnd MUST be present in a FOCUS dataset.",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -78,7 +78,7 @@
     },
     "ChargePeriodEnd-C-003-M": {
         "Function": "Format",
-        "Reference": "Charge Period End",
+        "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
         "ApplicabilityCriteria": [],
         "Type": "Static",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -3,9 +3,7 @@
         "Function": "Composite",
         "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -1,0 +1,128 @@
+{
+    "ChargePeriodEnd-C-000-M": {
+        "Function": "Composite",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "",
+            "Keyword": "",
+            "Requirement": {
+              "CheckFunction": "AND",
+              "Items": [
+                "ChargePeriodEnd-D-001-M",
+                "ChargePeriodEnd-C-002-M",
+                "ChargePeriodEnd-C-003-M",
+                "ChargePeriodEnd-C-004-M",
+                "ChargePeriodEnd-C-005-M"
+              ]
+            },
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-001-M": {
+        "Function": "Presence",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "Dataset includes ChargePeriodEnd column"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST be present in a FOCUS dataset.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-002-M": {
+        "Function": "DataType",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST be of type Data/DateTime.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-003-M": {
+        "Function": "Format",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST conform to DateTimeFormat requirements.",
+            "Keyword": "",
+            "Requirement": {
+              "CheckFunction": "DateTimeFormat:CR",
+              "ColumnName": "ChargePeriodEnd"
+            },
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-004-M": {
+        "Function": "NullabilityRules",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST NOT be null",
+            "Keyword": "MUST NOT",
+            "Requirement": {},
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": "Cross-column reference: DateTimeFormat"
+    },
+  "ChargePeriodEnd-C-005-M": {
+        "Function": "Validation",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST be the exclusive end bound of the effective period of the charge.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },  
+}


### PR DESCRIPTION
### Summary: PR for Conformance definition for column: chargeperiodend #1278 

## Changes Made

- Updated json values for the chargeperiodend file based on the chargeperiodend_cr.md file
- Added the json output to the ../conformance_rules/columns/ directory
- Updated the conformance_datasets.json file based on alphabetic ordering. 

## Notes:
- Items in the json structure are not in the same order as seen in the template files. 
- Based on the initial table, it is not clear what the `dependencies` field is referencing or expecting. 

