### PR TITLE
AI #1268: Add SubAccountName and SubAccountId conformance rules

### DIFF
--- a/specification/conformance/applicability_criteria.json
+++ b/specification/conformance/applicability_criteria.json
@@ -14,6 +14,9 @@
     },
     "USAGE_MEASUREMENT_SUPPORTED": {
       "Description": "Data generator supports the measurement of usage quantities"
+    },
+    "SUB_ACCOUNT_SUPPORTED": {
+      "Description": "Data generator supports sub account construct for resource and service grouping"
     }
   }
 }

--- a/specification/conformance/conformance_rules/columns/subaccountid.json
+++ b/specification/conformance/conformance_rules/columns/subaccountid.json
@@ -1,0 +1,125 @@
+{
+  "SubAccountId-C-000-C": {
+    "Function": "Composite",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "All SubAccountId rules MUST be enforced",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-001-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-002-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-003-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-004-M"
+          }
+        ]
+      },
+      "Condition": {},
+      "Dependencies": [
+        "CostAndUsage-D-018-C"
+      ]
+    }
+  },
+  "SubAccountId-C-001-M": {
+    "Function": "Type",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST be of type String",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "TypeString",
+        "ColumnName": "SubAccountId"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "SubAccountId-C-002-M": {
+    "Function": "Format",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST conform to StringHandling requirements",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "FormatString",
+        "ColumnName": "SubAccountId"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "SubAccountId-C-003-M": {
+    "Function": "Validation",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST be null when a charge is not related to a sub account",
+      "Keyword": "MUST",
+      "Requirement": {},
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "SubAccountId-C-004-M": {
+    "Function": "Validation",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Dynamic",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST NOT be null when a charge is related to a sub account",
+      "Keyword": "MUST",
+      "Requirement": {},
+      "Condition": {},
+      "Dependencies": []
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/columns/subaccountname.json
+++ b/specification/conformance/conformance_rules/columns/subaccountname.json
@@ -1,0 +1,145 @@
+{
+  "SubAccountName-C-000-C": {
+    "Function": "Composite",
+    "Reference": "SubAccountName",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "All SubAccountName rules MUST be enforced",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountName-C-001-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountName-C-002-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountName-C-003-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountName-C-004-M"
+          }
+        ]
+      },
+      "Condition": {},
+      "Dependencies": [
+        "CostAndUsage-D-019-C"
+      ]
+    }
+  },
+  "SubAccountName-C-001-M": {
+    "Function": "Type",
+    "Reference": "SubAccountName",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountName MUST be of type String",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "TypeString",
+        "ColumnName": "SubAccountName"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "SubAccountName-C-002-M": {
+    "Function": "Format",
+    "Reference": "SubAccountName",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountName MUST conform to StringHandling requirements",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "FormatString",
+        "ColumnName": "SubAccountName"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "SubAccountName-C-003-M": {
+    "Function": "Validation",
+    "Reference": "SubAccountName",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountName MUST be null when SubAccountId is null",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "CheckValue",
+        "ColumnName": "SubAccountName",
+        "Value": null
+      },
+      "Condition": {
+        "CheckFunction": "CheckValue",
+        "ColumnName": "SubAccountId",
+        "Value": null
+      },
+      "Dependencies": [
+        "SubAccountId-C-000-C"
+      ]
+    }
+  },
+  "SubAccountName-C-004-M": {
+    "Function": "Validation",
+    "Reference": "SubAccountName",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountName MUST NOT be null when SubAccountId is not null",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "CheckNotValue",
+        "ColumnName": "SubAccountName",
+        "Value": null
+      },
+      "Condition": {
+        "CheckFunction": "CheckNotValue",
+        "ColumnName": "SubAccountId",
+        "Value": null
+      },
+      "Dependencies": [
+        "SubAccountId-C-000-C"
+      ]
+    }
+  }
+}

--- a/specification/conformance/conformance_rules/datasets/costandusage.json
+++ b/specification/conformance/conformance_rules/datasets/costandusage.json
@@ -102,6 +102,14 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "CostAndUsage-D-017-M"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "CostAndUsage-D-018-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "CostAndUsage-D-019-C"
           }
         ]
       },
