### PR TITLE
AI #1291: Create conformance rules for PublisherName column

### DIFF
--- a/specification/conformance/conformance_rules/columns/publishername.json
+++ b/specification/conformance/conformance_rules/columns/publishername.json
@@ -6,9 +6,7 @@
     "Notes": "Main composite rule for PublisherName column",
     "CRVersionIntroduced": "1.2",
     "Status": "Active",
-    "ApplicabilityCriteria": [
-      "Dataset includes PublisherName column"
-    ],
+    "ApplicabilityCriteria": [],
     "Type": "Static",
     "ValidationCriteria": {
       "MustSatisfy": "The PublisherName column adheres to the following requirements:",
@@ -34,11 +32,13 @@
           }
         ]
       },
-      "Condition": {
-        "CheckFunction": "Equal",
-        "CheckCondition": "All Rows"
-      },
-      "Dependencies": []
+      "Condition": {},
+      "Dependencies": [
+        "PublisherName-C-001-M",
+        "PublisherName-C-002-M",
+        "PublisherName-C-003-M",
+        "PublisherName-C-004-M"
+      ]
     }
   },
   "PublisherName-C-001-M": {

--- a/specification/conformance/conformance_rules/columns/publishername.json
+++ b/specification/conformance/conformance_rules/columns/publishername.json
@@ -1,7 +1,7 @@
 {
   "PublisherName-C-000-M": {
     "Function": "Composite",
-    "Reference": "Publisher Name",
+    "Reference": "PublisherName",
     "EntityType": "Column",
     "Notes": "Main composite rule for PublisherName column",
     "CRVersionIntroduced": "1.2",
@@ -25,121 +25,76 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "PublisherName-C-003-M"
-          },
-          {
-            "CheckFunction": "CheckConformanceRule",
-            "ConformanceRuleId": "PublisherName-C-004-M"
           }
         ]
       },
       "Condition": {},
       "Dependencies": [
+        "CostAndUsage-D-021-M",
         "PublisherName-C-001-M",
         "PublisherName-C-002-M",
-        "PublisherName-C-003-M",
-        "PublisherName-C-004-M"
+        "PublisherName-C-003-M"
       ]
     }
   },
   "PublisherName-C-001-M": {
-    "Function": "Presence",
-    "Reference": "Publisher Name",
+    "Function": "Type",
+    "Reference": "PublisherName",
     "EntityType": "Column",
-    "Notes": "PublisherName must be present in dataset",
+    "Notes": "",
     "CRVersionIntroduced": "1.2",
     "Status": "Active",
-    "ApplicabilityCriteria": [
-      "Dataset includes PublisherName column"
-    ],
-    "Type": "Static",
-    "ValidationCriteria": {
-      "MustSatisfy": "PublisherName MUST be present in a FOCUS dataset.",
-      "Keyword": "MUST",
-      "Requirement": {
-        "CheckFunction": "ColumnPresent",
-        "ColumnName": "PublisherName"
-      },
-      "Condition": {
-        "CheckFunction": "Equal",
-        "CheckCondition": "All Rows"
-      },
-      "Dependencies": []
-    }
-  },
-  "PublisherName-C-002-M": {
-    "Function": "DataType",
-    "Reference": "Publisher Name",
-    "EntityType": "Column",
-    "Notes": "PublisherName must be of type String",
-    "CRVersionIntroduced": "1.2",
-    "Status": "Active",
-    "ApplicabilityCriteria": [
-      "Dataset includes PublisherName column"
-    ],
+    "ApplicabilityCriteria": [],
     "Type": "Static",
     "ValidationCriteria": {
       "MustSatisfy": "PublisherName MUST be of type String.",
       "Keyword": "MUST",
       "Requirement": {
-        "CheckFunction": "DataType",
-        "DataType": "String"
+        "CheckFunction": "TypeString",
+        "ColumnName": "PublisherName"
       },
-      "Condition": {
-        "CheckFunction": "Equal",
-        "CheckCondition": "All Rows"
-      },
+      "Condition": {},
       "Dependencies": []
     }
   },
