### PR TITLE
AI #1277: Create Conformance Rules for ChargePeriodStart

### DIFF
--- a/specification/conformance/conformance_datasets.json
+++ b/specification/conformance/conformance_datasets.json
@@ -9,8 +9,9 @@
         "BillingPeriodStart-C-000-M",
         "BillingPeriodEnd-C-000-M",
         "ChargePeriodEnd-C-000-M",
-        "ListUnitPrice-C-000-C"
-        "CostAndUsage-D-000-M"
+        "ChargePeriodStart-C-000-M",
+        "CostAndUsage-D-000-M",
+        "ListUnitPrice-C-000-C"        
       ]
     }
   }

--- a/specification/conformance/conformance_datasets.json
+++ b/specification/conformance/conformance_datasets.json
@@ -8,6 +8,7 @@
         "BillingAccountType-C-000-M",
         "BillingPeriodStart-C-000-M",
         "BillingPeriodEnd-C-000-M",
+        "ChargePeriodEnd-C-000-M",
         "ListUnitPrice-C-000-C"
       ]
     }

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -9,7 +9,7 @@
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "",
-            "Keyword": "",
+            "Keyword": "MUST",
             "Requirement": {
               "CheckFunction": "AND",
               "Items": [
@@ -35,11 +35,11 @@
                }
               ]
             },
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
     },
     "ChargePeriodEnd-C-001-M": {
@@ -54,15 +54,15 @@
             "MustSatisfy": "ChargePeriodEnd MUST be present in a FOCUS dataset.",
             "Keyword": "MUST",
             "Requirement": {},
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
     },
     "ChargePeriodEnd-C-002-M": {
-        "Function": "DataType",
+        "Function": "Format",
         "Reference": "Charge Period End",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
@@ -73,11 +73,11 @@
             "MustSatisfy": "ChargePeriodEnd MUST be of type Data/DateTime.",
             "Keyword": "MUST",
             "Requirement": {},
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
     },
     "ChargePeriodEnd-C-003-M": {
@@ -90,20 +90,20 @@
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodEnd MUST conform to DateTimeFormat requirements.",
-            "Keyword": "",
+            "Keyword": "MUST",
             "Requirement": {
-              "CheckFunction": "DateTimeFormat:CR",
+              "CheckFunction": "FormatDateTime",
               "ColumnName": "ChargePeriodEnd"
             },
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
     },
     "ChargePeriodEnd-C-004-M": {
-        "Function": "NullabilityRules",
+        "Function": "Validation",
         "Reference": "Charge Period End",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
@@ -112,13 +112,16 @@
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodEnd MUST NOT be null",
-            "Keyword": "MUST NOT",
-            "Requirement": {},
-            "Condition":"All Rows",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "CheckNotValue",
+                "ColumnName": "ChargePeriodEnd"
+            },
+            "Condition":{},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": "Cross-column reference: DateTimeFormat"
     },
   "ChargePeriodEnd-C-005-M": {
@@ -133,11 +136,11 @@
             "MustSatisfy": "ChargePeriodEnd MUST be the exclusive end bound of the effective period of the charge.",
             "Keyword": "MUST",
             "Requirement": {},
-            "Condition":"All Rows",
+            "Condition": {},
             "Dependencies":[]
         },
         "CRVersionIntroduced": "1.2",
-        "Status": "active",
+        "Status": "Active",
         "Notes": ""