@@ -179,6 +187,14 @@
           {
             "CheckFunction": "CheckConformanceRule",
             "ConformanceRuleId": "ConsumedQuantity-C-000-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountId-C-000-C"
+          },
+          {
+            "CheckFunction": "CheckConformanceRule",
+            "ConformanceRuleId": "SubAccountName-C-000-C"
           },
           {
             "CheckFunction": "CheckConformanceRule",
@@ -503,6 +519,50 @@
       "Requirement": {
         "CheckFunction": "ColumnPresent",
         "ColumnName": "CommitmentDiscountStatus"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "CostAndUsage-D-018-C": {
+    "Function": "Presence",
+    "Reference": "SubAccountId",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountId MUST be present in a FOCUS dataset when the provider supports a sub account construct",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "ColumnPresent",
+        "ColumnName": "SubAccountId"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "CostAndUsage-D-019-C": {
+    "Function": "Presence",
+    "Reference": "SubAccountName",
+    "EntityType": "Column",
+    "Notes": "",
+    "CRVersionIntroduced": "1.2",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "SUB_ACCOUNT_SUPPORTED"
+    ],
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "SubAccountName MUST be present in a FOCUS dataset when the provider supports a sub account construct",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "ColumnPresent",
+        "ColumnName": "SubAccountName"
       },
       "Condition": {},
       "Dependencies": []

--- a/specification/conformance/cr-1.2.json
+++ b/specification/conformance/cr-1.2.json
@@ -17,6 +17,9 @@
     },
     "USAGE_MEASUREMENT_SUPPORTED": {
       "Description": "Data generator supports the measurement of usage quantities"
+    },
+    "SUB_ACCOUNT_SUPPORTED": {
+      "Description": "Data generator supports sub account construct for resource and service grouping"
     }
   },
   "CheckFunctions": {
@@ -194,632 +197,6 @@
     }
   },
   "ConformanceRules": {
-    "CostAndUsage-D-000-M": {
-      "Function": "Composite",
-      "Reference": "CostAndUsage",
-      "EntityType": "Dataset",
-      "Notes": "Main dataset composite rule",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-001-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-002-M"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-001-M": {
-      "Function": "Composite",
-      "Reference": "CostAndUsage",
-      "EntityType": "Dataset",
-      "Notes": "Columns present composite rule",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-003-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-004-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-005-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-C-006-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-C-007-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-008-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-009-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-010-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-011-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-012-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-013-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-014-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-015-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CostAndUsage-D-016-M"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-002-M": {
-      "Function": "Composite",
-      "Reference": "CostAndUsage",
-      "EntityType": "Dataset",
-      "Notes": "Columns composite rule",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "AvailabilityZone-C-000-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BilledCost-C-000-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingAccountName-C-000-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingAccountType-C-000-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingPeriodEnd-C-000-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingPeriodStart-C-000-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountCategory-C-000-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountId-C-000-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountName-C-000-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountType-C-000-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-000-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ChargeCategory-C-000-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ConsumedQuantity-C-000-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ListUnitPrice-C-000-C"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-003-C": {
-      "Function": "Presence",
-      "Reference": "AvailabilityZone",
-      "EntityType": "Dataset",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "AVAILABILITY_ZONE_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "RECOMMENDED be present in a FOCUS dataset",
-        "Keyword": "RECOMMENDED",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "AvailabilityZone"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-004-C": {
-      "Function": "Presence",
-      "Reference": "ListUnitPrice",
-      "EntityType": "Dataset",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "PUBLIC_PRICE_LIST_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be present in a FOCUS dataset when the data generator publishes unit prices exclusive of discounts",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "ListUnitPrice"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-005-M": {
-      "Function": "Presence",
-      "Reference": "BillingAccountName",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be present in a FOCUS dataset",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "BillingAccountName"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-C-006-M": {
-      "Function": "Presence",
-      "Reference": "BilledCost",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be present in a FOCUS dataset",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "BilledCost"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-C-007-C": {
-      "Function": "Presence",
-      "Reference": "BillingAccountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be present in a FOCUS dataset",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "BillingAccountType"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-008-M": {
-      "Function": "Presence",
-      "Reference": "ChargeCategory",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be present in a FOCUS dataset",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "ChargeCategory"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-009-M": {
-      "Function": "Presence",
-      "Reference": "BillingPeriodStart",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be present in a FOCUS dataset.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "BillingPeriodStart"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-010-M": {
-      "Function": "Presence",
-      "Reference": "BillingPeriodEnd",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be present in a FOCUS dataset",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "BillingPeriodEnd"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-011-C": {
-      "Function": "Presence",
-      "Reference": "ConsumedQuantity",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "ConsumedQuantity MUST be present in a FOCUS dataset when the provider supports the measurement of usage",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "ConsumedQuantity"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-012-M": {
-      "Function": "Presence",
-      "Reference": "CommitmentDiscountName",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountName MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "CommitmentDiscountName"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-013-M": {
-      "Function": "Presence",
-      "Reference": "CommitmentDiscountId",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountId MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "CommitmentDiscountId"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-014-M": {
-      "Function": "Presence",
-      "Reference": "CommitmentDiscountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountType MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "CommitmentDiscountType"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-015-M": {
-      "Function": "Presence",
-      "Reference": "CommitmentDiscountUnit",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountUnit MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "CommitmentDiscountUnit"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CostAndUsage-D-016-M": {
-      "Function": "Presence",
-      "Reference": "CommitmentDiscountCategory",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountCategory MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "ColumnPresent",
-          "ColumnName": "CommitmentDiscountCategory"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "DateTimeFormat-A-000-M": {
-      "Function": "Composite",
-      "Reference": "DateTimeFormat",
-      "EntityType": "Attribute",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "DateTimeFormat-A-001-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "DateTimeFormat-A-002-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "DateTimeFormat-A-003-M"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "DateTimeFormat-A-001-M": {
-      "Function": "Validation",
-      "Reference": "DateTimeFormat",
-      "EntityType": "Attribute",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "Date/time values MUST be in UTC (Coordinated Universal Time) to avoid ambiguity and ensure consistency across different time zones",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "DateTimeFormat-A-002-M": {
-      "Function": "Validation",
-      "Reference": "DateTimeFormat",
-      "EntityType": "Attribute",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "Date/time values format MUST be aligned with ISO 8601 standard, which provides a globally recognized format for representing dates and times (see ISO 8601-1:2019 governing document for details)",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "DateTimeFormat-A-003-M": {
-      "Function": "Validation",
-      "Reference": "DateTimeFormat",
-      "EntityType": "Attribute",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "Values providing information about a specific moment in time MUST be represented in the extended ISO 8601 format with UTC offset ('YYYY-MM-DDTHH:mm:ssZ')",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CurrencyFormat-A-000-M": {
-      "Function": "Composite",
-      "Reference": "CurrencyFormat",
-      "EntityType": "Attribute",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "Column IDs MUST use Pascal case",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CurrencyFormat-A-001-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CurrencyFormat-A-002-M"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CurrencyFormat-A-001-M": {
-      "Function": "Validation",
-      "Reference": "CurrencyFormat",
-      "EntityType": "Attribute",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "Currency-related columns MUST be represented as a three-letter alphabetic code as dictated in the governing document ISO 4217:2015 when the value is presented in national currency (e.g., USD, EUR)",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CurrencyFormat-A-002-M": {
-      "Function": "Validation",
-      "Reference": "CurrencyFormat",
-      "EntityType": "Attribute",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "Currency-related columns MUST conform to StringHandling requirements when the value is presented in virtual currency (e.g., credits, tokens)",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
     "ColumnHandling-A-000-M": {
       "Function": "Composite",
       "Reference": "ColumnHandling",
@@ -1114,115 +491,28 @@
         "Dependencies": []
       }
     },
-    "CommitmentDiscountName-C-000-M": {
+    "CurrencyFormat-A-000-M": {
       "Function": "Composite",
-      "Reference": "CommitmentDiscountName",
-      "EntityType": "Column",
+      "Reference": "CurrencyFormat",
+      "EntityType": "Attribute",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
+      "ApplicabilityCriteria": [],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "The CommitmentDiscountName column adheres to the following requirements:",
+        "MustSatisfy": "Column IDs MUST use Pascal case",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "AND",
           "Items": [
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountName-C-001-M"
+              "ConformanceRuleId": "CurrencyFormat-A-001-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountName-C-002-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountName-C-003-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountName-C-004-M"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": [
-          "CostAndUsage-D-012-M"
-        ]
-      }
-    },
-    "CommitmentDiscountName-C-001-M": {
-      "Function": "Type",
-      "Reference": "CommitmentDiscountName",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountName MUST be of type String.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "TypeString",
-          "ColumnName": "CommitmentDiscountName"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountName-C-002-M": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountName",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountName MUST conform to StringHandling requirements.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "FormatString",
-          "ColumnName": "CommitmentDiscountName"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountName-C-003-M": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountName",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountName nullability is defined as follows:",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountName-C-004-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountName-C-005-C"
+              "ConformanceRuleId": "CurrencyFormat-A-002-M"
             }
           ]
         },
@@ -1230,101 +520,383 @@
         "Dependencies": []
       }
     },
-    "CommitmentDiscountName-C-004-C": {
+    "CurrencyFormat-A-001-M": {
       "Function": "Validation",
-      "Reference": "CommitmentDiscountName",
-      "EntityType": "Column",
+      "Reference": "CurrencyFormat",
+      "EntityType": "Attribute",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
+      "ApplicabilityCriteria": [],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountName MUST be null when CommitmentDiscountId is null.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "CommitmentDiscountName",
-          "Value": null
-        },
-        "Condition": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "CommitmentDiscountId",
-          "Value": null
-        },
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountName-C-005-C": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountName",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "When CommitmentDiscountId is not null, CommitmentDiscountName adheres to the following additional requirements:",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountName-C-006-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountName-C-007-C"
-            }
-          ]
-        },
-        "Condition": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "CommitmentDiscountId",
-          "Value": null
-        },
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountName-C-006-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountName",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountName MUST NOT be null when a display name can be assigned to a commitment discount.",
+        "MustSatisfy": "Currency-related columns MUST be represented as a three-letter alphabetic code as dictated in the governing document ISO 4217:2015 when the value is presented in national currency (e.g., USD, EUR)",
         "Keyword": "MUST",
         "Requirement": {},
         "Condition": {},
         "Dependencies": []
       }
     },
-    "CommitmentDiscountName-C-007-C": {
+    "CurrencyFormat-A-002-M": {
       "Function": "Validation",
-      "Reference": "CommitmentDiscountName",
+      "Reference": "CurrencyFormat",
+      "EntityType": "Attribute",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "Currency-related columns MUST conform to StringHandling requirements when the value is presented in virtual currency (e.g., credits, tokens)",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "DateTimeFormat-A-000-M": {
+      "Function": "Composite",
+      "Reference": "DateTimeFormat",
+      "EntityType": "Attribute",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "DateTimeFormat-A-001-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "DateTimeFormat-A-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "DateTimeFormat-A-003-M"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "DateTimeFormat-A-001-M": {
+      "Function": "Validation",
+      "Reference": "DateTimeFormat",
+      "EntityType": "Attribute",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "Date/time values MUST be in UTC (Coordinated Universal Time) to avoid ambiguity and ensure consistency across different time zones",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "DateTimeFormat-A-002-M": {
+      "Function": "Validation",
+      "Reference": "DateTimeFormat",
+      "EntityType": "Attribute",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "Date/time values format MUST be aligned with ISO 8601 standard, which provides a globally recognized format for representing dates and times (see ISO 8601-1:2019 governing document for details)",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "DateTimeFormat-A-003-M": {
+      "Function": "Validation",
+      "Reference": "DateTimeFormat",
+      "EntityType": "Attribute",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "Values providing information about a specific moment in time MUST be represented in the extended ISO 8601 format with UTC offset ('YYYY-MM-DDTHH:mm:ssZ')",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "AvailabilityZone-C-000-M": {
+      "Function": "Composite",
+      "Reference": "AvailabilityZone",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "AVAILABILITY_ZONE_SUPPORTED"
       ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "AvailabilityZone-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "AvailabilityZone-C-003-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "AvailabilityZone-C-004-M"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-D-003-C"
+        ]
+      }
+    },
+    "AvailabilityZone-C-002-M": {
+      "Function": "Type",
+      "Reference": "AvailabilityZone",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be of type String",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeString",
+          "ColumnName": "AvailabilityZone"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "AvailabilityZone-C-003-M": {
+      "Function": "Type",
+      "Reference": "AvailabilityZone",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST conform to StringHandling requirements",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "FormatString",
+          "ColumnName": "AvailabilityZone"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "AvailabilityZone-C-004-M": {
+      "Function": "Validation",
+      "Reference": "AvailabilityZone",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
       "Type": "Dynamic",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountName MAY be null when a display name cannot be assigned to a commitment discount.",
-        "Keyword": "MAY",
+        "MustSatisfy": "MUST be null when a charge is not specific to an availability zone",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BilledCost-C-000-M": {
+      "Function": "Composite",
+      "Reference": "BilledCost",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BilledCost-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BilledCost-C-003-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BilledCost-C-004-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BilledCost-C-005-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BilledCost-C-006-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BilledCost-C-007-M"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-C-006-M"
+        ]
+      }
+    },
+    "BilledCost-C-002-M": {
+      "Function": "Validation",
+      "Reference": "BilledCost",
+      "EntityType": "Column",
+      "Notes": "A null value would invalidate accounting use cases",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST NOT be null",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "BilledCost",
+          "Value": null
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BilledCost-C-003-M": {
+      "Function": "Type",
+      "EntityType": "Column",
+      "Reference": "BilledCost",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be of type Decimal",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeDecimal",
+          "ColumnName": "BilledCost"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BilledCost-C-004-M": {
+      "Function": "Format",
+      "EntityType": "Column",
+      "Reference": "BilledCost",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST conform to NumericFormat requirements",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "FormatNumeric",
+          "ColumnName": "BilledCost"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BilledCost-C-005-M": {
+      "Function": "Validation",
+      "Reference": "BilledCost",
+      "EntityType": "Column",
+      "Notes": "Common for marketplace charges paid by customer directly to seller",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be 0 for charges where payments are received by a third party",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "BilledCost",
+          "Value": 0
+        },
+        "Condition": {
+          "CheckFunction": "CheckNotSameValue",
+          "ColumnAName": "ProviderName",
+          "ColumnBName": "InvoiceIssuerName"
+        },
+        "Dependencies": [
+          "ProviderName-C-000-M",
+          "InvoiceIssuerName-C-000-M"
+        ]
+      }
+    },
+    "BilledCost-C-006-M": {
+      "Function": "Validation",
+      "Reference": "BilledCost",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be denominated in the BillingCurrency",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BilledCost-C-007-M": {
+      "Function": "Validation",
+      "Reference": "BilledCost",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "SUM(BilledCost) MUST equal payable amount in invoice from InvoiceIssuer",
+        "Keyword": "MUST",
         "Requirement": {},
         "Condition": {},
         "Dependencies": []
@@ -1427,6 +999,298 @@
           "CheckFunction": "CheckNotValue",
           "ColumnName": "BillingAccountName",
           "Value": null
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BillingAccountType-C-000-M": {
+      "Function": "Composite",
+      "Reference": "BillingAccountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingAccountType-C-001-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingAccountType-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingAccountType-C-003-M"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-C-007-C"
+        ]
+      }
+    },
+    "BillingAccountType-C-002-M": {
+      "Function": "Type",
+      "Reference": "BillingAccountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be of type String",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeString",
+          "ColumnName": "BillingAccountType"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BillingAccountType-C-003-M": {
+      "Function": "Type",
+      "Reference": "BillingAccountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST conform to StringHandling requirements",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "FormatString",
+          "ColumnName": "BillingAccountType"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BillingAccountType-C-004-C": {
+      "Function": "Composite",
+      "Reference": "BillingAccountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingAccountType-C-005-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingAccountType-C-006-M"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BillingAccountType-C-005-M": {
+      "Function": "Validation",
+      "Reference": "BillingAccountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be null when BillingAccountId is null",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "BillingAccountType",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "BillingAccountId",
+          "Value": null
+        },
+        "Dependencies": []
+      }
+    },
+    "BillingAccountType-C-006-M": {
+      "Function": "Validation",
+      "Reference": "BillingAccountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST NOT be null when BillingAccountId is not null",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "BillingAccountType",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "BillingAccountId",
+          "Value": null
+        },
+        "Dependencies": []
+      }
+    },
+    "BillingAccountType-C-007-M": {
+      "Function": "Validation",
+      "Reference": "BillingAccountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be a consistent, readable display value",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BillingPeriodEnd-C-000-M": {
+      "Function": "Composite",
+      "Reference": "BillingPeriodEnd",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "BillingPeriodEnd column adheres to the following requirements",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingPeriodEnd-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingPeriodEnd-C-003-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingPeriodEnd-C-004-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingPeriodEnd-C-005-M"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-D-010-M"
+        ]
+      }
+    },
+    "BillingPeriodEnd-C-002-M": {
+      "Function": "Type",
+      "Reference": "BillingPeriodEnd",
+      "EntityType": "Column",
+      "Notes": "Relies on new TypeDateTime check",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be of type Date/Time",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeDateTime",
+          "ColumnName": "BillingPeriodEnd"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BillingPeriodEnd-C-003-M": {
+      "Function": "Format",
+      "Reference": "BillingPeriodEnd",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST conform to DateTimeFormat requirements",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "FormatDateTime",
+          "ColumnName": "BillingPeriodEnd"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BillingPeriodEnd-C-004-M": {
+      "Function": "Validation",
+      "Reference": "BillingPeriodEnd",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST NOT be null",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "BillingPeriodEnd",
+          "Value": null
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "BillingPeriodEnd-C-005-M": {
+      "Function": "Validation",
+      "Reference": "BillingPeriodEnd",
+      "EntityType": "Column",
+      "Notes": "Validates exclusive end bound of the billing period.",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be the exclusive end bound of the billing period",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckExclusiveEndBound",
+          "StartColumnName": "BillingPeriodStart",
+          "EndColumnName": "BillingPeriodEnd"
         },
         "Condition": {},
         "Dependencies": []
@@ -1675,16 +1539,638 @@
         "Dependencies": []
       }
     },
