### PR TITLE
AI #1292: Create conformance rules for ServiceCategory column

### DIFF
--- a/specification/conformance/conformance_rules/columns/servicecategory.json
+++ b/specification/conformance/conformance_rules/columns/servicecategory.json
@@ -1,0 +1,140 @@
+{
+  "ServiceCategory-C-000-M": {
+    "Function": "Composite",
+    "Reference": "Service Category",
+    "EntityType": "Column",
+    "Notes": "Main composite rule for ServiceCategory column",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes ServiceCategory column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "The ServiceCategory column adheres to the following requirements:",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ServiceCategory-D-001-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ServiceCategory-C-002-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ServiceCategory-C-003-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ServiceCategory-C-004-M"
+          }
+        ]
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "ServiceCategory-D-001-M": {
+    "Function": "Presence",
+    "Reference": "Service Category",
+    "EntityType": "Column",
+    "Notes": "ServiceCategory must be present in dataset",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes ServiceCategory column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ServiceCategory MUST be present in a FOCUS dataset.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "ColumnPresent",
+        "ColumnName": "ServiceCategory"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "ServiceCategory-C-002-M": {
+    "Function": "DataType",
+    "Reference": "Service Category",
+    "EntityType": "Column",
+    "Notes": "ServiceCategory must be of type String",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ServiceCategory MUST be of type String.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "DataType",
+        "DataType": "String"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "ServiceCategory-C-003-M": {
+    "Function": "NullabilityRules",
+    "Reference": "Service Category",
+    "EntityType": "Column",
+    "Notes": "ServiceCategory must not be null",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ServiceCategory MUST NOT be null.",
+      "Keyword": "MUST NOT",
+      "Requirement": {
+        "CheckFunction": "IsNotNull",
+        "ColumnName": "ServiceCategory"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "ServiceCategory-C-004-M": {
+    "Function": "Validation",
+    "Reference": "Service Category",
+    "EntityType": "Column",
+    "Notes": "ServiceCategory must be one of the allowed values",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ServiceCategory MUST be one of the allowed values.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AttributeConformance",
+        "AttributeID": "AllowedValues"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": [
+        "AllowedValues:CR"
+      ]
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -183,6 +183,10 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "ListUnitPrice-C-000-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ServiceCategory-C-000-M"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Creates comprehensive conformance rules for the ServiceCategory column based on CR specification
- Implements 4 validation rules covering presence, data type, nullability, and allowed values validation
- Updates CostAndUsage dataset to reference new ServiceCategory conformance rules

## Changes
- **Added**: `specification/conformance/conformance_rules/columns/servicecategory.json`
- **Updated**: `specification/conformance/conformance_rules/datasets/costandusage.json` to reference ServiceCategory-C-000-M

## Test plan
- [ ] Validate JSON schema compliance
- [ ] Verify rule references and dependencies
- [ ] Confirm alignment with CR specification requirements

Resolves #1292

🤖 Generated with [Claude Code](https://claude.ai/code)