-  "PublisherName-C-003-M": {
+  "PublisherName-C-002-M": {
     "Function": "Format",
-    "Reference": "Publisher Name",
+    "Reference": "PublisherName",
     "EntityType": "Column",
-    "Notes": "PublisherName must conform to StringHandling requirements",
+    "Notes": "",
     "CRVersionIntroduced": "1.2",
     "Status": "Active",
-    "ApplicabilityCriteria": [
-      "Dataset includes PublisherName column"
-    ],
+    "ApplicabilityCriteria": [],
     "Type": "Static",
     "ValidationCriteria": {
       "MustSatisfy": "PublisherName MUST conform to StringHandling requirements.",
       "Keyword": "MUST",
       "Requirement": {
-        "CheckFunction": "AttributeConformance",
-        "AttributeID": "StringHandling"
+        "CheckFunction": "FormatString",
+        "ColumnName": "PublisherName"
       },
-      "Condition": {
-        "CheckFunction": "Equal",
-        "CheckCondition": "All Rows"
-      },
-      "Dependencies": [
-        "StringHandling:CR"
-      ]
+      "Condition": {},
+      "Dependencies": []
     }
   },
-  "PublisherName-C-004-M": {
-    "Function": "NullabilityRules",
-    "Reference": "Publisher Name",
+  "PublisherName-C-003-M": {
+    "Function": "Nullability",
+    "Reference": "PublisherName",
     "EntityType": "Column",
-    "Notes": "PublisherName must not be null",
+    "Notes": "",
     "CRVersionIntroduced": "1.2",
     "Status": "Active",
-    "ApplicabilityCriteria": [
-      "Dataset includes PublisherName column"
-    ],
+    "ApplicabilityCriteria": [],
     "Type": "Static",
     "ValidationCriteria": {
       "MustSatisfy": "PublisherName MUST NOT be null.",
       "Keyword": "MUST NOT",
       "Requirement": {
-        "CheckFunction": "IsNotNull",
-        "ColumnName": "PublisherName"
+        "CheckFunction": "CheckNotValue",
+        "ColumnName": "PublisherName",
+        "Value": null
       },
-      "Condition": {
-        "CheckFunction": "Equal",
-        "CheckCondition": "All Rows"
-      },
+      "Condition": {},
       "Dependencies": []
     }
   }

--- a/specification/conformance/conformance_rules/columns/publishername.json
+++ b/specification/conformance/conformance_rules/columns/publishername.json
@@ -1,0 +1,146 @@
+{
+  "PublisherName-C-000-M": {
+    "Function": "Composite",
+    "Reference": "Publisher Name",
+    "EntityType": "Column",
+    "Notes": "Main composite rule for PublisherName column",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes PublisherName column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "The PublisherName column adheres to the following requirements:",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "PublisherName-C-001-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "PublisherName-C-002-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "PublisherName-C-003-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "PublisherName-C-004-M"
+          }
+        ]
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "PublisherName-C-001-M": {
+    "Function": "Presence",
+    "Reference": "Publisher Name",
+    "EntityType": "Column",
+    "Notes": "PublisherName must be present in dataset",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes PublisherName column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "PublisherName MUST be present in a FOCUS dataset.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "ColumnPresent",
+        "ColumnName": "PublisherName"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "PublisherName-C-002-M": {
+    "Function": "DataType",
+    "Reference": "Publisher Name",
+    "EntityType": "Column",
+    "Notes": "PublisherName must be of type String",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes PublisherName column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "PublisherName MUST be of type String.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "DataType",
+        "DataType": "String"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "PublisherName-C-003-M": {
+    "Function": "Format",
+    "Reference": "Publisher Name",
+    "EntityType": "Column",
+    "Notes": "PublisherName must conform to StringHandling requirements",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes PublisherName column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "PublisherName MUST conform to StringHandling requirements.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AttributeConformance",
+        "AttributeID": "StringHandling"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": [
+        "StringHandling:CR"
+      ]
+    }
+  },
+  "PublisherName-C-004-M": {
+    "Function": "NullabilityRules",
+    "Reference": "Publisher Name",
+    "EntityType": "Column",
+    "Notes": "PublisherName must not be null",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes PublisherName column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "PublisherName MUST NOT be null.",
+      "Keyword": "MUST NOT",
+      "Requirement": {
+        "CheckFunction": "IsNotNull",
+        "ColumnName": "PublisherName"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -113,13 +113,14 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "CostAndUsage-D-019-C"
-<<<<<<< HEAD
           },
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "CostAndUsage-D-020-C"
-=======
->>>>>>> f91e554a (AI #1267: Add SubAccountId conformance rules (#1423))
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "CostAndUsage-D-021-M"
           }
         ]
       },
@@ -141,12 +142,9 @@
         "CostAndUsage-D-016-M",
         "CostAndUsage-D-017-M",
         "CostAndUsage-D-018-M",
-<<<<<<< HEAD
         "CostAndUsage-D-019-C",
-        "CostAndUsage-D-020-C"
-=======
-        "CostAndUsage-D-019-C"
->>>>>>> f91e554a (AI #1267: Add SubAccountId conformance rules (#1423))
+        "CostAndUsage-D-020-C",
+        "CostAndUsage-D-021-M"
       ]
     }
   },