-    "AvailabilityZone-C-000-M": {
+    "CommitmentDiscountCategory-C-000-C": {
       "Function": "Composite",
-      "Reference": "AvailabilityZone",
+      "Reference": "CommitmentDiscountCategory",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "AVAILABILITY_ZONE_SUPPORTED"
+        "COMMITMENT_DISCOUNT_SUPPORTED"
       ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "All CommitmentDiscountCategory rules MUST be enforced when the provider supports commitment discounts.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountCategory-C-001-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountCategory-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountCategory-C-005-M"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-D-016-M"
+        ]
+      }
+    },
+    "CommitmentDiscountCategory-C-001-M": {
+      "Function": "Type",
+      "Reference": "CommitmentDiscountCategory",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountCategory MUST be of type String.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeString",
+          "ColumnName": "CommitmentDiscountCategory"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountCategory-C-002-M": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountCategory",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountCategory nullability is defined as follows:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountCategory-C-003-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountCategory-C-004-C"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountCategory-C-003-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountCategory",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountCategory MUST be null when CommitmentDiscountId is null.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "CommitmentDiscountCategory",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "CommitmentDiscountId",
+          "Value": null
+        },
+        "Dependencies": [
+          "CommitmentDiscountId-C-000-C"
+        ]
+      }
+    },
+    "CommitmentDiscountCategory-C-004-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountCategory",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountCategory MUST NOT be null when CommitmentDiscountId is not null.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountCategory",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountId",
+          "Value": null
+        },
+        "Dependencies": [
+          "CommitmentDiscountId-C-000-C"
+        ]
+      }
+    },
+    "CommitmentDiscountCategory-C-005-M": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountCategory",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountCategory MUST be one of the allowed values.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "OR",
+          "Items": [
+            {
+              "CheckFunction": "CheckValue",
+              "ColumnName": "CommitmentDiscountCategory",
+              "Value": "Spend"
+            },
+            {
+              "CheckFunction": "CheckValue",
+              "ColumnName": "CommitmentDiscountCategory",
+              "Value": "Usage"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountId-C-000-C": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "All CommitmentDiscountId rules MUST be enforced",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountId-C-001-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountId-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountId-C-003-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountId-C-006-C"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-D-013-M"
+        ]
+      }
+    },
+    "CommitmentDiscountId-C-001-M": {
+      "Function": "Type",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountId MUST be of type String.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeString",
+          "ColumnName": "CommitmentDiscountId"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountId-C-002-M": {
+      "Function": "Format",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountId MUST conform to StringHandling requirements.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "FormatString",
+          "ColumnName": "CommitmentDiscountId"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountId-C-003-M": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountId nullability is defined as follows:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountId-C-004-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountId-C-005-C"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountId-C-004-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountId MUST be null when a charge is not related to a commitment discount.",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountId-C-005-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountId MUST NOT be null when a charge is related to a commitment discount.",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountId-C-006-C": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "When CommitmentDiscountId is not null, CommitmentDiscountId adheres to the following additional requirements:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountId-C-007-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountId-C-008-C"
+            }
+          ]
+        },
+        "Condition": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountId",
+          "Value": null
+        },
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountId-C-007-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountId MUST be a unique identifier within the provider.",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountId-C-008-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountId SHOULD be a fully-qualified identifier.",
+        "Keyword": "SHOULD",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountName-C-000-M": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "The CommitmentDiscountName column adheres to the following requirements:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountName-C-001-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountName-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountName-C-003-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountName-C-004-M"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-D-012-M"
+        ]
+      }
+    },
+    "CommitmentDiscountName-C-001-M": {
+      "Function": "Type",
+      "Reference": "CommitmentDiscountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountName MUST be of type String.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeString",
+          "ColumnName": "CommitmentDiscountName"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountName-C-002-M": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountName MUST conform to StringHandling requirements.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "FormatString",
+          "ColumnName": "CommitmentDiscountName"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountName-C-003-M": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountName nullability is defined as follows:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountName-C-004-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountName-C-005-C"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountName-C-004-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountName MUST be null when CommitmentDiscountId is null.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "CommitmentDiscountName",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "CommitmentDiscountId",
+          "Value": null
+        },
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountName-C-005-C": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "When CommitmentDiscountId is not null, CommitmentDiscountName adheres to the following additional requirements:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountName-C-006-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountName-C-007-C"
+            }
+          ]
+        },
+        "Condition": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountId",
+          "Value": null
+        },
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountName-C-006-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountName MUST NOT be null when a display name can be assigned to a commitment discount.",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountName-C-007-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountName MAY be null when a display name cannot be assigned to a commitment discount.",
+        "Keyword": "MAY",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountStatus-C-000-C": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountStatus",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
       "Type": "Static",
       "ValidationCriteria": {
         "MustSatisfy": "",
@@ -1694,47 +2180,49 @@
           "Items": [
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "AvailabilityZone-C-002-M"
+              "ConformanceRuleId": "CommitmentDiscountStatus-C-001-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "AvailabilityZone-C-003-M"
+              "ConformanceRuleId": "CommitmentDiscountStatus-C-002-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "AvailabilityZone-C-004-M"
+              "ConformanceRuleId": "CommitmentDiscountStatus-C-005-M"
             }
           ]
         },
         "Condition": {},
         "Dependencies": [
-          "CostAndUsage-D-003-C"
+          "CostAndUsage-D-009-M"
         ]
       }
     },