-    },  
+    }  
 }

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -1,0 +1,144 @@
+{
+    "ChargePeriodEnd-C-000-M": {
+        "Function": "Composite",
+        "Reference": "ChargePeriodEnd",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+        "ApplicabilityCriteria": [],
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "",
+            "Keyword": "MUST",
+            "Requirement": {
+              "CheckFunction": "AND",
+              "Items": [
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-D-001-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-002-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-003-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-004-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-005-M"
+               }
+              ]
+            },
+            "Condition": {},
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-001-M": {
+        "Function": "Presence",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "Dataset includes ChargePeriodEnd column"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST be present in a FOCUS dataset.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition": {},
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-002-M": {
+        "Function": "Format",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST be of type Data/DateTime.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition": {},
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-003-M": {
+        "Function": "Format",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST conform to DateTimeFormat requirements.",
+            "Keyword": "MUST",
+            "Requirement": {
+              "CheckFunction": "FormatDateTime",
+              "ColumnName": "ChargePeriodEnd"
+            },
+            "Condition": {},
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-004-M": {
+        "Function": "Validation",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST NOT be null",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "CheckNotValue",
+                "ColumnName": "ChargePeriodEnd"
+            },
+            "Condition":{},
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": "Cross-column reference: DateTimeFormat"
+    },
+  "ChargePeriodEnd-C-005-M": {
+        "Function": "Validation",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST be the exclusive end bound of the effective period of the charge.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition": {},
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    }  
+}

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -13,11 +13,26 @@
             "Requirement": {
               "CheckFunction": "AND",
               "Items": [
-                "ChargePeriodEnd-D-001-M",
-                "ChargePeriodEnd-C-002-M",
-                "ChargePeriodEnd-C-003-M",
-                "ChargePeriodEnd-C-004-M",
-                "ChargePeriodEnd-C-005-M"
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-D-001-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-002-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-003-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-004-M"
+               },
+               {
+                "CheckFunction": "CheckConformanceRule",
+                "ConformanceRuleId": "ChargePeriodEnd-C-005-M"
+               }
               ]
             },
             "Condition":"All Rows",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -128,9 +128,7 @@
         "Function": "Validation",
         "Reference": "Charge Period End",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodEnd MUST be the exclusive end bound of the effective period of the charge.",

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -1,7 +1,7 @@
 {
     "ChargePeriodEnd-C-000-M": {
         "Function": "Composite",
-        "Reference": "Charge Period End",
+        "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
             "All Rows"

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -4,7 +4,7 @@
         "Reference": "ChargePeriodEnd",
         "EntityType": "Column",
         "ApplicabilityCriteria": [
-            "All Rows"
+        "ApplicabilityCriteria": [],
         ],
         "Type": "Static",
         "ValidationCriteria": {

--- a/specification/conformance/conformance_rules/columns/chargeperiodend.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodend.json
@@ -1,0 +1,128 @@
+{
+    "ChargePeriodEnd-C-000-M": {
+        "Function": "Composite",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "",
+            "Keyword": "",
+            "Requirement": {
+              "CheckFunction": "AND",
+              "Items": [
+                "ChargePeriodEnd-D-001-M",
+                "ChargePeriodEnd-C-002-M",
+                "ChargePeriodEnd-C-003-M",
+                "ChargePeriodEnd-C-004-M",
+                "ChargePeriodEnd-C-005-M"
+              ]
+            },
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-001-M": {
+        "Function": "Presence",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "Dataset includes ChargePeriodEnd column"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST be present in a FOCUS dataset.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-002-M": {
+        "Function": "DataType",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST be of type Data/DateTime.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-003-M": {
+        "Function": "Format",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST conform to DateTimeFormat requirements.",
+            "Keyword": "",
+            "Requirement": {
+              "CheckFunction": "DateTimeFormat:CR",
+              "ColumnName": "ChargePeriodEnd"
+            },
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },
+    "ChargePeriodEnd-C-004-M": {
+        "Function": "NullabilityRules",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST NOT be null",
+            "Keyword": "MUST NOT",
+            "Requirement": {},
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": "Cross-column reference: DateTimeFormat"
+    },
+  "ChargePeriodEnd-C-005-M": {
+        "Function": "Validation",
+        "Reference": "Charge Period End",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodEnd MUST be the exclusive end bound of the effective period of the charge.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition":"All Rows",
+            "Dependencies":[]
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "active",
+        "Notes": ""
+    },  
+}

--- a/specification/conformance/conformance_rules/columns/chargeperiodstart.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodstart.json
@@ -1,0 +1,142 @@
+{
+    "ChargePeriodStart-C-000-M": {
+        "Function": "Composite",
+        "Reference": "ChargePeriodStart",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "All ChargePeriodStart rules MUST be enforced",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "AND",
+                "Items": [
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-D-001-M"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-C-002-M"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-C-003-M"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-C-004-M"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-C-005-M"
+                    }
+                ]
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodStart-D-001-M": {
+        "Function": "Presence",
+        "Reference": "ChargePeriodStart",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST be present in a FOCUS dataset.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodStart-C-002-M": {
+        "Function": "Format",
+        "Reference": "ChargePeriodStart",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST be of type Date/Time.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "TypeDateTime",
+                "ColumnName": "ChargePeriodStart",
+                "ExpectedType": "DateTime"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodStart-C-003-M": {
+        "Function": "Format",
+        "Reference": "ChargePeriodStart",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST conform to DateTimeFormat requirements.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "FormatDateTime",
+                "ColumnName": "ChargePeriodStart"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodStart-C-004-M": {
+        "Function": "Validation",
+        "Reference": "ChargePeriodStart",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST NOT be null.",
+            "Keyword": "MUST NOT",
+            "Requirement": {
+                "CheckFunction": "CheckNotValue",
+                "ColumnName": "ChargePeriodStart"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodStart-C-005-M": {
+        "Function": "Validation",
+        "Reference": "ChargePeriodStart",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST be the inclusive start bound of the effective period of the charge.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "CheckValue",
+                "ColumnName": "ChargePeriodStart",
+                "ExpectedValue": "InclusiveStart"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    }
+}

--- a/specification/conformance/conformance_rules/columns/chargeperiodstart.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodstart.json
@@ -1,11 +1,9 @@
 {
     "ChargePeriodStart-C-000-M": {
         "Function": "Composite",
-        "Reference": "Charge Period Start",
+        "Reference": "ChargePeriodStart",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "All ChargePeriodStart rules MUST be enforced",
@@ -44,11 +42,9 @@
     },
     "ChargePeriodStart-D-001-M": {
         "Function": "Presence",
-        "Reference": "Charge Period Start",
+        "Reference": "ChargePeriodStart",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "Dataset includes ChargePeriodStart column"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodStart MUST be present in a FOCUS dataset.",
@@ -63,11 +59,9 @@
     },
     "ChargePeriodStart-C-002-M": {
         "Function": "Format",
-        "Reference": "Charge Period Start",
+        "Reference": "ChargePeriodStart",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodStart MUST be of type Date/Time.",
@@ -86,11 +80,9 @@
     },
     "ChargePeriodStart-C-003-M": {
         "Function": "Format",
-        "Reference": "Charge Period Start",
+        "Reference": "ChargePeriodStart",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodStart MUST conform to DateTimeFormat requirements.",
@@ -104,15 +96,13 @@
         },
         "CRVersionIntroduced": "1.2",
         "Status": "Active",
-        "Notes": "Cross-column reference: DateTimeFormat"
+        "Notes": ""
     },
     "ChargePeriodStart-C-004-M": {
         "Function": "Validation",
-        "Reference": "Charge Period Start",
+        "Reference": "ChargePeriodStart",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodStart MUST NOT be null.",
@@ -130,11 +120,9 @@
     },
     "ChargePeriodStart-C-005-M": {
         "Function": "Validation",
-        "Reference": "Charge Period Start",
+        "Reference": "ChargePeriodStart",
         "EntityType": "Column",
-        "ApplicabilityCriteria": [
-            "All Rows"
-        ],
+        "ApplicabilityCriteria": [],
         "Type": "Static",
         "ValidationCriteria": {
             "MustSatisfy": "ChargePeriodStart MUST be the inclusive start bound of the effective period of the charge.",

--- a/specification/conformance/conformance_rules/columns/chargeperiodstart.json
+++ b/specification/conformance/conformance_rules/columns/chargeperiodstart.json
@@ -1,0 +1,154 @@
+{
+    "ChargePeriodStart-C-000-M": {
+        "Function": "Composite",
+        "Reference": "Charge Period Start",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "All ChargePeriodStart rules MUST be enforced",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "AND",
+                "Items": [
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-D-001-M"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-C-002-M"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-C-003-M"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-C-004-M"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "ChargePeriodStart-C-005-M"
+                    }
+                ]
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodStart-D-001-M": {
+        "Function": "Presence",
+        "Reference": "Charge Period Start",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "Dataset includes ChargePeriodStart column"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST be present in a FOCUS dataset.",
+            "Keyword": "MUST",
+            "Requirement": {},
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodStart-C-002-M": {
+        "Function": "Format",
+        "Reference": "Charge Period Start",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST be of type Date/Time.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "TypeDateTime",
+                "ColumnName": "ChargePeriodStart",
+                "ExpectedType": "DateTime"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodStart-C-003-M": {
+        "Function": "Format",
+        "Reference": "Charge Period Start",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST conform to DateTimeFormat requirements.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "FormatDateTime",
+                "ColumnName": "ChargePeriodStart"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": "Cross-column reference: DateTimeFormat"
+    },
+    "ChargePeriodStart-C-004-M": {
+        "Function": "Validation",
+        "Reference": "Charge Period Start",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST NOT be null.",
+            "Keyword": "MUST NOT",
+            "Requirement": {
+                "CheckFunction": "CheckNotValue",
+                "ColumnName": "ChargePeriodStart"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "ChargePeriodStart-C-005-M": {
+        "Function": "Validation",
+        "Reference": "Charge Period Start",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": [
+            "All Rows"
+        ],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "ChargePeriodStart MUST be the inclusive start bound of the effective period of the charge.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "CheckValue",
+                "ColumnName": "ChargePeriodStart",
+                "ExpectedValue": "InclusiveStart"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.2",
+        "Status": "Active",
+        "Notes": ""
+    }
+}


### PR DESCRIPTION
### Summary: PR for Conformance definition for column: chargeperiodstart #1277 

## Changes Made

- Updated json values for the chargeperiodstart file based on the chargeperiodestart_cr.md file
- Added the json output to the ../conformance_rules/columns/ directory
- Updated the conformance_datasets.json file based on alphabetic ordering. 

## Notes:
- Validation for Requirements in "ChargePeriodStart-C-005-M" section of the file. 
- This commit includes references to ChargePeriodEnd" in PR 1398 but should not. 
