### PR TITLE
AI #1271: Create conformance rules for ContractedCost column

### DIFF
--- a/guidelines/writing-conformance-guidelines.md
+++ b/guidelines/writing-conformance-guidelines.md
@@ -319,7 +319,7 @@ The second phase of conversion is to take the table created in Stage 1 and creat
 - Write your rules into this file based on the rules in the Stage 1 table from the AI ticket (See: [ConformanceRule Templates](#conformancerule-templates) for helpers)
 - If you need to add new ApplicabilityCriteria add them to `applicability_criteria.json` avoiding duplication
 - If you need to add new CheckFunctions add them to `check_functions.json` avoiding duplication
-- Add your top level conformance rule entry into the relevant Dataset entries in the `conformance_datasets.json` file
+- Add your top level conformance rule entry into the relevant Dataset entries in the `conformance_datasets.json` file, ensuring column references are listed in alphabetical order
 - Commit your changes to your branch and then move onto raising the PR section
 If you need assistance reach out to Mike Fuller in the FOCUS slack
 

--- a/specification/conformance/conformance_rules/columns/contractedcost.json
+++ b/specification/conformance/conformance_rules/columns/contractedcost.json
@@ -1,0 +1,345 @@
+{
+  "ContractedCost-C-000-M": {
+    "Function": "Composite",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "Root composite rule",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "All ContractedCost rules MUST be enforced",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-D-001-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-002-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-003-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-004-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-005-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-006-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-007-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-010-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-011-C"
+          }
+        ]
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "ContractedCost-D-001-M": {
+    "Function": "Presence",
+    "Reference": "ContractedCost",
+    "EntityType": "Dataset",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ContractedCost MUST be present in a FOCUS dataset",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "ColumnPresent",
+        "ColumnName": "ContractedCost"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "ContractedCost-C-002-M": {
+    "Function": "Type",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ContractedCost MUST be of type Decimal",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "TypeDecimal",
+        "ColumnName": "ContractedCost"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "ContractedCost-C-003-M": {
+    "Function": "Format",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "Cross-attribute reference: NumericFormat",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ContractedCost MUST conform to NumericFormat requirements",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "FormatNumeric",
+        "ColumnName": "ContractedCost"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "ContractedCost-C-004-M": {
+    "Function": "Validation",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ContractedCost MUST NOT be null",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "CheckNotValue",
+        "ColumnName": "ContractedCost",
+        "Value": null
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "ContractedCost-C-005-M": {
+    "Function": "Validation",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ContractedCost MUST be a valid decimal value",
+      "Keyword": "MUST",
+      "Requirement": {},
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "ContractedCost-C-006-M": {
+    "Function": "Validation",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "Cross-column reference: BillingCurrency",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "ContractedCost MUST be denominated in the BillingCurrency",
+      "Keyword": "MUST",
+      "Requirement": {},
+      "Condition": {},
+      "Dependencies": [
+        "BillingCurrency-C-000-M"
+      ]
+    }
+  },
+  "ContractedCost-C-007-C": {
+    "Function": "Composite",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "Lead-in composite",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "When ContractedUnitPrice is null, ContractedCost adheres to the following additional requirements",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-008-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ContractedCost-C-009-C"
+          }
+        ]
+      },
+      "Condition": {
+        "CheckFunction": "CheckValue",
+        "ColumnName": "ContractedUnitPrice",
+        "Value": null
+      },
+      "Dependencies": [
+        "ContractedUnitPrice-C-000-M"
+      ]
+    }
+  },
+  "ContractedCost-C-008-C": {
+    "Function": "Validation",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "Cross-row dependency: requires identifying related charges and using their ContractedCost",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "ContractedCost of a charge calculated based on other charges (e.g., when the ChargeCategory is \"Tax\") MUST be calculated based on the ContractedCost of those related charges",
+      "Keyword": "MUST",
+      "Requirement": {},
+      "Condition": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckValue",
+            "ColumnName": "ContractedUnitPrice",
+            "Value": null
+          },
+          {
+            "CheckFunction": "CheckValue",
+            "ColumnName": "ChargeCategory",
+            "Value": "Tax"
+          }
+        ]
+      },
+      "Dependencies": [
+        "ContractedUnitPrice-C-000-M",
+        "ChargeCategory-C-000-M"
+      ]
+    }
+  },
+  "ContractedCost-C-009-C": {
+    "Function": "Validation",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "Cross-column reference: BilledCost",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "ContractedCost of a charge unrelated to other charges (e.g., when the ChargeCategory is \"Credit\") MUST match the BilledCost",
+      "Keyword": "MUST",
+      "Requirement": {},
+      "Condition": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckValue",
+            "ColumnName": "ContractedUnitPrice",
+            "Value": null
+          },
+          {
+            "CheckFunction": "CheckValue",
+            "ColumnName": "ChargeCategory",
+            "Value": "Credit"
+          }
+        ]
+      },
+      "Dependencies": [
+        "ContractedUnitPrice-C-000-M",
+        "ChargeCategory-C-000-M",
+        "BilledCost-C-000-M"
+      ]
+    }
+  },
+  "ContractedCost-C-010-C": {
+    "Function": "Validation",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "Cross-column references: ContractedUnitPrice, PricingQuantity, ContractedCost",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "The product of ContractedUnitPrice and PricingQuantity MUST match the ContractedCost when ContractedUnitPrice is not null, PricingQuantity is not null, and ChargeClass is not \"Correction\"",
+      "Keyword": "MUST",
+      "Requirement": {},
+      "Condition": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckNotValue",
+            "ColumnName": "ContractedUnitPrice",
+            "Value": null
+          },
+          {
+            "CheckFunction": "CheckNotValue",
+            "ColumnName": "PricingQuantity",
+            "Value": null
+          },
+          {
+            "CheckFunction": "CheckNotValue",
+            "ColumnName": "ChargeClass",
+            "Value": "Correction"
+          }
+        ]
+      },
+      "Dependencies": [
+        "ContractedUnitPrice-C-000-M",
+        "PricingQuantity-C-000-M",
+        "ChargeClass-C-000-M"
+      ]
+    }
+  },
+  "ContractedCost-C-011-C": {
+    "Function": "Validation",
+    "Reference": "ContractedCost",
+    "EntityType": "Column",
+    "Notes": "Cross-column references: ContractedCost, ContractedUnitPrice, PricingQuantity",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "Discrepancies in ContractedCost, ContractedUnitPrice, or PricingQuantity MAY exist when ChargeClass is \"Correction\"",
+      "Keyword": "MAY",
+      "Requirement": {},
+      "Condition": {
+        "CheckFunction": "CheckValue",
+        "ColumnName": "ChargeClass",
+        "Value": "Correction"
+      },
+      "Dependencies": [
+        "ContractedUnitPrice-C-000-M",
+        "PricingQuantity-C-000-M",
+        "ChargeClass-C-000-M"
+      ]
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -150,6 +150,10 @@
           },
           {
             "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ChargeCategory-C-000-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "CommitmentDiscountCategory-C-000-C"
           },
           {
@@ -174,11 +178,11 @@
           },
           {
             "CheckFunction": "CheckConformanceRule",
-            "ConformanceRuleId": "ChargeCategory-C-000-M"
+            "ConformanceRuleId": "ConsumedQuantity-C-000-C"
           },
           {
             "CheckFunction": "CheckConformanceRule",
-            "ConformanceRuleId": "ConsumedQuantity-C-000-C"
+            "ConformanceRuleId": "ContractedCost-C-000-M"
           },
           {
             "CheckFunction": "CheckConformanceRule",


### PR DESCRIPTION
## Summary
- Added comprehensive conformance rules for ContractedCost column based on CR specification
- Implemented all 11 conformance rules including composite, presence, type, format, and validation rules  
- Added reference to ContractedCost-C-000-M in CostAndUsage dataset in alphabetical order
- Updated documentation to specify that column references in datasets should be in alphabetical order

## Details
- **ContractedCost-C-000-M**: Root composite rule linking all ContractedCost validation rules
- **ContractedCost-D-001-M**: Presence rule ensuring column exists in FOCUS datasets
- **ContractedCost-C-002-M**: Type validation ensuring Decimal data type
- **ContractedCost-C-003-M**: Format validation for NumericFormat compliance
- **ContractedCost-C-004-M**: Null validation ensuring non-null values
- **ContractedCost-C-005-M**: Basic decimal value validation
- **ContractedCost-C-006-M**: Currency denomination validation (dynamic)
- **ContractedCost-C-007-C**: Conditional composite for ContractedUnitPrice null scenarios
- **ContractedCost-C-008-C**: Tax calculation validation (dynamic)  
- **ContractedCost-C-009-C**: Credit matching with BilledCost (dynamic)
- **ContractedCost-C-010-C**: Unit price * quantity validation (dynamic)
- **ContractedCost-C-011-C**: Correction charge tolerance validation (dynamic)

## Cross-column Dependencies
Rules include proper dependencies on:
- ContractedUnitPrice-C-000-M
- PricingQuantity-C-000-M  
- ChargeCategory-C-000-M
- BilledCost-C-000-M
- ChargeClass-C-000-M
- BillingCurrency-C-000-M

## Documentation Updates
Updated writing-conformance-rules.md to specify that column references in conformance_datasets.json should be listed in alphabetical order for consistency.

## Test plan
- [x] JSON syntax validation passes
- [x] Column reference added to CostAndUsage dataset in alphabetical order
- [x] All conformance rule IDs follow proper naming conventions
- [x] Documentation updated with alphabetical ordering requirement

Fixes #1271

🤖 Generated with [Claude Code](https://claude.ai/code)