-    "AvailabilityZone-C-002-M": {
+    "CommitmentDiscountStatus-C-001-M": {
       "Function": "Type",
-      "Reference": "AvailabilityZone",
+      "Reference": "CommitmentDiscountStatus",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
-      "ApplicabilityCriteria": [],
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
       "Type": "Static",
       "ValidationCriteria": {
         "MustSatisfy": "MUST be of type String",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "TypeString",
-          "ColumnName": "AvailabilityZone"
+          "ColumnName": "CommitmentDiscountStatus"
         },
         "Condition": {},
         "Dependencies": []
       }
     },
-    "AvailabilityZone-C-003-M": {
-      "Function": "Type",
-      "Reference": "AvailabilityZone",
+    "CommitmentDiscountStatus-C-002-M": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountStatus",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
@@ -1742,27 +2230,839 @@
       "ApplicabilityCriteria": [],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "MUST conform to StringHandling requirements",
+        "MustSatisfy": "",
         "Keyword": "MUST",
         "Requirement": {
-          "CheckFunction": "FormatString",
-          "ColumnName": "AvailabilityZone"
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountStatus-C-003-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountStatus-C-004-C"
+            }
+          ]
         },
         "Condition": {},
         "Dependencies": []
       }
     },
-    "AvailabilityZone-C-004-M": {
+    "CommitmentDiscountStatus-C-004-C": {
       "Function": "Validation",
-      "Reference": "AvailabilityZone",
+      "Reference": "CommitmentDiscountStatus",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST not be null",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountStatus",
+          "Value": null
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CommitmentDiscountId"
+        ],
+        "Value": null
+      }
+    },
+    "CommitmentDiscountStatus-C-005-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountStatus",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST NOT be null",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountStatus",
+          "Value": null
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CommitmentDiscountId"
+        ],
+        "Value": null
+      }
+    },
+    "CommitmentDiscountStatus-C-006-M": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountStatus",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be one of the allowed values",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckAllowedValues",
+          "ColumnName": "CommitmentDiscountStatus",
+          "AllowedValues": [
+            "Active",
+            "Expired",
+            "Pending"
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountType-C-000-M": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "All CommitmentDiscountType rules MUST be enforced.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountType-C-001-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountType-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountType-C-003-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountType-C-004-C"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-D-014-M"
+        ]
+      }
+    },
+    "CommitmentDiscountType-C-001-M": {
+      "Function": "Type",
+      "Reference": "CommitmentDiscountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountType MUST be of type String.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeString",
+          "ColumnName": "CommitmentDiscountType"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountType-C-002-M": {
+      "Function": "Format",
+      "Reference": "CommitmentDiscountType",
+      "EntityType": "Column",
+      "Notes": "Cross-column reference: StringHandling",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountType MUST conform to StringHandling requirements.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "FormatString",
+          "ColumnName": "CommitmentDiscountType"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountType-C-003-M": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountType nullability is defined as follows:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountType-C-004-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountType-C-005-C"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountType-C-004-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountType",
+      "EntityType": "Column",
+      "Notes": "Cross-column reference: CommitmentDiscountId",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountType MUST be null when CommitmentDiscountId is null.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "CommitmentDiscountType",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "CommitmentDiscountId",
+          "Value": null
+        },
+        "Dependencies": [
+          "CommitmentDiscountId-C-000-M"
+        ]
+      }
+    },
+    "CommitmentDiscountType-C-005-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountType",
+      "EntityType": "Column",
+      "Notes": "Cross-column reference: CommitmentDiscountId",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountType MUST NOT be null when CommitmentDiscountId is not null.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountType",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountId",
+          "Value": null
+        },
+        "Dependencies": [
+          "CommitmentDiscountId-C-000-M"
+        ]
+      }
+    },
+    "CommitmentDiscountUnit-C-000-M": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "All CommitmentDiscountUnit rules MUST be enforced when the provider supports commitment discounts.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-001-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-003-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-004-O"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-007-C"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-D-015-M"
+        ]
+      }
+    },
+    "CommitmentDiscountUnit-C-001-M": {
+      "Function": "Type",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountUnit MUST be of type String.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeString",
+          "ColumnName": "CommitmentDiscountUnit"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountUnit-C-002-M": {
+      "Function": "Format",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountUnit MUST conform to StringHandling requirements.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "FormatString",
+          "ColumnName": "CommitmentDiscountUnit"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountUnit-C-003-M": {
+      "Function": "Format",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountUnit SHOULD conform to UnitFormat requirements.",
+        "Keyword": "SHOULD",
+        "Requirement": {
+          "CheckFunction": "FormatUnit",
+          "ColumnName": "CommitmentDiscountUnit"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountUnit-C-004-O": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountUnit nullability is defined as follows:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-005-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-006-C"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountUnit-C-005-M": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
       "Type": "Dynamic",
       "ValidationCriteria": {
-        "MustSatisfy": "MUST be null when a charge is not specific to an availability zone",
+        "MustSatisfy": "CommitmentDiscountUnit MUST be null when CommitmentDiscountQuantity is null.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "CommitmentDiscountUnit",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "CommitmentDiscountQuantity",
+          "Value": null
+        },
+        "Dependencies": [
+          "CommitmentDiscountQuantity-C-000-M"
+        ]
+      }
+    },
+    "CommitmentDiscountUnit-C-006-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountUnit MUST NOT be null when CommitmentDiscountQuantity is not null.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountUnit",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountQuantity",
+          "Value": null
+        },
+        "Dependencies": [
+          "CommitmentDiscountQuantity-C-000-M"
+        ]
+      }
+    },
+    "CommitmentDiscountUnit-C-007-C": {
+      "Function": "Composite",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "When CommitmentDiscountUnit is not null, CommitmentDiscountUnit adheres to the following additional requirements:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-008-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-009-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-010-C"
+            }
+          ]
+        },
+        "Condition": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "CommitmentDiscountUnit",
+          "Value": null
+        },
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountUnit-C-008-M": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "Mirrors cross-column dependency on CommitmentDiscountId",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountUnit MUST remain consistent over time for a given CommitmentDiscountId.",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountUnit-C-009-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountUnit MUST represent the unit used to measure the commitment discount.",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CommitmentDiscountUnit-C-010-C": {
+      "Function": "Validation",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "When accounting for commitment discount flexibility, the CommitmentDiscountUnit value SHOULD reflect this consideration.",
+        "Keyword": "SHOULD",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "ConsumedQuantity-C-000-C": {
+      "Function": "Composite",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "All ConsumedQuantity rules MUST be enforced",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ConsumedQuantity-C-001-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ConsumedQuantity-C-002-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ConsumedQuantity-C-003-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ConsumedQuantity-C-008-M"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": [
+          "CostAndUsage-D-011-C"
+        ]
+      }
+    },
+    "ConsumedQuantity-C-001-M": {
+      "Function": "Type",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "ConsumedQuantity MUST be of type Decimal",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "TypeDecimal",
+          "ColumnName": "ConsumedQuantity"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "ConsumedQuantity-C-002-M": {
+      "Function": "Format",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "ConsumedQuantity MUST conform to NumericFormat requirements",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "FormatNumeric",
+          "ColumnName": "ConsumedQuantity"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "ConsumedQuantity-C-003-M": {
+      "Function": "Composite",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "ConsumedQuantity nullability is defined as follows:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ConsumedQuantity-C-004-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ConsumedQuantity-C-005-C"
+            }
+          ]
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "ConsumedQuantity-C-004-C": {
+      "Function": "Validation",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "ConsumedQuantity MUST be null when ChargeCategory is not 'Usage', or when ChargeCategory is 'Usage' and CommitmentDiscountStatus is 'Unused'",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {
+          "CheckFunction": "OR",
+          "Items": [
+            {
+              "CheckFunction": "CheckNotValue",
+              "ColumnName": "ChargeCategory",
+              "Value": "Usage"
+            },
+            {
+              "CheckFunction": "AND",
+              "Items": [
+                {
+                  "CheckFunction": "CheckValue",
+                  "ColumnName": "ChargeCategory",
+                  "Value": "Usage"
+                },
+                {
+                  "CheckFunction": "CheckValue",
+                  "ColumnName": "CommitmentDiscountStatus",
+                  "Value": "Unused"
+                }
+              ]
+            }
+          ]
+        },
+        "Dependencies": []
+      }
+    },
+    "ConsumedQuantity-C-005-C": {
+      "Function": "Composite",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "When ChargeCategory is 'Usage' and CommitmentDiscountStatus is not 'Unused', ConsumedQuantity adheres to the following additional requirements:",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ConsumedQuantity-C-006-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ConsumedQuantity-C-007-C"
+            }
+          ]
+        },
+        "Condition": {
+          "CheckFunction": "AND",
+          "Items": [
+            {
+              "CheckFunction": "CheckValue",
+              "ColumnName": "ChargeCategory",
+              "Value": "Usage"
+            },
+            {
+              "CheckFunction": "CheckNotValue",
+              "ColumnName": "CommitmentDiscountStatus",
+              "Value": "Unused"
+            }
+          ]
+        },
+        "Dependencies": []
+      }
+    },
+    "ConsumedQuantity-C-006-C": {
+      "Function": "Validation",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "ConsumedQuantity MUST NOT be null when ChargeClass is not 'Correction'",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "ChargeClass",
+          "Value": null
+        },
+        "Condition": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "ChargeClass",
+          "Value": "Correction"
+        },
+        "Dependencies": []
+      }
+    },
+    "ConsumedQuantity-C-007-C": {
+      "Function": "Validation",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "ConsumedQuantity MAY be null when ChargeClass is 'Correction'",
+        "Keyword": "MAY",
+        "Requirement": {},
+        "Condition": {
+          "CheckFunction": "CheckValue",
+          "ColumnName": "ChargeClass",
+          "Value": "Correction"
+        },
+        "Dependencies": []
+      }
+    },
+    "ConsumedQuantity-C-008-M": {
+      "Function": "Validation",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "ConsumedQuantity MUST be a valid decimal value when not null",
         "Keyword": "MUST",
         "Requirement": {},
         "Condition": {},
@@ -2148,807 +3448,277 @@
         ]
       }
     },