@@ -633,12 +631,14 @@
       "Condition": {},
       "Dependencies": []
     }
-<<<<<<< HEAD
   },
   "CostAndUsage-D-020-C": {
     "Function": "Presence",
     "Reference": "CapacityReservationStatus",
     "EntityType": "Dataset",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "Notes": "",
     "ApplicabilityCriteria": [
       "CAPACITY_RESERVATION_SUPPORTED"
     ],
@@ -652,11 +652,26 @@
       },
       "Condition": {},
       "Dependencies": []
-    },
+    }
+  },
+  "CostAndUsage-D-021-M": {
+    "Function": "Presence",
+    "Reference": "PublisherName",
+    "EntityType": "Dataset",
+    "Notes": "",
     "CRVersionIntroduced": "1.2",
     "Status": "Active",
-    "Notes": ""
-=======
->>>>>>> f91e554a (AI #1267: Add SubAccountId conformance rules (#1423))
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "PublisherName MUST be present in a FOCUS dataset.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "ColumnPresent",
+        "ColumnName": "PublisherName"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
   }
 }

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -113,10 +113,13 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "CostAndUsage-D-019-C"
+<<<<<<< HEAD
           },
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "CostAndUsage-D-020-C"
+=======
+>>>>>>> f91e554a (AI #1267: Add SubAccountId conformance rules (#1423))
           }
         ]
       },
@@ -138,8 +141,12 @@
         "CostAndUsage-D-016-M",
         "CostAndUsage-D-017-M",
         "CostAndUsage-D-018-M",
+<<<<<<< HEAD
         "CostAndUsage-D-019-C",
         "CostAndUsage-D-020-C"
+=======
+        "CostAndUsage-D-019-C"
+>>>>>>> f91e554a (AI #1267: Add SubAccountId conformance rules (#1423))
       ]
     }
   },
@@ -626,6 +633,7 @@
       "Condition": {},
       "Dependencies": []
     }
+<<<<<<< HEAD
   },
   "CostAndUsage-D-020-C": {
     "Function": "Presence",
@@ -648,5 +656,7 @@
     "CRVersionIntroduced": "1.2",
     "Status": "Active",
     "Notes": ""
+=======
+>>>>>>> f91e554a (AI #1267: Add SubAccountId conformance rules (#1423))
   }
 }

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -228,6 +228,10 @@
           },
           {
             "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "PublisherName-C-000-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "SubAccountId-C-000-C"
           },
           {
@@ -255,6 +259,7 @@
         "ChargeCategory-C-000-M",
         "ConsumedQuantity-C-000-C",
         "ListUnitPrice-C-000-C",
+        "PublisherName-C-000-M",
         "SubAccountId-C-000-C",
         "SubAccountName-C-000-C"
       ]


### PR DESCRIPTION
## Summary
- Creates comprehensive conformance rules for the PublisherName column based on CR specification
- Implements 4 validation rules covering presence, data type, format, and nullability requirements
- Updates CostAndUsage dataset to reference new PublisherName conformance rules

## Changes
- **Added**: `specification/conformance/conformance_rules/columns/publishername.json`
- **Updated**: `specification/conformance/conformance_rules/datasets/costandusage.json` to reference PublisherName-C-000-M

## Test plan
- [ ] Validate JSON schema compliance
- [ ] Verify rule references and dependencies
- [ ] Confirm alignment with CR specification requirements

Resolves #1291

🤖 Generated with [Claude Code](https://claude.ai/code)