### PR TITLE
AIs #1298 #1299 #1300 #1301 Add conformance rules for SKU columns group

### DIFF
--- a/specification/conformance/applicability_criteria.json
+++ b/specification/conformance/applicability_criteria.json
@@ -12,6 +12,9 @@
     "PUBLIC_PRICE_LIST_SUPPORTED": {
       "Description": "Data generator publishes unit prices exclusive of discounts"
     },
+    "UNIT_PRICING_SUPPORTED": {
+      "Description": "Provider supports unit pricing concepts and publishes price lists, publicly or as part of contracting"
+    },
     "USAGE_MEASUREMENT_SUPPORTED": {
       "Description": "Data generator supports the measurement of usage quantities"
     }

--- a/specification/conformance/conformance_rules/columns/resourcename.json
+++ b/specification/conformance/conformance_rules/columns/resourcename.json
@@ -1,0 +1,146 @@
+{
+  "ResourceName-C-000-C": {
+    "Function": "Composite",
+    "Reference": "Resource Name",
+    "EntityType": "Column",
+    "Notes": "Main composite rule for ResourceName column",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes ResourceName column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "The ResourceName column adheres to the following requirements:",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ResourceName-D-001-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ResourceName-C-002-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ResourceName-C-003-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ResourceName-C-004-C"
+          }
+        ]
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "ResourceName-D-001-C": {
+    "Function": "Presence",
+    "Reference": "Resource Name",
+    "EntityType": "Column",
+    "Notes": "ResourceName presence is conditional on provider capabilities",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Provider supports billing based on provisioned resources and supports assigning names to resources"
+    ],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "ResourceName MUST be present in a FOCUS dataset when the provider supports billing based on provisioned resources and supports assigning names to resources.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "ColumnPresent",
+        "ColumnName": "ResourceName"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "ResourceName-C-002-M": {
+    "Function": "DataType",
+    "Reference": "Resource Name",
+    "EntityType": "Column",
+    "Notes": "ResourceName must be of type String",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes ResourceName column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ResourceName MUST be of type String.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "DataType",
+        "DataType": "String"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  },
+  "ResourceName-C-003-M": {
+    "Function": "Format",
+    "Reference": "Resource Name",
+    "EntityType": "Column",
+    "Notes": "ResourceName must conform to StringHandling requirements",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes ResourceName column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ResourceName MUST conform to StringHandling requirements.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AttributeConformance",
+        "AttributeID": "StringHandling"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": [
+        "StringHandling:CR"
+      ]
+    }
+  },
+  "ResourceName-C-004-C": {
+    "Function": "NullabilityRules",
+    "Reference": "Resource Name",
+    "EntityType": "Column",
+    "Notes": "ResourceName may be null",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "Dataset includes ResourceName column"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "ResourceName MAY be null.",
+      "Keyword": "MAY",
+      "Requirement": {
+        "CheckFunction": "MayBeNull",
+        "ColumnName": "ResourceName"
+      },
+      "Condition": {
+        "CheckFunction": "Equal",
+        "CheckCondition": "All Rows"
+      },
+      "Dependencies": []
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/columns/skuid.json
+++ b/specification/conformance/conformance_rules/columns/skuid.json
@@ -1,0 +1,158 @@
+{
+  "ConformanceRules": {
+    "SkuId-C-000-C": {
+      "RuleID": "SkuId-C-000-C",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuId-D-001-C,SkuId-C-002-M,SkuId-C-003-M,SkuId-C-004-M,SkuId-C-008-M,SkuId-C-012-C,SkuId-C-013-O)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "Composite rule for SkuId column validation"
+    },
+    "SkuId-D-001-C": {
+      "RuleID": "SkuId-D-001-C",
+      "Function": "Presence",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "UNIT_PRICING_SUPPORTED",
+      "Condition": "All Rows",
+      "Requirement": null,
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuId MUST be present in a FOCUS dataset when the provider supports unit pricing concepts and publishes price lists, publicly or as part of contracting"
+    },
+    "SkuId-C-002-M": {
+      "RuleID": "SkuId-C-002-M",
+      "Function": "DataType",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All Rows",
+      "Requirement": "String",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuId MUST be of type String"
+    },
+    "SkuId-C-003-M": {
+      "RuleID": "SkuId-C-003-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All Rows",
+      "Requirement": "StringHandling:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuId MUST conform to StringHandling requirements"
+    },
+    "SkuId-C-004-M": {
+      "RuleID": "SkuId-C-004-M",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuId-C-005-C,SkuId-C-006-C,SkuId-C-007-C)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuId nullability is defined as follows"
+    },
+    "SkuId-C-005-C": {
+      "RuleID": "SkuId-C-005-C",
+      "Function": "NullabilityRules",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "ChargeCategory is 'Tax'",
+      "Requirement": "ChargeCategory:CR",
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuId MUST be null when ChargeCategory is 'Tax'"
+    },
+    "SkuId-C-006-C": {
+      "RuleID": "SkuId-C-006-C",
+      "Function": "NullabilityRules",
+      "Keyword": "MUST NOT",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "ChargeCategory is 'Usage' or 'Purchase' and ChargeClass is not 'Correction'",
+      "Requirement": "AND(ChargeCategory:CR,ChargeClass:CR)",
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuId MUST NOT be null when ChargeCategory is 'Usage' or 'Purchase' and ChargeClass is not 'Correction'"
+    },
+    "SkuId-C-007-C": {
+      "RuleID": "SkuId-C-007-C",
+      "Function": "NullabilityRules",
+      "Keyword": "MAY",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All other cases",
+      "Requirement": null,
+      "Type": "static",
+      "Severity": "warning",
+      "Description": "SkuId MAY be null in all other cases"
+    },
+    "SkuId-C-008-M": {
+      "RuleID": "SkuId-C-008-M",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuId-C-009-M,SkuId-C-010-M,SkuId-C-011-M)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuId for a given SKU adheres to the following additional requirements"
+    },
+    "SkuId-C-009-M": {
+      "RuleID": "SkuId-C-009-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All Rows",
+      "Requirement": "BillingAccount:CR",
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuId MUST remain consistent across billing accounts or contracts"
+    },
+    "SkuId-C-010-M": {
+      "RuleID": "SkuId-C-010-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All Rows",
+      "Requirement": "PricingCategory:CR",
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuId MUST remain consistent across PricingCategory values"
+    },
+    "SkuId-C-011-M": {
+      "RuleID": "SkuId-C-011-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All Rows",
+      "Requirement": null,
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuId MUST remain consistent regardless of any other factors that might impact the price but do not affect the functionality of the SKU"
+    },
+    "SkuId-C-012-C": {
+      "RuleID": "SkuId-C-012-C",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "ChargeCategory is 'Usage' or 'Purchase'",
+      "Requirement": "AND(Resource:CR,Service:CR,ChargeCategory:CR)",
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuId MUST be associated with a given resource or service when ChargeCategory is 'Usage' or 'Purchase'"
+    },
+    "SkuId-C-013-O": {
+      "RuleID": "SkuId-C-013-O",
+      "Function": "Validation",
+      "Keyword": "MAY",
+      "ApplicabilityCriteria": "Dataset includes SkuId column",
+      "Condition": "All Rows",
+      "Requirement": "SkuPriceId:CR",
+      "Type": "static",
+      "Severity": "warning",
+      "Description": "SkuId MAY equal SkuPriceId"
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/columns/skumeter.json
+++ b/specification/conformance/conformance_rules/columns/skumeter.json
@@ -1,0 +1,92 @@
+{
+  "ConformanceRules": {
+    "SkuMeter-C-000-O": {
+      "RuleID": "SkuMeter-C-000-O",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "All Rows",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuMeter-D-001-C, SkuMeter-C-002-M, SkuMeter-C-003-M, SkuMeter-C-004-C, SkuMeter-C-007-O)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "Composite rule for SkuMeter column validation"
+    },
+    "SkuMeter-D-001-C": {
+      "RuleID": "SkuMeter-D-001-C",
+      "Function": "Presence",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "UNIT_PRICING_SUPPORTED",
+      "Condition": "All Rows",
+      "Requirement": null,
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuMeter MUST be present in a FOCUS dataset when the provider supports unit pricing concepts and publishes price lists, publicly or as part of contracting"
+    },
+    "SkuMeter-C-002-M": {
+      "RuleID": "SkuMeter-C-002-M",
+      "Function": "DataType",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuMeter column",
+      "Condition": "All Rows",
+      "Requirement": "String",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuMeter MUST be of type String"
+    },
+    "SkuMeter-C-003-M": {
+      "RuleID": "SkuMeter-C-003-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuMeter column",
+      "Condition": "All Rows",
+      "Requirement": "StringHandling:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuMeter MUST conform to StringHandling requirements"
+    },
+    "SkuMeter-C-004-C": {
+      "RuleID": "SkuMeter-C-004-C",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuMeter column",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuMeter-C-005-C, SkuMeter-C-006-C)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuMeter nullability is defined as follows"
+    },
+    "SkuMeter-C-005-C": {
+      "RuleID": "SkuMeter-C-005-C",
+      "Function": "NullabilityRules",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuMeter column",
+      "Condition": "when SkuId is null",
+      "Requirement": "SkuId:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuMeter MUST be null when SkuId is null"
+    },
+    "SkuMeter-C-006-C": {
+      "RuleID": "SkuMeter-C-006-C",
+      "Function": "NullabilityRules",
+      "Keyword": "SHOULD NOT",
+      "ApplicabilityCriteria": "Dataset includes SkuMeter column",
+      "Condition": "when SkuId is not null",
+      "Requirement": "SkuId:CR",
+      "Type": "static",
+      "Severity": "warning",
+      "Description": "SkuMeter SHOULD NOT be null when SkuId is not null"
+    },
+    "SkuMeter-C-007-O": {
+      "RuleID": "SkuMeter-C-007-O",
+      "Function": "Validation",
+      "Keyword": "SHOULD",
+      "ApplicabilityCriteria": "Dataset includes SkuMeter column",
+      "Condition": "All Rows",
+      "Requirement": "SkuId:CR",
+      "Type": "static",
+      "Severity": "warning",
+      "Description": "SkuMeter SHOULD remain consistent over time for a given SkuId"
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/columns/skupricedetails.json
+++ b/specification/conformance/conformance_rules/columns/skupricedetails.json
@@ -1,0 +1,268 @@
+{
+  "ConformanceRules": {
+    "SkuPriceDetails-C-000-M": {
+      "RuleID": "SkuPriceDetails-C-000-M",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "UNIT_PRICING_SUPPORTED",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuPriceDetails-D-001-C,SkuPriceDetails-C-002-M,SkuPriceDetails-C-003-O,SkuPriceDetails-C-004-C,SkuPriceDetails-C-007-M,SkuPriceDetails-C-020-M)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "The SkuPriceDetails column adheres to the following requirements"
+    },
+    "SkuPriceDetails-D-001-C": {
+      "RuleID": "SkuPriceDetails-D-001-C",
+      "Function": "Presence",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "UNIT_PRICING_SUPPORTED",
+      "Condition": "All Rows",
+      "Requirement": null,
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuPriceDetails MUST be present in a FOCUS dataset when the provider supports unit pricing concepts and publishes price lists, publicly or as part of contracting"
+    },
+    "SkuPriceDetails-C-002-M": {
+      "RuleID": "SkuPriceDetails-C-002-M",
+      "Function": "Format",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "KeyValueFormat:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceDetails MUST conform to KeyValueFormat requirements"
+    },
+    "SkuPriceDetails-C-003-O": {
+      "RuleID": "SkuPriceDetails-C-003-O",
+      "Function": "Format",
+      "Keyword": "SHOULD",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "PascalCase:CR",
+      "Type": "static",
+      "Severity": "warning",
+      "Description": "SkuPriceDetails property keys SHOULD conform to PascalCase format"
+    },
+    "SkuPriceDetails-C-004-C": {
+      "RuleID": "SkuPriceDetails-C-004-C",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuPriceDetails-C-005-C,SkuPriceDetails-C-006-C)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceDetails nullability is defined as follows"
+    },
+    "SkuPriceDetails-C-005-C": {
+      "RuleID": "SkuPriceDetails-C-005-C",
+      "Function": "NullabilityRules",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "SkuPriceId is null",
+      "Requirement": "SkuPriceId:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceDetails MUST be null when SkuPriceId is null"
+    },
+    "SkuPriceDetails-C-006-C": {
+      "RuleID": "SkuPriceDetails-C-006-C",
+      "Function": "NullabilityRules",
+      "Keyword": "MAY",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "SkuPriceId is not null",
+      "Requirement": "SkuPriceId:CR",
+      "Type": "static",
+      "Severity": "warning",
+      "Description": "SkuPriceDetails MAY be null when SkuPriceId is not null"
+    },
+    "SkuPriceDetails-C-007-M": {
+      "RuleID": "SkuPriceDetails-C-007-M",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "SkuPriceDetails is not null",
+      "Requirement": "AND(SkuPriceDetails-C-008-M,SkuPriceDetails-C-009-M,SkuPriceDetails-C-010-C,SkuPriceDetails-C-011-C,SkuPriceDetails-C-012-O,SkuPriceDetails-C-013-O,SkuPriceDetails-C-017-O,SkuPriceDetails-C-018-C,SkuPriceDetails-C-019-C)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "When SkuPriceDetails is not null, SkuPriceDetails adheres to the following additional requirements"
+    },
+    "SkuPriceDetails-C-008-M": {
+      "RuleID": "SkuPriceDetails-C-008-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "SkuPriceId:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceDetails MUST be associated with a given SkuPriceId"
+    },
+    "SkuPriceDetails-C-009-M": {
+      "RuleID": "SkuPriceDetails-C-009-M",
+      "Function": "Validation",
+      "Keyword": "MUST NOT",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "SkuPriceId:CR",
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuPriceDetails MUST NOT include properties that are not applicable to the corresponding SkuPriceId"
+    },
+    "SkuPriceDetails-C-010-C": {
+      "RuleID": "SkuPriceDetails-C-010-C",
+      "Function": "Validation",
+      "Keyword": "SHOULD",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "The FOCUS-defined SKU Price properties listed are applicable to the corresponding SkuPriceId",
+      "Requirement": "SkuPricePropertyDefinitions:CR",
+      "Type": "dynamic",
+      "Severity": "warning",
+      "Description": "SkuPriceDetails SHOULD include all FOCUS-defined SKU Price properties listed below that are applicable to the corresponding SkuPriceId"
+    },
+    "SkuPriceDetails-C-011-C": {
+      "RuleID": "SkuPriceDetails-C-011-C",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "An equivalent property is included as a Provider-defined property",
+      "Requirement": "SkuPricePropertyDefinitions:CR",
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuPriceDetails MUST include the FOCUS-defined SKU Price property when an equivalent property is included as a Provider-defined property"
+    },
+    "SkuPriceDetails-C-012-O": {
+      "RuleID": "SkuPriceDetails-C-012-O",
+      "Function": "Validation",
+      "Keyword": "MAY",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": null,
+      "Type": "static",
+      "Severity": "info",
+      "Description": "SkuPriceDetails MAY include properties that are already captured in other dedicated columns"
+    },
+    "SkuPriceDetails-C-013-O": {
+      "RuleID": "SkuPriceDetails-C-013-O",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuPriceDetails-C-014-O,SkuPriceDetails-C-015-O,SkuPriceDetails-C-016-O)",
+      "Type": "static",
+      "Severity": "warning",
+      "Description": "SkuPriceDetails properties for a given SkuPriceId adhere to the following additional requirements"
+    },
+    "SkuPriceDetails-C-014-O": {
+      "RuleID": "SkuPriceDetails-C-014-O",
+      "Function": "Validation",
+      "Keyword": "SHOULD",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": null,
+      "Type": "dynamic",
+      "Severity": "warning",
+      "Description": "Existing SkuPriceDetails properties SHOULD remain consistent over time"
+    },
+    "SkuPriceDetails-C-015-O": {
+      "RuleID": "SkuPriceDetails-C-015-O",
+      "Function": "Validation",
+      "Keyword": "SHOULD NOT",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": null,
+      "Type": "dynamic",
+      "Severity": "warning",
+      "Description": "Existing SkuPriceDetails properties SHOULD NOT be removed"
+    },
+    "SkuPriceDetails-C-016-O": {
+      "RuleID": "SkuPriceDetails-C-016-O",
+      "Function": "Validation",
+      "Keyword": "MAY",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": null,
+      "Type": "dynamic",
+      "Severity": "info",
+      "Description": "Additional SkuPriceDetails properties MAY be added over time"
+    },
+    "SkuPriceDetails-C-017-O": {
+      "RuleID": "SkuPriceDetails-C-017-O",
+      "Function": "Validation",
+      "Keyword": "SHOULD",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "SkuId:CR",
+      "Type": "dynamic",
+      "Severity": "warning",
+      "Description": "Property key SHOULD remain consistent across comparable SKUs having that property, and the values for this key SHOULD remain in a consistent format"
+    },
+    "SkuPriceDetails-C-018-C": {
+      "RuleID": "SkuPriceDetails-C-018-C",
+      "Function": "Format",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "Property is not FOCUS-defined (i.e., is Provider-defined)",
+      "Requirement": "SkuPricePropertyDefinitions:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "Property key MUST begin with the string 'x_' unless it is a FOCUS-defined property"
+    },
+    "SkuPriceDetails-C-019-C": {
+      "RuleID": "SkuPriceDetails-C-019-C",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "Property holds a numeric value",
+      "Requirement": "PricingUnit:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "Property value MUST represent the value for a single PricingUnit when the property holds a numeric value"
+    },
+    "SkuPriceDetails-C-020-M": {
+      "RuleID": "SkuPriceDetails-C-020-M",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuPriceDetails-C-021-M,SkuPriceDetails-C-022-M,SkuPriceDetails-C-023-C)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "FOCUS-defined SKU Price properties adhere to the following additional requirements"
+    },
+    "SkuPriceDetails-C-021-M": {
+      "RuleID": "SkuPriceDetails-C-021-M",
+      "Function": "Format",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "SkuPricePropertyDefinitions:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "Property key MUST match the spelling and casing specified for the FOCUS-defined property"
+    },
+    "SkuPriceDetails-C-022-M": {
+      "RuleID": "SkuPriceDetails-C-022-M",
+      "Function": "DataType",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "All Rows",
+      "Requirement": "SkuPricePropertyDefinitions:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "Property value MUST be of the type specified for that property"
+    },
+    "SkuPriceDetails-C-023-C": {
+      "RuleID": "SkuPriceDetails-C-023-C",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceDetails column",
+      "Condition": "Property holds a numeric value",
+      "Requirement": "AND(SkuPricePropertyDefinitions:CR,PricingUnit:CR)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "Property value MUST represent the value for a single PricingUnit, denominated in the unit of measure specified for that property when the property holds a numeric value"
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/columns/skupriceid.json
+++ b/specification/conformance/conformance_rules/columns/skupriceid.json
@@ -1,0 +1,191 @@
+{
+  "ConformanceRules": {
+    "SkuPriceId-C-000-C": {
+      "RuleID": "SkuPriceId-C-000-C",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "UNIT_PRICING_SUPPORTED",
+      "Requirement": "AND(SkuPriceId-D-001-C, SkuPriceId-C-002-M, SkuPriceId-C-003-M, SkuPriceId-C-004-M, SkuPriceId-C-008-M)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "Composite rule for SkuPriceId column validation"
+    },
+    "SkuPriceId-D-001-C": {
+      "RuleID": "SkuPriceId-D-001-C",
+      "Function": "Presence",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "UNIT_PRICING_SUPPORTED",
+      "Requirement": null,
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST be present in a FOCUS dataset when the provider supports unit pricing concepts and publishes price lists, publicly or as part of contracting"
+    },
+    "SkuPriceId-C-002-M": {
+      "RuleID": "SkuPriceId-C-002-M",
+      "Function": "DataType",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "All Rows",
+      "Requirement": "String",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST be of type String"
+    },
+    "SkuPriceId-C-003-M": {
+      "RuleID": "SkuPriceId-C-003-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "All Rows",
+      "Requirement": "StringHandling:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST conform to String Handling requirements"
+    },
+    "SkuPriceId-C-004-M": {
+      "RuleID": "SkuPriceId-C-004-M",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "All Rows",
+      "Requirement": "AND(SkuPriceId-C-005-C, SkuPriceId-C-006-C, SkuPriceId-C-007-C)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId nullability is defined as follows"
+    },
+    "SkuPriceId-C-005-C": {
+      "RuleID": "SkuPriceId-C-005-C",
+      "Function": "NullabilityRules",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "ChargeCategory is 'Tax'",
+      "Requirement": "ChargeCategory:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST be null when ChargeCategory is 'Tax'"
+    },
+    "SkuPriceId-C-006-C": {
+      "RuleID": "SkuPriceId-C-006-C",
+      "Function": "NullabilityRules",
+      "Keyword": "MUST NOT",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "ChargeCategory is 'Usage' or 'Purchase' and ChargeClass is not 'Correction'",
+      "Requirement": "AND(ChargeCategory:CR, ChargeClass:CR)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST NOT be null when ChargeCategory is 'Usage' or 'Purchase' and ChargeClass is not 'Correction'"
+    },
+    "SkuPriceId-C-007-C": {
+      "RuleID": "SkuPriceId-C-007-C",
+      "Function": "NullabilityRules",
+      "Keyword": "MAY",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "All other cases",
+      "Requirement": null,
+      "Type": "static",
+      "Severity": "warning",
+      "Description": "SkuPriceId MAY be null in all other cases"
+    },
+    "SkuPriceId-C-008-M": {
+      "RuleID": "SkuPriceId-C-008-M",
+      "Function": "Composite",
+      "Keyword": null,
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "SkuPriceId is not null",
+      "Requirement": "AND(SkuPriceId-C-009-M, SkuPriceId-C-010-M, SkuPriceId-C-011-M, SkuPriceId-C-012-O, SkuPriceId-C-013-C, SkuPriceId-C-014-M, SkuPriceId-C-015-C, SkuPriceId-C-016-C)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "When SkuPriceId is not null, SkuPriceId adheres to the following additional requirements"
+    },
+    "SkuPriceId-C-009-M": {
+      "RuleID": "SkuPriceId-C-009-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "SkuPriceId is not null",
+      "Requirement": "SkuId:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST have one and only one parent SkuId"
+    },
+    "SkuPriceId-C-010-M": {
+      "RuleID": "SkuPriceId-C-010-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "SkuPriceId is not null",
+      "Requirement": null,
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST remain consistent over time"
+    },
+    "SkuPriceId-C-011-M": {
+      "RuleID": "SkuPriceId-C-011-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "SkuPriceId is not null",
+      "Requirement": "BillingAccount:CR",
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST remain consistent across billing accounts or contracts"
+    },
+    "SkuPriceId-C-012-O": {
+      "RuleID": "SkuPriceId-C-012-O",
+      "Function": "Validation",
+      "Keyword": "MAY",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "SkuPriceId is not null",
+      "Requirement": "SkuId:CR",
+      "Type": "static",
+      "Severity": "warning",
+      "Description": "SkuPriceId MAY equal SkuId"
+    },
+    "SkuPriceId-C-013-C": {
+      "RuleID": "SkuPriceId-C-013-C",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "ChargeCategory is 'Usage' or 'Purchase'",
+      "Requirement": "OR(Resource:CR, Service:CR)",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST be associated with a given resource or service when ChargeCategory is 'Usage' or 'Purchase'"
+    },
+    "SkuPriceId-C-014-M": {
+      "RuleID": "SkuPriceId-C-014-M",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "SkuPriceId is not null",
+      "Requirement": "PriceList:CR",
+      "Type": "dynamic",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST reference a SKU Price in a provider-supplied price list, enabling the lookup of detailed information about the SKU Price"
+    },
+    "SkuPriceId-C-015-C": {
+      "RuleID": "SkuPriceId-C-015-C",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "Provider publishes unit prices exclusive of discounts",
+      "Requirement": "ListUnitPrice:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST support the lookup of the ListUnitPrice when the provider publishes unit prices exclusive of discounts"
+    },
+    "SkuPriceId-C-016-C": {
+      "RuleID": "SkuPriceId-C-016-C",
+      "Function": "Validation",
+      "Keyword": "MUST",
+      "ApplicabilityCriteria": "Dataset includes SkuPriceId column",
+      "Condition": "Provider supports negotiated pricing concepts",
+      "Requirement": "ContractedUnitPrice:CR",
+      "Type": "static",
+      "Severity": "error",
+      "Description": "SkuPriceId MUST support the verification of the given ContractedUnitPrice when the provider supports negotiated pricing concepts"
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -183,6 +183,10 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "ListUnitPrice-C-000-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "ResourceName-C-000-C"
           }
         ]
       },

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -187,6 +187,22 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "ResourceName-C-000-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SkuId-C-000-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SkuMeter-C-000-O"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SkuPriceDetails-C-000-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SkuPriceId-C-000-C"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Add UNIT_PRICING_SUPPORTED applicability criteria for SKU columns
- Create comprehensive conformance rules for SkuId, SkuMeter, SkuPriceDetails, and SkuPriceId columns
- Update dataset references in costandusage.json to include all 4 SKU column rule references

## Test plan
- [ ] Validate JSON schema compliance for all new conformance rule files
- [ ] Verify applicability criteria reference is correctly added
- [ ] Confirm dataset references are in proper alphabetical order
- [ ] Test rule validation logic with sample data

Resolves #1298, #1299, #1300, #1301

🤖 Generated with [Claude Code](https://claude.ai/code)