-    "CommitmentDiscountId-C-000-C": {
+    "SubAccountId-C-000-C": {
       "Function": "Composite",
-      "Reference": "CommitmentDiscountId",
+      "Reference": "SubAccountId",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "All CommitmentDiscountId rules MUST be enforced",
+        "MustSatisfy": "All SubAccountId rules MUST be enforced",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "AND",
           "Items": [
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountId-C-001-M"
+              "ConformanceRuleId": "SubAccountId-C-001-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountId-C-002-M"
+              "ConformanceRuleId": "SubAccountId-C-002-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountId-C-003-M"
+              "ConformanceRuleId": "SubAccountId-C-003-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountId-C-006-C"
+              "ConformanceRuleId": "SubAccountId-C-004-M"
             }
           ]
         },
         "Condition": {},
         "Dependencies": [
-          "CostAndUsage-D-013-M"
+          "CostAndUsage-D-018-C"
         ]
       }
     },
-    "CommitmentDiscountId-C-001-M": {
+    "SubAccountId-C-001-M": {
       "Function": "Type",
-      "Reference": "CommitmentDiscountId",
+      "Reference": "SubAccountId",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountId MUST be of type String.",
+        "MustSatisfy": "SubAccountId MUST be of type String",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "TypeString",
-          "ColumnName": "CommitmentDiscountId"
+          "ColumnName": "SubAccountId"
         },
         "Condition": {},
         "Dependencies": []
       }
     },
-    "CommitmentDiscountId-C-002-M": {
+    "SubAccountId-C-002-M": {
       "Function": "Format",
-      "Reference": "CommitmentDiscountId",
+      "Reference": "SubAccountId",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountId MUST conform to StringHandling requirements.",
+        "MustSatisfy": "SubAccountId MUST conform to StringHandling requirements",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "FormatString",
-          "ColumnName": "CommitmentDiscountId"
+          "ColumnName": "SubAccountId"
         },
         "Condition": {},
         "Dependencies": []
       }
     },
-    "CommitmentDiscountId-C-003-M": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountId",
+    "SubAccountId-C-003-M": {
+      "Function": "Validation",
+      "Reference": "SubAccountId",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "SubAccountId MUST be null when a charge is not related to a sub account",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "SubAccountId-C-004-M": {
+      "Function": "Validation",
+      "Reference": "SubAccountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "SUB_ACCOUNT_SUPPORTED"
+      ],
+      "Type": "Dynamic",
+      "ValidationCriteria": {
+        "MustSatisfy": "SubAccountId MUST NOT be null when a charge is related to a sub account",
+        "Keyword": "MUST",
+        "Requirement": {},
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "SubAccountName-C-000-C": {
+      "Function": "Composite",
+      "Reference": "SubAccountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "SUB_ACCOUNT_SUPPORTED"
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountId nullability is defined as follows:",
+        "MustSatisfy": "All SubAccountName rules MUST be enforced",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "AND",
           "Items": [
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountId-C-004-C"
+              "ConformanceRuleId": "SubAccountName-C-001-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountId-C-005-C"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountId-C-004-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountId",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountId MUST be null when a charge is not related to a commitment discount.",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountId-C-005-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountId",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountId MUST NOT be null when a charge is related to a commitment discount.",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountId-C-006-C": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountId",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "When CommitmentDiscountId is not null, CommitmentDiscountId adheres to the following additional requirements:",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountId-C-007-C"
+              "ConformanceRuleId": "SubAccountName-C-002-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountId-C-008-C"
-            }
-          ]
-        },
-        "Condition": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "CommitmentDiscountId",
-          "Value": null
-        },
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountId-C-007-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountId",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountId MUST be a unique identifier within the provider.",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountId-C-008-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountId",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountId SHOULD be a fully-qualified identifier.",
-        "Keyword": "SHOULD",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "ConsumedQuantity-C-000-C": {
-      "Function": "Composite",
-      "Reference": "ConsumedQuantity",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "All ConsumedQuantity rules MUST be enforced",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ConsumedQuantity-C-001-M"
+              "ConformanceRuleId": "SubAccountName-C-003-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ConsumedQuantity-C-002-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ConsumedQuantity-C-003-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ConsumedQuantity-C-008-M"
+              "ConformanceRuleId": "SubAccountName-C-004-M"
             }
           ]
         },
         "Condition": {},
         "Dependencies": [
-          "CostAndUsage-D-011-C"
+          "CostAndUsage-D-019-C"
         ]
       }
     },
