### PR TITLE
AI #1260: Create Conformance Rules for CapacityReservationStatus

### DIFF
--- a/specification/conformance/applicability_criteria.json
+++ b/specification/conformance/applicability_criteria.json
@@ -14,6 +14,9 @@
     },
     "USAGE_MEASUREMENT_SUPPORTED": {
       "Description": "Data generator supports the measurement of usage quantities"
+    },
+    "CAPACITY_RESERVATION_SUPPORTED": {
+      "Description": "Capacity reservations must be present when the provider supports capacity reservations."
     }
   }
 }

--- a/specification/conformance/conformance_datasets.json
+++ b/specification/conformance/conformance_datasets.json
@@ -2,7 +2,8 @@
   "ConformanceDatasets": {
     "CostAndUsage": {
       "ConformanceRules": [
-        "CostAndUsage-D-000-M"
+        "CostAndUsage-D-000-M",
+        "CapacityReservationStatus-C-000-M"
       ]
     }
   }

--- a/specification/conformance/conformance_rules/columns/capacityreservationstatus.json
+++ b/specification/conformance/conformance_rules/columns/capacityreservationstatus.json
@@ -1,0 +1,285 @@
+{
+    "CapacityReservationStatus-C-000-M": {
+        "Function": "Composite",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "CapacityReservationStatus MUST be present.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": {
+                    "AND": {
+                        "Items": [
+                           {
+                               "CheckFunction": "CheckConformanceRule",
+                               "ConformanceRuleId": "CapacityReservationStatus-D-001-C"
+                           },
+                            {
+                               "CheckFunction": "CheckConformanceRule",
+                               "ConformanceRuleId": "CapacityReservationStatus-C-002-M"
+                           },
+                            {
+                               "CheckFunction": "CheckConformanceRule",
+                               "ConformanceRuleId": "CapacityReservationStatus-C-003-C"
+                           },
+                            {
+                               "CheckFunction": "CheckConformanceRule",
+                               "ConformanceRuleId": "CapacityReservationStatus-C-006-C"
+                           }
+                    ]
+                }
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "CapacityReservationStatus-D-001-C": {
+        "Function": "Presence",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria": ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "CapacityReservationStatus MUST be present in a FOCUS dataset when the provider supports capacity reservations.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "ColumnPresent",
+                "ColumnName": "CapacityReservationStatus"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "CapacityReservationStatus-C-002-M": {
+        "Function": "DataType",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria":  ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "CapacityReservationStatus MUST be of type String.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "String",
+                "ColumnName": "CapacityReservationStatus"
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "CapacityReservationStatus-C-003-C": {
+        "Function": "Composite",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria":  ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "CapacityReservationStatus nullability is defined as follows:",
+            "Keyword": "MUST",
+            "Requirement": {
+                "AND": [
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "CapacityReservationStatus-C-004-C"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "CapacityReservationStatus-C-005-C"
+                    }
+                ]
+            },
+            "Condition": [],
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "CapacityReservationStatus-C-004-C": {
+        "Function": "NullabilityRules",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria":  ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "CapacityReservationStatus MUST be null when CapacityReservationId is null.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "CheckValue",
+                "ColumnName": "CapacityReservationStatus",
+                "Value": null
+            },
+            "Condition": {
+                "AND": {
+                    "CheckFunction": "CheckValue",
+                    "ColumnName": "CapacityReservationId",
+                    "Value": null
+                }
+            },
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": "Cross-column reference: CapacityReservationId"
+    },
+    "CapacityReservationStatus-C-005-C": {
+        "Function": "Validation",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria":  ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "CapacityReservationStatus MUST NOT be null when CapacityReservationId is not null and ChargeCategory is \"Usage\".",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "CheckNotValue",
+                "ColumnName": "CapacityReservationStatus",
+                "Value": null
+            },
+            "Condition": {
+                "AND": [
+                    {
+                        "CheckFunction": "CheckNotValue",
+                        "ColumnName": "CapacityReservationId",
+                        "Value": null
+                    },
+                    {
+                        "CheckFunction": "CheckValue",
+                        "ColumnName": "ChargeCategory",
+                        "Value": "Usage"
+                    }
+                ]
+            },
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": "Cross-column reference: CapacityReservationId, ChargeCategory"
+    },
+    "CapacityReservationStatus-C-006-C": {
+        "Function": "Composite",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria":  ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "When CapacityReservationStatus is not null, CapacityReservationStatus adheres to the following additional requirements:",
+            "Keyword": "MUST",
+            "Requirement": {
+                "AND": [
+                    "CapacityReservationStatus-C-007-C",
+                    "CapacityReservationStatus-C-008-C",
+                    "CapacityReservationStatus-C-009-C"
+                ]
+            },
+            "Condition": {
+                "CheckFunction": "CheckNotValue",
+                "ColumnName": "CapacityReservationStatus",
+                "Value": null
+            },
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "CapacityReservationStatus-C-007-M": {
+        "Function": "Validation",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria":  ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "CapacityReservationStatus MUST be one of the allowed values.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "OR",
+                "Items": [
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "CapacityReservationStatus-C-007-C"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "CapacityReservationStatus-C-008-C"
+                    },
+                    {
+                        "CheckFunction": "CheckConformanceRule",
+                        "ConformanceRuleId": "CapacityReservationStatus-C-009-C"
+                    }
+                ]
+            },
+            "Condition": {
+                "CheckFunction": "CheckNotValue",
+                "ColumnName": "CapacityReservationStatus",
+                "Value": null
+            },
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "CapacityReservationStatus-C-008-C": {
+        "Function": "Validation",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria":  ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "CapacityReservationStatus MUST be \"Unused\" when the charge represents the unused portion of a capacity reservation.",
+            "Keyword": "MUST",
+            "Requirement":  {
+                "CheckFunction": "CheckValue",
+                "ColumnName": "CapacityReservationStatus",
+                "Value": "Unused"
+            },
+            "Condition": {
+                "CheckFunction": "CheckValue",
+                "ColumnName": "CapacityReservationStatus",
+                "Value": "Unused"
+            },
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": ""
+    },
+    "CapacityReservationStatus-C-009-C": {
+        "Function": "Validation",
+        "Reference": "CapacityReservationStatus",
+        "EntityType": "Column",
+        "ApplicabilityCriteria":  ["CAPACITY_RESERVATION_SUPPORTED"],
+        "Type": "Static",
+        "ValidationCriteria": {
+            "MustSatisfy": "CapacityReservationStatus MUST be \"Used\" when the charge represents the used portion of a capacity reservation.",
+            "Keyword": "MUST",
+            "Requirement": {
+                "CheckFunction": "CheckValue",
+                "ColumnName": "CapacityReservationStatus",
+                "Value": "Used"
+            },
+            "Condition": {
+                "CheckFunction": "CheckValue",
+                "ColumnName": "CapacityReservationStatus",
+                "Value": "Used"
+            },
+            "Dependencies": []
+        },
+        "CRVersionIntroduced": "1.1",
+        "Status": "Active",
+        "Notes": ""
+    }
+}
+}


### PR DESCRIPTION
### Summary: PR for Conformance definition for column: capacityreservationstatus #1260 

## Changes Made

- Updated json values for the capacityreservationstatus file based on the capacityreservationstatus_cr.md file
- Added the json output to the ../conformance_rules/columns/ directory
- Updated the conformance_datasets.json file.

## Notes:
- Validation of Requirements for "CapacityReservationStatus-C-008-C" and "CapacityReservationStatus-C-009-C". Read this as validating the value type, unless this was to read as a simple `CheckValue` on the column.