### PR TITLE
AI #1267: Add SubAccountId conformance rules

### DIFF
--- a/specification/conformance/applicability_criteria.json
+++ b/specification/conformance/applicability_criteria.json
@@ -14,6 +14,9 @@
     },
     "USAGE_MEASUREMENT_SUPPORTED": {
       "Description": "Data generator supports the measurement of usage quantities"
+    },
+    "SUB_ACCOUNT_SUPPORTED": {
+      "Description": "Data generator supports sub account construct for resource and service grouping"
     }
   }
 }

--- a/specification/conformance/conformance_rules/columns/subaccountid.json
+++ b/specification/conformance/conformance_rules/columns/subaccountid.json
@@ -27,16 +27,15 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "SubAccountId-C-003-M"
-          },
-          {
-            "CheckFunction": "CheckConformanceRule",
-            "ConformanceRuleId": "SubAccountId-C-004-M"
           }
         ]
       },
       "Condition": {},
       "Dependencies": [
-        "CostAndUsage-D-018-C"
+        "CostAndUsage-D-018-C",
+        "SubAccountId-C-001-M",
+        "SubAccountId-C-002-M",
+        "SubAccountId-C-003-M"
       ]
     }
   },
@@ -85,6 +84,40 @@
     }
   },
   "SubAccountId-C-003-M": {
+    "Function": "Nullability",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId nullability is defined as follows:",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-004-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-005-M"
+          }
+        ]
+      },
+      "Condition": {},
+      "Dependencies": [
+        "SubAccountId-C-004-M",
+        "SubAccountId-C-005-M"
+      ]
+    }
+  },
+  "SubAccountId-C-004-M": {
     "Function": "Validation",
     "Reference": "SubAccountId",
     "EntityType": "Column",
@@ -103,7 +136,7 @@
       "Dependencies": []
     }
   },
-  "SubAccountId-C-004-M": {
+  "SubAccountId-C-005-M": {
     "Function": "Validation",
     "Reference": "SubAccountId",
     "EntityType": "Column",

--- a/specification/conformance/conformance_rules/columns/subaccountid.json
+++ b/specification/conformance/conformance_rules/columns/subaccountid.json
@@ -1,0 +1,125 @@
+{
+  "SubAccountId-C-000-C": {
+    "Function": "Composite",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "All SubAccountId rules MUST be enforced",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-001-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-002-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-003-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-004-M"
+          }
+        ]
+      },
+      "Condition": {},
+      "Dependencies": [
+        "CostAndUsage-D-018-C"
+      ]
+    }
+  },
+  "SubAccountId-C-001-M": {
+    "Function": "Type",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST be of type String",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "TypeString",
+        "ColumnName": "SubAccountId"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "SubAccountId-C-002-M": {
+    "Function": "Format",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST conform to StringHandling requirements",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "FormatString",
+        "ColumnName": "SubAccountId"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "SubAccountId-C-003-M": {
+    "Function": "Validation",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST be null when a charge is not related to a sub account",
+      "Keyword": "MUST",
+      "Requirement": {},
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "SubAccountId-C-004-M": {
+    "Function": "Validation",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST NOT be null when a charge is related to a sub account",
+      "Keyword": "MUST",
+      "Requirement": {},
+      "Condition": {},
+      "Dependencies": []
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -108,7 +108,7 @@
           },
           {
             "CheckFunction": "CheckConformanceRule",
-            "ConformanceRuleId": "CostAndUsage-D-018-C"
+            "ConformanceRuleId": "CostAndUsage-D-019-C"
           }
         ]
       },
@@ -128,7 +128,8 @@
         "CostAndUsage-D-014-M",
         "CostAndUsage-D-015-M",
         "CostAndUsage-D-016-M",
-        "CostAndUsage-D-017-M"
+        "CostAndUsage-D-017-M",
+        "CostAndUsage-D-019-C"
       ]
     }
   },
@@ -205,11 +206,11 @@
           },
           {
             "CheckFunction": "CheckConformanceRule",
-            "ConformanceRuleId": "SubAccountId-C-000-C"
+            "ConformanceRuleId": "ListUnitPrice-C-000-C"
           },
           {
             "CheckFunction": "CheckConformanceRule",
-            "ConformanceRuleId": "ListUnitPrice-C-000-C"
+            "ConformanceRuleId": "SubAccountId-C-000-C"
           }
         ]
       },
@@ -229,7 +230,8 @@
         "CommitmentDiscountUnit-C-000-M",
         "ChargeCategory-C-000-M",
         "ConsumedQuantity-C-000-C",
-        "ListUnitPrice-C-000-C"
+        "ListUnitPrice-C-000-C",
+        "SubAccountId-C-000-C"
       ]
     }
   },
@@ -551,10 +553,10 @@
       "Dependencies": []
     }
   },
-  "CostAndUsage-D-018-C": {
+  "CostAndUsage-D-019-C": {
     "Function": "Presence",
     "Reference": "SubAccountId",
-    "EntityType": "Column",
+    "EntityType": "Dataset",
     "Notes": "",
     "CRVersionIntroduced": "1.2",
     "Status": "Active",

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -112,7 +112,7 @@
           },
           {
             "CheckFunction": "CheckConformanceRule",
-            "ConformanceRuleId": "CostAndUsage-D-019-C" 
+            "ConformanceRuleId": "CostAndUsage-D-019-C"
           }
         ]
       },
@@ -135,7 +135,6 @@
         "CostAndUsage-D-017-M",
         "CostAndUsage-D-018-M",
         "CostAndUsage-D-019-C"
-        
       ]
     }
   },
@@ -584,6 +583,7 @@
       },
       "Condition": {},
       "Dependencies": []
+    }
   },
   "CostAndUsage-D-019-C": {
     "Function": "Presence",

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -105,6 +105,10 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "CostAndUsage-D-017-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "CostAndUsage-D-018-C"
           }
         ]
       },
@@ -198,6 +202,10 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "ConsumedQuantity-C-000-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-000-C"
           },
           {
             "CheckFunction": "CheckConformanceRule",
@@ -538,6 +546,28 @@
       "Requirement": {
         "CheckFunction": "ColumnPresent",
         "ColumnName": "CommitmentDiscountStatus"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "CostAndUsage-D-018-C": {
+    "Function": "Presence",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST be present in a FOCUS dataset when the provider supports a sub account construct",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "ColumnPresent",
+        "ColumnName": "SubAccountId"
       },
       "Condition": {},
       "Dependencies": []


### PR DESCRIPTION
- Added SUB_ACCOUNT_SUPPORTED applicability criteria for sub account construct support
- Created comprehensive conformance rules for SubAccountId column:
  - SubAccountId-C-000-C: Main composite rule with SUB_ACCOUNT_SUPPORTED criteria
  - SubAccountId-C-001-M: Type validation (MUST be String)
  - SubAccountId-C-002-M: StringHandling format requirements
  - SubAccountId-C-003-M: Nullability rule (MUST be null when charge not related to sub account)
  - SubAccountId-C-004-M: Nullability rule (MUST NOT be null when charge is related to sub account)
- Added CostAndUsage-D-018-C presence rule for SubAccountId with SUB_ACCOUNT_SUPPORTED criteria
- Updated CostAndUsage dataset composite rules to include SubAccountId validation
- Generated updated cr-1.2.json with all new rules and criteria

🤖 Generated with [Claude Code](https://claude.ai/code)