-    "ConsumedQuantity-C-001-M": {
+    "SubAccountName-C-001-M": {
       "Function": "Type",
-      "Reference": "ConsumedQuantity",
+      "Reference": "SubAccountName",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "ConsumedQuantity MUST be of type Decimal",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "TypeDecimal",
-          "ColumnName": "ConsumedQuantity"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "ConsumedQuantity-C-002-M": {
-      "Function": "Format",
-      "Reference": "ConsumedQuantity",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "ConsumedQuantity MUST conform to NumericFormat requirements",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "FormatNumeric",
-          "ColumnName": "ConsumedQuantity"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "ConsumedQuantity-C-003-M": {
-      "Function": "Composite",
-      "Reference": "ConsumedQuantity",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "ConsumedQuantity nullability is defined as follows:",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ConsumedQuantity-C-004-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ConsumedQuantity-C-005-C"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "ConsumedQuantity-C-004-C": {
-      "Function": "Validation",
-      "Reference": "ConsumedQuantity",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "ConsumedQuantity MUST be null when ChargeCategory is not 'Usage', or when ChargeCategory is 'Usage' and CommitmentDiscountStatus is 'Unused'",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {
-          "CheckFunction": "OR",
-          "Items": [
-            {
-              "CheckFunction": "CheckNotValue",
-              "ColumnName": "ChargeCategory",
-              "Value": "Usage"
-            },
-            {
-              "CheckFunction": "AND",
-              "Items": [
-                {
-                  "CheckFunction": "CheckValue",
-                  "ColumnName": "ChargeCategory",
-                  "Value": "Usage"
-                },
-                {
-                  "CheckFunction": "CheckValue",
-                  "ColumnName": "CommitmentDiscountStatus",
-                  "Value": "Unused"
-                }
-              ]
-            }
-          ]
-        },
-        "Dependencies": []
-      }
-    },
-    "ConsumedQuantity-C-005-C": {
-      "Function": "Composite",
-      "Reference": "ConsumedQuantity",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "When ChargeCategory is 'Usage' and CommitmentDiscountStatus is not 'Unused', ConsumedQuantity adheres to the following additional requirements:",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ConsumedQuantity-C-006-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "ConsumedQuantity-C-007-C"
-            }
-          ]
-        },
-        "Condition": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckValue",
-              "ColumnName": "ChargeCategory",
-              "Value": "Usage"
-            },
-            {
-              "CheckFunction": "CheckNotValue",
-              "ColumnName": "CommitmentDiscountStatus",
-              "Value": "Unused"
-            }
-          ]
-        },
-        "Dependencies": []
-      }
-    },
-    "ConsumedQuantity-C-006-C": {
-      "Function": "Validation",
-      "Reference": "ConsumedQuantity",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "ConsumedQuantity MUST NOT be null when ChargeClass is not 'Correction'",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "ChargeClass",
-          "Value": null
-        },
-        "Condition": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "ChargeClass",
-          "Value": "Correction"
-        },
-        "Dependencies": []
-      }
-    },
-    "ConsumedQuantity-C-007-C": {
-      "Function": "Validation",
-      "Reference": "ConsumedQuantity",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "ConsumedQuantity MAY be null when ChargeClass is 'Correction'",
-        "Keyword": "MAY",
-        "Requirement": {},
-        "Condition": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "ChargeClass",
-          "Value": "Correction"
-        },
-        "Dependencies": []
-      }
-    },
-    "ConsumedQuantity-C-008-M": {
-      "Function": "Validation",
-      "Reference": "ConsumedQuantity",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "USAGE_MEASUREMENT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "ConsumedQuantity MUST be a valid decimal value when not null",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountUnit-C-000-M": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountUnit",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "All CommitmentDiscountUnit rules MUST be enforced when the provider supports commitment discounts.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-001-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-002-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-003-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-004-O"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-007-C"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": [
-          "CostAndUsage-D-015-M"
-        ]
-      }
-    },
-    "CommitmentDiscountUnit-C-001-M": {
-      "Function": "Type",
-      "Reference": "CommitmentDiscountUnit",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountUnit MUST be of type String.",
+        "MustSatisfy": "SubAccountName MUST be of type String",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "TypeString",
-          "ColumnName": "CommitmentDiscountUnit"
+          "ColumnName": "SubAccountName"
         },
         "Condition": {},
         "Dependencies": []
       }
     },
-    "CommitmentDiscountUnit-C-002-M": {
+    "SubAccountName-C-002-M": {
       "Function": "Format",
-      "Reference": "CommitmentDiscountUnit",
+      "Reference": "SubAccountName",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountUnit MUST conform to StringHandling requirements.",
+        "MustSatisfy": "SubAccountName MUST conform to StringHandling requirements",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "FormatString",
-          "ColumnName": "CommitmentDiscountUnit"
+          "ColumnName": "SubAccountName"
         },
         "Condition": {},
         "Dependencies": []
       }
     },
-    "CommitmentDiscountUnit-C-003-M": {
-      "Function": "Format",
-      "Reference": "CommitmentDiscountUnit",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountUnit SHOULD conform to UnitFormat requirements.",
-        "Keyword": "SHOULD",
-        "Requirement": {
-          "CheckFunction": "FormatUnit",
-          "ColumnName": "CommitmentDiscountUnit"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountUnit-C-004-O": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountUnit",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountUnit nullability is defined as follows:",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-005-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-006-C"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountUnit-C-005-M": {
+    "SubAccountName-C-003-M": {
       "Function": "Validation",
-      "Reference": "CommitmentDiscountUnit",
+      "Reference": "SubAccountName",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
       ],
-      "Type": "Dynamic",
+      "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountUnit MUST be null when CommitmentDiscountQuantity is null.",
+        "MustSatisfy": "SubAccountName MUST be null when SubAccountId is null",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "CheckValue",
-          "ColumnName": "CommitmentDiscountUnit",
+          "ColumnName": "SubAccountName",
           "Value": null
         },
         "Condition": {
           "CheckFunction": "CheckValue",
-          "ColumnName": "CommitmentDiscountQuantity",
+          "ColumnName": "SubAccountId",
           "Value": null
         },
         "Dependencies": [
-          "CommitmentDiscountQuantity-C-000-M"
+          "SubAccountId-C-000-C"
         ]
       }
     },
-    "CommitmentDiscountUnit-C-006-C": {
+    "SubAccountName-C-004-M": {
       "Function": "Validation",
-      "Reference": "CommitmentDiscountUnit",
+      "Reference": "SubAccountName",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountUnit MUST NOT be null when CommitmentDiscountQuantity is not null.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "CommitmentDiscountUnit",
-          "Value": null
-        },
-        "Condition": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "CommitmentDiscountQuantity",
-          "Value": null
-        },
-        "Dependencies": [
-          "CommitmentDiscountQuantity-C-000-M"
-        ]
-      }
-    },
-    "CommitmentDiscountUnit-C-007-C": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountUnit",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "When CommitmentDiscountUnit is not null, CommitmentDiscountUnit adheres to the following additional requirements:",
+        "MustSatisfy": "SubAccountName MUST NOT be null when SubAccountId is not null",
         "Keyword": "MUST",
         "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-008-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-009-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountUnit-C-010-C"
-            }
-          ]
+          "CheckFunction": "CheckNotValue",
+          "ColumnName": "SubAccountName",
+          "Value": null
         },
         "Condition": {
           "CheckFunction": "CheckNotValue",
-          "ColumnName": "CommitmentDiscountUnit",
+          "ColumnName": "SubAccountId",
           "Value": null
         },
-        "Dependencies": []
+        "Dependencies": [
+          "SubAccountId-C-000-C"
+        ]
       }
     },
-    "CommitmentDiscountUnit-C-008-M": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountUnit",
-      "EntityType": "Column",
-      "Notes": "Mirrors cross-column dependency on CommitmentDiscountId",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountUnit MUST remain consistent over time for a given CommitmentDiscountId.",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountUnit-C-009-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountUnit",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountUnit MUST represent the unit used to measure the commitment discount.",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountUnit-C-010-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountUnit",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "When accounting for commitment discount flexibility, the CommitmentDiscountUnit value SHOULD reflect this consideration.",
-        "Keyword": "SHOULD",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BillingAccountType-C-000-M": {
+    "CostAndUsage-D-000-M": {
       "Function": "Composite",
-      "Reference": "BillingAccountType",
-      "EntityType": "Column",
-      "Notes": "",
+      "Reference": "CostAndUsage",
+      "EntityType": "Dataset",
+      "Notes": "Main dataset composite rule",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [],
@@ -2961,69 +3731,23 @@
           "Items": [
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingAccountType-C-001-M"
+              "ConformanceRuleId": "CostAndUsage-D-001-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingAccountType-C-002-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingAccountType-C-003-M"
+              "ConformanceRuleId": "CostAndUsage-D-002-M"
             }
           ]
         },
         "Condition": {},
-        "Dependencies": [
-          "CostAndUsage-C-007-C"
-        ]
-      }
-    },
-    "BillingAccountType-C-002-M": {
-      "Function": "Type",
-      "Reference": "BillingAccountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be of type String",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "TypeString",
-          "ColumnName": "BillingAccountType"
-        },
-        "Condition": {},
         "Dependencies": []
       }
     },
-    "BillingAccountType-C-003-M": {
-      "Function": "Type",
-      "Reference": "BillingAccountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST conform to StringHandling requirements",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "FormatString",
-          "ColumnName": "BillingAccountType"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BillingAccountType-C-004-C": {
+    "CostAndUsage-D-001-M": {
       "Function": "Composite",
-      "Reference": "BillingAccountType",
-      "EntityType": "Column",
-      "Notes": "",
+      "Reference": "CostAndUsage",
+      "EntityType": "Dataset",
+      "Notes": "Columns present composite rule",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [],
@@ -3036,11 +3760,71 @@
           "Items": [
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingAccountType-C-005-M"
+              "ConformanceRuleId": "CostAndUsage-D-003-C"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingAccountType-C-006-M"
+              "ConformanceRuleId": "CostAndUsage-D-004-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-005-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-C-006-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-C-007-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-008-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-009-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-010-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-011-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-012-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-013-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-014-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-015-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-016-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-017-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-018-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CostAndUsage-D-019-C"
             }
           ]
         },
@@ -3048,112 +3832,371 @@
         "Dependencies": []
       }
     },
-    "BillingAccountType-C-005-M": {
-      "Function": "Validation",
-      "Reference": "BillingAccountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be null when BillingAccountId is null",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "BillingAccountType",
-          "Value": null
-        },
-        "Condition": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "BillingAccountId",
-          "Value": null
-        },
-        "Dependencies": []
-      }
-    },
-    "BillingAccountType-C-006-M": {
-      "Function": "Validation",
-      "Reference": "BillingAccountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST NOT be null when BillingAccountId is not null",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "BillingAccountType",
-          "Value": null
-        },
-        "Condition": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "BillingAccountId",
-          "Value": null
-        },
-        "Dependencies": []
-      }
-    },
-    "BillingAccountType-C-007-M": {
-      "Function": "Validation",
-      "Reference": "BillingAccountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be a consistent, readable display value",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountCategory-C-000-C": {
+    "CostAndUsage-D-002-M": {
       "Function": "Composite",
-      "Reference": "CommitmentDiscountCategory",
-      "EntityType": "Column",
-      "Notes": "",
+      "Reference": "CostAndUsage",
+      "EntityType": "Dataset",
+      "Notes": "Columns composite rule",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
+      "ApplicabilityCriteria": [],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "All CommitmentDiscountCategory rules MUST be enforced when the provider supports commitment discounts.",
+        "MustSatisfy": "",
         "Keyword": "MUST",
         "Requirement": {
           "CheckFunction": "AND",
           "Items": [
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountCategory-C-001-M"
+              "ConformanceRuleId": "AvailabilityZone-C-000-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountCategory-C-002-M"
+              "ConformanceRuleId": "BilledCost-C-000-M"
             },
             {
               "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountCategory-C-005-M"
+              "ConformanceRuleId": "BillingAccountName-C-000-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingAccountType-C-000-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingPeriodEnd-C-000-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "BillingPeriodStart-C-000-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountCategory-C-000-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountId-C-000-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountName-C-000-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountStatus-C-000-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountType-C-000-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "CommitmentDiscountUnit-C-000-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ChargeCategory-C-000-M"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ConsumedQuantity-C-000-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "SubAccountId-C-000-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "SubAccountName-C-000-C"
+            },
+            {
+              "CheckFunction": "CheckConformanceRule",
+              "ConformanceRuleId": "ListUnitPrice-C-000-C"
             }
           ]
         },
         "Condition": {},
-        "Dependencies": [
-          "CostAndUsage-D-016-M"
-        ]
+        "Dependencies": []
       }
     },
-    "CommitmentDiscountCategory-C-001-M": {
-      "Function": "Type",
+    "CostAndUsage-D-003-C": {
+      "Function": "Presence",
+      "Reference": "AvailabilityZone",
+      "EntityType": "Dataset",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "AVAILABILITY_ZONE_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "RECOMMENDED be present in a FOCUS dataset",
+        "Keyword": "RECOMMENDED",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "AvailabilityZone"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-004-C": {
+      "Function": "Presence",
+      "Reference": "ListUnitPrice",
+      "EntityType": "Dataset",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "PUBLIC_PRICE_LIST_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be present in a FOCUS dataset when the data generator publishes unit prices exclusive of discounts",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "ListUnitPrice"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-005-M": {
+      "Function": "Presence",
+      "Reference": "BillingAccountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be present in a FOCUS dataset",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "BillingAccountName"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-C-006-M": {
+      "Function": "Presence",
+      "Reference": "BilledCost",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be present in a FOCUS dataset",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "BilledCost"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-C-007-C": {
+      "Function": "Presence",
+      "Reference": "BillingAccountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be present in a FOCUS dataset",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "BillingAccountType"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-008-M": {
+      "Function": "Presence",
+      "Reference": "ChargeCategory",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be present in a FOCUS dataset",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "ChargeCategory"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-009-M": {
+      "Function": "Presence",
+      "Reference": "BillingPeriodStart",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be present in a FOCUS dataset.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "BillingPeriodStart"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-010-M": {
+      "Function": "Presence",
+      "Reference": "BillingPeriodEnd",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "MUST be present in a FOCUS dataset",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "BillingPeriodEnd"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-011-C": {
+      "Function": "Presence",
+      "Reference": "ConsumedQuantity",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "USAGE_MEASUREMENT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "ConsumedQuantity MUST be present in a FOCUS dataset when the provider supports the measurement of usage",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "ConsumedQuantity"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-012-M": {
+      "Function": "Presence",
+      "Reference": "CommitmentDiscountName",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountName MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "CommitmentDiscountName"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-013-M": {
+      "Function": "Presence",
+      "Reference": "CommitmentDiscountId",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountId MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "CommitmentDiscountId"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-014-M": {
+      "Function": "Presence",
+      "Reference": "CommitmentDiscountType",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountType MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "CommitmentDiscountType"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-015-M": {
+      "Function": "Presence",
+      "Reference": "CommitmentDiscountUnit",
+      "EntityType": "Column",
+      "Notes": "",
+      "CRVersionIntroduced": "1.2",
+      "Status": "Active",
+      "ApplicabilityCriteria": [
+        "COMMITMENT_DISCOUNT_SUPPORTED"
+      ],
+      "Type": "Static",
+      "ValidationCriteria": {
+        "MustSatisfy": "CommitmentDiscountUnit MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
+        "Keyword": "MUST",
+        "Requirement": {
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "CommitmentDiscountUnit"
+        },
+        "Condition": {},
+        "Dependencies": []
+      }
+    },
+    "CostAndUsage-D-016-M": {
+      "Function": "Presence",
       "Reference": "CommitmentDiscountCategory",
       "EntityType": "Column",
       "Notes": "",
@@ -3164,19 +4207,19 @@
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountCategory MUST be of type String.",
+        "MustSatisfy": "CommitmentDiscountCategory MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
         "Keyword": "MUST",
         "Requirement": {
-          "CheckFunction": "TypeString",
+          "CheckFunction": "ColumnPresent",
           "ColumnName": "CommitmentDiscountCategory"
         },
         "Condition": {},
         "Dependencies": []
       }
     },
-    "CommitmentDiscountCategory-C-002-M": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountCategory",
+    "CostAndUsage-D-017-M": {
+      "Function": "Presence",
+      "Reference": "CommitmentDiscountStatus",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
@@ -3186,577 +4229,56 @@
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountCategory nullability is defined as follows:",
+        "MustSatisfy": "CommitmentDiscountStatus MUST be present in a FOCUS dataset when the provider supports commitment discounts.",
         "Keyword": "MUST",
         "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountCategory-C-003-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountCategory-C-004-C"
-            }
-          ]
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "CommitmentDiscountStatus"
         },
         "Condition": {},
         "Dependencies": []
       }
     },
-    "CommitmentDiscountCategory-C-003-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountCategory",
+    "CostAndUsage-D-018-C": {
+      "Function": "Presence",
+      "Reference": "SubAccountId",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
       ],
-      "Type": "Dynamic",
+      "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountCategory MUST be null when CommitmentDiscountId is null.",
+        "MustSatisfy": "SubAccountId MUST be present in a FOCUS dataset when the provider supports a sub account construct",
         "Keyword": "MUST",
         "Requirement": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "CommitmentDiscountCategory",
-          "Value": null
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "SubAccountId"
         },
-        "Condition": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "CommitmentDiscountId",
-          "Value": null
-        },
-        "Dependencies": [
-          "CommitmentDiscountId-C-000-C"
-        ]
+        "Condition": {},
+        "Dependencies": []
       }
     },
-    "CommitmentDiscountCategory-C-004-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountCategory",
+    "CostAndUsage-D-019-C": {
+      "Function": "Presence",
+      "Reference": "SubAccountName",
       "EntityType": "Column",
       "Notes": "",
       "CRVersionIntroduced": "1.2",
       "Status": "Active",
       "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountCategory MUST NOT be null when CommitmentDiscountId is not null.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "CommitmentDiscountCategory",
-          "Value": null
-        },
-        "Condition": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "CommitmentDiscountId",
-          "Value": null
-        },
-        "Dependencies": [
-          "CommitmentDiscountId-C-000-C"
-        ]
-      }
-    },
-    "CommitmentDiscountCategory-C-005-M": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountCategory",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
+        "SUB_ACCOUNT_SUPPORTED"
       ],
       "Type": "Static",
       "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountCategory MUST be one of the allowed values.",
+        "MustSatisfy": "SubAccountName MUST be present in a FOCUS dataset when the provider supports a sub account construct",
         "Keyword": "MUST",
         "Requirement": {
-          "CheckFunction": "OR",
-          "Items": [
-            {
-              "CheckFunction": "CheckValue",
-              "ColumnName": "CommitmentDiscountCategory",
-              "Value": "Spend"
-            },
-            {
-              "CheckFunction": "CheckValue",
-              "ColumnName": "CommitmentDiscountCategory",
-              "Value": "Usage"
-            }
-          ]
+          "CheckFunction": "ColumnPresent",
+          "ColumnName": "SubAccountName"
         },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountType-C-000-M": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "All CommitmentDiscountType rules MUST be enforced.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountType-C-001-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountType-C-002-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountType-C-003-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountType-C-004-C"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": [
-          "CostAndUsage-D-014-M"
-        ]
-      }
-    },
-    "CommitmentDiscountType-C-001-M": {
-      "Function": "Type",
-      "Reference": "CommitmentDiscountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountType MUST be of type String.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "TypeString",
-          "ColumnName": "CommitmentDiscountType"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountType-C-002-M": {
-      "Function": "Format",
-      "Reference": "CommitmentDiscountType",
-      "EntityType": "Column",
-      "Notes": "Cross-column reference: StringHandling",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountType MUST conform to StringHandling requirements.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "FormatString",
-          "ColumnName": "CommitmentDiscountType"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountType-C-003-M": {
-      "Function": "Composite",
-      "Reference": "CommitmentDiscountType",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountType nullability is defined as follows:",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountType-C-004-C"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "CommitmentDiscountType-C-005-C"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "CommitmentDiscountType-C-004-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountType",
-      "EntityType": "Column",
-      "Notes": "Cross-column reference: CommitmentDiscountId",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountType MUST be null when CommitmentDiscountId is null.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "CommitmentDiscountType",
-          "Value": null
-        },
-        "Condition": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "CommitmentDiscountId",
-          "Value": null
-        },
-        "Dependencies": [
-          "CommitmentDiscountId-C-000-M"
-        ]
-      }
-    },
-    "CommitmentDiscountType-C-005-C": {
-      "Function": "Validation",
-      "Reference": "CommitmentDiscountType",
-      "EntityType": "Column",
-      "Notes": "Cross-column reference: CommitmentDiscountId",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [
-        "COMMITMENT_DISCOUNT_SUPPORTED"
-      ],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "CommitmentDiscountType MUST NOT be null when CommitmentDiscountId is not null.",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "CommitmentDiscountType",
-          "Value": null
-        },
-        "Condition": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "CommitmentDiscountId",
-          "Value": null
-        },
-        "Dependencies": [
-          "CommitmentDiscountId-C-000-M"
-        ]
-      }
-    },
-    "BillingPeriodEnd-C-000-M": {
-      "Function": "Composite",
-      "Reference": "BillingPeriodEnd",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "BillingPeriodEnd column adheres to the following requirements",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingPeriodEnd-C-002-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingPeriodEnd-C-003-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingPeriodEnd-C-004-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BillingPeriodEnd-C-005-M"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": [
-          "CostAndUsage-D-010-M"
-        ]
-      }
-    },
-    "BillingPeriodEnd-C-002-M": {
-      "Function": "Type",
-      "Reference": "BillingPeriodEnd",
-      "EntityType": "Column",
-      "Notes": "Relies on new TypeDateTime check",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be of type Date/Time",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "TypeDateTime",
-          "ColumnName": "BillingPeriodEnd"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BillingPeriodEnd-C-003-M": {
-      "Function": "Format",
-      "Reference": "BillingPeriodEnd",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST conform to DateTimeFormat requirements",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "FormatDateTime",
-          "ColumnName": "BillingPeriodEnd"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BillingPeriodEnd-C-004-M": {
-      "Function": "Validation",
-      "Reference": "BillingPeriodEnd",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST NOT be null",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "BillingPeriodEnd",
-          "Value": null
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BillingPeriodEnd-C-005-M": {
-      "Function": "Validation",
-      "Reference": "BillingPeriodEnd",
-      "EntityType": "Column",
-      "Notes": "Validates exclusive end bound of the billing period.",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be the exclusive end bound of the billing period",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckExclusiveEndBound",
-          "StartColumnName": "BillingPeriodStart",
-          "EndColumnName": "BillingPeriodEnd"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BilledCost-C-000-M": {
-      "Function": "Composite",
-      "Reference": "BilledCost",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "AND",
-          "Items": [
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BilledCost-C-002-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BilledCost-C-003-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BilledCost-C-004-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BilledCost-C-005-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BilledCost-C-006-M"
-            },
-            {
-              "CheckFunction": "CheckConformanceRule",
-              "ConformanceRuleId": "BilledCost-C-007-M"
-            }
-          ]
-        },
-        "Condition": {},
-        "Dependencies": [
-          "CostAndUsage-C-006-M"
-        ]
-      }
-    },
-    "BilledCost-C-002-M": {
-      "Function": "Validation",
-      "Reference": "BilledCost",
-      "EntityType": "Column",
-      "Notes": "A null value would invalidate accounting use cases",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST NOT be null",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckNotValue",
-          "ColumnName": "BilledCost",
-          "Value": null
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BilledCost-C-003-M": {
-      "Function": "Type",
-      "EntityType": "Column",
-      "Reference": "BilledCost",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be of type Decimal",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "TypeDecimal",
-          "ColumnName": "BilledCost"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BilledCost-C-004-M": {
-      "Function": "Format",
-      "EntityType": "Column",
-      "Reference": "BilledCost",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST conform to NumericFormat requirements",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "FormatNumeric",
-          "ColumnName": "BilledCost"
-        },
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BilledCost-C-005-M": {
-      "Function": "Validation",
-      "Reference": "BilledCost",
-      "EntityType": "Column",
-      "Notes": "Common for marketplace charges paid by customer directly to seller",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Static",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be 0 for charges where payments are received by a third party",
-        "Keyword": "MUST",
-        "Requirement": {
-          "CheckFunction": "CheckValue",
-          "ColumnName": "BilledCost",
-          "Value": 0
-        },
-        "Condition": {
-          "CheckFunction": "CheckNotSameValue",
-          "ColumnAName": "ProviderName",
-          "ColumnBName": "InvoiceIssuerName"
-        },
-        "Dependencies": [
-          "ProviderName-C-000-M",
-          "InvoiceIssuerName-C-000-M"
-        ]
-      }
-    },
-    "BilledCost-C-006-M": {
-      "Function": "Validation",
-      "Reference": "BilledCost",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "MUST be denominated in the BillingCurrency",
-        "Keyword": "MUST",
-        "Requirement": {},
-        "Condition": {},
-        "Dependencies": []
-      }
-    },
-    "BilledCost-C-007-M": {
-      "Function": "Validation",
-      "Reference": "BilledCost",
-      "EntityType": "Column",
-      "Notes": "",
-      "CRVersionIntroduced": "1.2",
-      "Status": "Active",
-      "ApplicabilityCriteria": [],
-      "Type": "Dynamic",
-      "ValidationCriteria": {
-        "MustSatisfy": "SUM(BilledCost) MUST equal payable amount in invoice from InvoiceIssuer",
-        "Keyword": "MUST",
-        "Requirement": {},
         "Condition": {},
         "Dependencies": []
       }


### PR DESCRIPTION
- Added SUB_ACCOUNT_SUPPORTED applicability criteria for sub account construct support
- Created comprehensive conformance rules for SubAccountName column:
  - SubAccountName-C-000-C: Main composite rule with SUB_ACCOUNT_SUPPORTED criteria
  - SubAccountName-C-001-M: Type validation (MUST be String)
  - SubAccountName-C-002-M: StringHandling format requirements
  - SubAccountName-C-003-M: Nullability rule (MUST be null when SubAccountId is null)
  - SubAccountName-C-004-M: Nullability rule (MUST NOT be null when SubAccountId is not null)
- Created comprehensive conformance rules for SubAccountId column:
  - SubAccountId-C-000-C: Main composite rule with SUB_ACCOUNT_SUPPORTED criteria
  - SubAccountId-C-001-M: Type validation (MUST be String)
  - SubAccountId-C-002-M: StringHandling format requirements
  - SubAccountId-C-003-M: Nullability rule (charge not related to sub account) - Dynamic
  - SubAccountId-C-004-M: Nullability rule (charge is related to sub account) - Dynamic
- Added presence rules:
  - CostAndUsage-D-018-C: Presence rule for SubAccountId with SUB_ACCOUNT_SUPPORTED criteria
  - CostAndUsage-D-019-C: Presence rule for SubAccountName with SUB_ACCOUNT_SUPPORTED criteria
- Updated CostAndUsage dataset composite rules to include both SubAccount columns
- Generated updated cr-1.2.json with all new rules and criteria

🤖 Generated with [Claude Code](https://claude.ai/code)