### PR TITLE
FR #1090: Associate attributes with datasets

### DIFF
--- a/specification/attributes/attributes.mdpp
+++ b/specification/attributes/attributes.mdpp
@@ -1,6 +1,6 @@
 # Attributes
 
-Attributes are requirements that apply across a [*FOCUS dataset*](#glossary:FOCUS-dataset) instead of an individual column level. An attribute is associated with a dataset in the dataset's Requirements section.  Requirements on data content can include naming conventions, data types, formatting standardizations, etc. Attributes may introduce high-level requirements for data granularity, recency, frequency, etc. Requirements defined in attributes are necessary for servicing [FinOps capabilities][FODOFC] accurately using a standard set of instructions regardless of the origin of the data.
+Attributes are requirements that apply either across a [*FOCUS dataset*](#glossary:FOCUS-dataset) or an individual column level. An attribute is associated with a dataset or column in their respective Requirements sections.  Requirements on data content can include naming conventions, data types, formatting standardizations, etc. Attributes may introduce high-level requirements for data granularity, recency, frequency, etc. Requirements defined in attributes are necessary for servicing [FinOps capabilities][FODOFC] accurately using a standard set of instructions regardless of the origin of the data.
 
 !INCLUDE "column_handling.md",1
 !INCLUDE "currency_format.md",1

--- a/specification/attributes/attributes.mdpp
+++ b/specification/attributes/attributes.mdpp
@@ -1,9 +1,6 @@
 # Attributes
 
-Attributes are requirements that apply across all FOCUS datasets ([*primary*](#glossary:FOCUS-dataset) and [*adjacent*](#glossary:FOCUS-adjacent-dataset)) instead of an individual column level. Requirements on data content can include naming
-conventions, data types, formatting standardizations, etc. Attributes may introduce high-level requirements
-for data granularity, recency, frequency, etc. Requirements defined in attributes are necessary for servicing
-[FinOps capabilities][FODOFC] accurately using a standard set of instructions regardless of the origin of the data.
+Attributes are requirements that apply across a [*FOCUS dataset*](#glossary:FOCUS-dataset) instead of an individual column level. An attribute is associated with a dataset in the dataset's Requirements section.  Requirements on data content can include naming conventions, data types, formatting standardizations, etc. Attributes may introduce high-level requirements for data granularity, recency, frequency, etc. Requirements defined in attributes are necessary for servicing [FinOps capabilities][FODOFC] accurately using a standard set of instructions regardless of the origin of the data.
 
 !INCLUDE "column_handling.md",1
 !INCLUDE "currency_format.md",1

--- a/specification/datasets/cost_and_usage/cost_and_usage.mdpp
+++ b/specification/datasets/cost_and_usage/cost_and_usage.mdpp
@@ -1,7 +1,2 @@
-# Cost and Usage
-
-The Cost and Usage dataset is the primary dataset for FOCUS cost and usage data.
-
-The specification for the Cost and Usage dataset defines a group of columns that provide qualitative values (such as dates, resource, and provider information) categorized as "dimensions" and quantitative values (numeric values) categorized as "metrics" that can be used for performing various [FinOps capabilities][FODOFC]. Metrics are commonly used for aggregations (sum, multiplication, averaging etc.) and statistical operations within the dataset. Dimensions are commonly used to categorize, filter, and reveal details in your data when combined with metrics. The columns are presented in alphabetical order.
-
+!INCLUDE "dataset.md",0
 !INCLUDE "columns/columns.mdpp",0

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -68,11 +68,7 @@ The specification for the Cost and Usage dataset defines a group of columns that
 
 <div class='h4-nonindex'>Relationships</div>
 
-The Cost and Usage dataset can be joined to the Contract Commitment dataset through the use of the Contract Commitment ID field.
-
-| Dataset A           | Dataset A Column       | Dataset B           | Dataset B Column       |
-| ------------------- | ---------------------- | ------------------- | ---------------------- |
-| Cost and Usage      | Contract Commitment ID | Contract Commitment | Contract Commitment ID |
+(none)
 
 <div class='h4-nonindex'>Requirements</div>
 

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -6,7 +6,65 @@ The specification for the Cost and Usage dataset defines a group of columns that
 
 <div class='h4-nonindex'>Columns</div>
 
-<<column list TBD>>
+| Column                                                                        | Column Type | Feature Level | Allows Nulls | Data Type | Required |
+| ----------------------------------------------------------------------------- | ----------- | ------------- | ------------ | --------- | -------- |
+| [Billed Cost](#billedcost)                                                    | Metric      | Mandatory     | False        | Decimal   | TRUE     |
+| [Billing Account ID](#billingaccountid)                                       | Dimension   | Mandatory     | False        | String    | TRUE     |
+| [Billing Account Type](#billingaccounttype)                                   | Dimension   | Conditional   | False        | String    | FALSE    |
+| [Billing Currency](#billingcurrency)                                          | Dimension   | Mandatory     | False        | String    | TRUE     |
+| [Billing Period End](#billingperiodend)                                       | Dimension   | Mandatory     | False        | Date/Time | TRUE     |
+| [Billing Period Start](#billingperiodstart)                                   | Dimension   | Mandatory     | False        | Date/Time | TRUE     |
+| [Charge Category](#charge category)                                           | Dimension   | Mandatory     | False        | String    | TRUE     |
+| [Charge Frequency](#chargefrequency)                                          | Dimension   | Recommended   | False        | String    | TRUE     |
+| [Charge Period End](#chargeperiodend)                                         | Dimension   | Mandatory     | False        | Date/Time | TRUE     |
+| [Charge Period Start](#chargeperiodstart)                                     | Dimension   | Mandatory     | False        | Date/Time | TRUE     |
+| [Contracted Cost](#contractedcost)                                            | Metric      | Mandatory     | False        | Decimal   | TRUE     |
+| [Effective Cost](#effectivecost)                                              | Metric      | Mandatory     | False        | Decimal   | TRUE     |
+| [Invoice Issuer](#invoiceissuername)                                          | Dimension   | Mandatory     | False        | String    | TRUE     |
+| [List Cost](#listcost)                                                        | Metric      | Mandatory     | False        | Decimal   | TRUE     |
+| [Provider](#providername)                                                     | Dimension   | Mandatory     | False        | String    | TRUE     |
+| [Publisher](#publishername)                                                   | Dimension   | Mandatory     | False        | String    | TRUE     |
+| [Service Category](#servicecategory)                                          | Dimension   | Mandatory     | False        | String    | TRUE     |
+| [Service Name](#servicename)                                                  | Dimension   | Mandatory     | False        | String    | TRUE     |
+| [Service Subcategory](#servicesubcategory)                                    | Dimension   | Recommended   | False        | String    | FALSE    |
+| [Availability Zone](#availabilityzone)                                        | Dimension   | Recommended   | True         | String    | FALSE    |
+| [Billing Account Name](#billingaccountname)                                   | Dimension   | Mandatory     | True         | String    | TRUE     |
+| [Capacity Reservation ID](#capacityreservationid)                             | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Capacity Reservation Status](#capacityreservationstatus)                     | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Charge Class](#charge class)                                                 | Dimension   | Mandatory     | True         | String    | TRUE     |
+| [Charge Description](#chargedescription)                                      | Dimension   | Mandatory     | True         | String    | TRUE     |
+| [Commitment Discount Category](#commitmentdiscountcategory)                   | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Commitment Discount ID](#commitmentdiscountid)                               | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Commitment Discount Name](#commitmentdiscountname)                           | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Commitment Discount Quantity](#commitmentdiscountquantity)                   | Metric      | Conditional   | True         | Decimal   | TRUE     |
+| [Commitment Discount Status](#commitmentdiscountstatus)                       | Dimension   | Conditional   | True         | String    | FALSE    |
+| [Commitment Discount Type](#commitmentdiscounttype)                           | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Commitment Discount Unit](#commitmentdiscountunit)                           | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Consumed Quantity](#consumedquantity)                                        | Metric      | Conditional   | True         | Decimal   | TRUE     |
+| [Consumed Unit](#consumedunit)                                                | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Contracted Unit Price](#contractedunitprice)                                 | Metric      | Conditional   | True         | Decimal   | FALSE    |
+| [Invoice ID](#invoiceid)                                                      | Dimension   | Recommended   | True         | String    | FALSE    |
+| [List Unit Price](#listunitprice)                                             | Metric      | Conditional   | True         | Decimal   | TRUE     |
+| [Pricing Category](#pricingcategory)                                          | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Pricing Currency](#pricingcurrency)                                          | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Pricing Currency Contracted Unit Price](#pricingcurrencycontractedunitprice) | Metric      | Conditional   | True         | Decimal   | TRUE     |
+| [Pricing Currency Effective Cost](#pricingcurrencyeffectivecost)              | Metric      | Conditional   | True         | Decimal   | TRUE     |
+| [Pricing Currency List Unit Price](#pricingcurrencylistunitprice)             | Metric      | Conditional   | True         | Decimal   | TRUE     |
+| [Pricing Quantity](#pricingquantity)                                          | Metric      | Mandatory     | True         | Decimal   | TRUE     |
+| [Pricing Unit](#pricingunit)                                                  | Dimension   | Mandatory     | True         | String    | TRUE     |
+| [Region ID](#regionid)                                                        | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Region Name](#regionname)                                                    | Dimension   | Conditional   | True         | String    | FALSE    |
+| [Resource ID](#resourceid)                                                    | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Resource Name](#resourcename)                                                | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Resource Type](#resourcetype)                                                | Dimension   | Conditional   | True         | String    | TRUE     |
+| [SKU ID](#skuid)                                                              | Dimension   | Conditional   | True         | String    | TRUE     |
+| [SKU Meter](#skumeter)                                                        | Dimension   | Conditional   | True         | String    | TRUE     |
+| [SKU Price Details](#skupricedetails)                                         | Dimension   | Conditional   | True         | JSON      | TRUE     |
+| [SKU Price ID](#skupriceid)                                                   | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Sub Account ID](#subaccountid)                                               | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Sub Account Name](#subaccountname)                                           | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Sub Account Type](#subaccounttype)                                           | Dimension   | Conditional   | True         | String    | TRUE     |
+| [Tags](#tags)                                                                 | Dimension   | Conditional   | True         | JSON      | TRUE     |
 
 <div class='h4-nonindex'>Relationships</div>
 

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -74,7 +74,6 @@ None
 
 The CostAndUsage dataset adheres to the following requirements:
 
-* CostAndUsage MUST be present.
 * CostAndUsage MUST conform to [ColumnHandling](#columnhandling) requirements.
 * CostAndUsage MUST conform to [DiscountHandling](#discounthandling) requirements.
 * CostAndUsage MUST conform to [NullHandling](#nullhandling) requirements.

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -8,31 +8,22 @@ The specification for the Cost and Usage dataset defines a group of columns that
 
 | Column                                                                        | Column Type | Feature Level | Allows Nulls | Data Type |
 | ----------------------------------------------------------------------------- | ----------- | ------------- | ------------ | --------- |
+| [Availability Zone](#availabilityzone)                                        | Dimension   | Recommended   | True         | String    |
 | [Billed Cost](#billedcost)                                                    | Metric      | Mandatory     | False        | Decimal   |
 | [Billing Account ID](#billingaccountid)                                       | Dimension   | Mandatory     | False        | String    |
+| [Billing Account Name](#billingaccountname)                                   | Dimension   | Mandatory     | True         | String    |
 | [Billing Account Type](#billingaccounttype)                                   | Dimension   | Conditional   | False        | String    |
 | [Billing Currency](#billingcurrency)                                          | Dimension   | Mandatory     | False        | String    |
 | [Billing Period End](#billingperiodend)                                       | Dimension   | Mandatory     | False        | Date/Time |
 | [Billing Period Start](#billingperiodstart)                                   | Dimension   | Mandatory     | False        | Date/Time |
+| [Capacity Reservation ID](#capacityreservationid)                             | Dimension   | Conditional   | True         | String    |
+| [Capacity Reservation Status](#capacityreservationstatus)                     | Dimension   | Conditional   | True         | String    |
 | [Charge Category](#chargecategory)                                            | Dimension   | Mandatory     | False        | String    |
+| [Charge Class](#charge class)                                                 | Dimension   | Mandatory     | True         | String    |
+| [Charge Description](#chargedescription)                                      | Dimension   | Mandatory     | True         | String    |
 | [Charge Frequency](#chargefrequency)                                          | Dimension   | Recommended   | False        | String    |
 | [Charge Period End](#chargeperiodend)                                         | Dimension   | Mandatory     | False        | Date/Time |
 | [Charge Period Start](#chargeperiodstart)                                     | Dimension   | Mandatory     | False        | Date/Time |
-| [Contracted Cost](#contractedcost)                                            | Metric      | Mandatory     | False        | Decimal   |
-| [Effective Cost](#effectivecost)                                              | Metric      | Mandatory     | False        | Decimal   |
-| [Invoice Issuer](#invoiceissuername)                                          | Dimension   | Mandatory     | False        | String    |
-| [List Cost](#listcost)                                                        | Metric      | Mandatory     | False        | Decimal   |
-| [Provider](#providername)                                                     | Dimension   | Mandatory     | False        | String    |
-| [Publisher](#publishername)                                                   | Dimension   | Mandatory     | False        | String    |
-| [Service Category](#servicecategory)                                          | Dimension   | Mandatory     | False        | String    |
-| [Service Name](#servicename)                                                  | Dimension   | Mandatory     | False        | String    |
-| [Service Subcategory](#servicesubcategory)                                    | Dimension   | Recommended   | False        | String    |
-| [Availability Zone](#availabilityzone)                                        | Dimension   | Recommended   | True         | String    |
-| [Billing Account Name](#billingaccountname)                                   | Dimension   | Mandatory     | True         | String    |
-| [Capacity Reservation ID](#capacityreservationid)                             | Dimension   | Conditional   | True         | String    |
-| [Capacity Reservation Status](#capacityreservationstatus)                     | Dimension   | Conditional   | True         | String    |
-| [Charge Class](#charge class)                                                 | Dimension   | Mandatory     | True         | String    |
-| [Charge Description](#chargedescription)                                      | Dimension   | Mandatory     | True         | String    |
 | [Commitment Discount Category](#commitmentdiscountcategory)                   | Dimension   | Conditional   | True         | String    |
 | [Commitment Discount ID](#commitmentdiscountid)                               | Dimension   | Conditional   | True         | String    |
 | [Commitment Discount Name](#commitmentdiscountname)                           | Dimension   | Conditional   | True         | String    |
@@ -42,21 +33,30 @@ The specification for the Cost and Usage dataset defines a group of columns that
 | [Commitment Discount Unit](#commitmentdiscountunit)                           | Dimension   | Conditional   | True         | String    |
 | [Consumed Quantity](#consumedquantity)                                        | Metric      | Conditional   | True         | Decimal   |
 | [Consumed Unit](#consumedunit)                                                | Dimension   | Conditional   | True         | String    |
+| [Contracted Cost](#contractedcost)                                            | Metric      | Mandatory     | False        | Decimal   |
 | [Contracted Unit Price](#contractedunitprice)                                 | Metric      | Conditional   | True         | Decimal   |
+| [Effective Cost](#effectivecost)                                              | Metric      | Mandatory     | False        | Decimal   |
 | [Invoice ID](#invoiceid)                                                      | Dimension   | Recommended   | True         | String    |
+| [Invoice Issuer](#invoiceissuername)                                          | Dimension   | Mandatory     | False        | String    |
+| [List Cost](#listcost)                                                        | Metric      | Mandatory     | False        | Decimal   |
 | [List Unit Price](#listunitprice)                                             | Metric      | Conditional   | True         | Decimal   |
 | [Pricing Category](#pricingcategory)                                          | Dimension   | Conditional   | True         | String    |
-| [Pricing Currency](#pricingcurrency)                                          | Dimension   | Conditional   | True         | String    |
 | [Pricing Currency Contracted Unit Price](#pricingcurrencycontractedunitprice) | Metric      | Conditional   | True         | Decimal   |
 | [Pricing Currency Effective Cost](#pricingcurrencyeffectivecost)              | Metric      | Conditional   | True         | Decimal   |
 | [Pricing Currency List Unit Price](#pricingcurrencylistunitprice)             | Metric      | Conditional   | True         | Decimal   |
+| [Pricing Currency](#pricingcurrency)                                          | Dimension   | Conditional   | True         | String    |
 | [Pricing Quantity](#pricingquantity)                                          | Metric      | Mandatory     | True         | Decimal   |
 | [Pricing Unit](#pricingunit)                                                  | Dimension   | Mandatory     | True         | String    |
+| [Provider](#providername)                                                     | Dimension   | Mandatory     | False        | String    |
+| [Publisher](#publishername)                                                   | Dimension   | Mandatory     | False        | String    |
 | [Region ID](#regionid)                                                        | Dimension   | Conditional   | True         | String    |
 | [Region Name](#regionname)                                                    | Dimension   | Conditional   | True         | String    |
 | [Resource ID](#resourceid)                                                    | Dimension   | Conditional   | True         | String    |
 | [Resource Name](#resourcename)                                                | Dimension   | Conditional   | True         | String    |
 | [Resource Type](#resourcetype)                                                | Dimension   | Conditional   | True         | String    |
+| [Service Category](#servicecategory)                                          | Dimension   | Mandatory     | False        | String    |
+| [Service Name](#servicename)                                                  | Dimension   | Mandatory     | False        | String    |
+| [Service Subcategory](#servicesubcategory)                                    | Dimension   | Recommended   | False        | String    |
 | [SKU ID](#skuid)                                                              | Dimension   | Conditional   | True         | String    |
 | [SKU Meter](#skumeter)                                                        | Dimension   | Conditional   | True         | String    |
 | [SKU Price Details](#skupricedetails)                                         | Dimension   | Conditional   | True         | JSON      |

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -19,7 +19,7 @@ The specification for the Cost and Usage dataset defines a group of columns that
 | [Capacity Reservation ID](#capacityreservationid)                             | Dimension   | Conditional   | True         | String    |
 | [Capacity Reservation Status](#capacityreservationstatus)                     | Dimension   | Conditional   | True         | String    |
 | [Charge Category](#chargecategory)                                            | Dimension   | Mandatory     | False        | String    |
-| [Charge Class](#charge class)                                                 | Dimension   | Mandatory     | True         | String    |
+| [Charge Class](#chargeclass)                                                  | Dimension   | Mandatory     | True         | String    |
 | [Charge Description](#chargedescription)                                      | Dimension   | Mandatory     | True         | String    |
 | [Charge Frequency](#chargefrequency)                                          | Dimension   | Recommended   | False        | String    |
 | [Charge Period End](#chargeperiodend)                                         | Dimension   | Mandatory     | False        | Date/Time |

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -1,0 +1,48 @@
+# Cost and Usage
+
+The Cost and Usage dataset is the primary dataset for FOCUS cost and usage data.
+
+The specification for the Cost and Usage dataset defines a group of columns that provide qualitative values (such as dates, resource, and provider information) categorized as "dimensions" and quantitative values (numeric values) categorized as "metrics" that can be used for performing various [FinOps capabilities][FODOFC]. Metrics are commonly used for aggregations (sum, multiplication, averaging etc.) and statistical operations within the dataset. Dimensions are commonly used to categorize, filter, and reveal details in your data when combined with metrics. The columns are presented in alphabetical order.
+
+<div class='h4-nonindex'>Columns</div>
+
+<<column list TBD>>
+
+<div class='h4-nonindex'>Relationships</div>
+
+The Cost and Usage dataset can be joined to the Contract Commitment dataset through the use of the Contract Commitment ID field.
+
+| Dataset A           | Dataset A Column       | Dataset B           | Dataset B Column       |
+| ------------------- | ---------------------- | ------------------- | ---------------------- |
+| Cost and Usage      | Contract Commitment ID | Contract Commitment | Contract Commitment ID |
+
+<div class='h4-nonindex'>Requirements</div>
+
+The CostAndUsage dataset adheres to the following requirements:
+
+* CostAndUsage MUST be present.
+* CostAndUsage MUST conform to [ColumnHandling](#columnhandling) requirements.
+* CostAndUsage MUST conform to [CurrencyFormat](#currencyformat) requirements.
+* CostAndUsage MUST conform to [DateTimeFormat](#datetimeformat) requirements.
+* CostAndUsage MUST conform to [DiscountHandling](#discounthandling) requirements.
+* CostAndUsage MUST conform to [KeyValueFormat](#keyvalueformat) requirements.
+* CostAndUsage MUST conform to [NullHandling](#nullhandling) requirements.
+* CostAndUsage MUST conform to [NumericFormat](#numericformat) requirements.
+* CostAndUsage MUST conform to [StringHandling](#stringhandling) requirements.
+* CostAndUsage MUST conform to [UnitFormat](#unitformat) requirements.
+
+<div class='h4-nonindex'>Dataset ID</div>
+
+CostAndUsage
+
+<div class='h4-nonindex'>Display Name</div>
+
+Cost and Usage
+
+<div class='h4-nonindex'>Description</div>
+
+Describes the cost and usage incurred by consuming a provider's resources and services.
+
+<div class='h4-nonindex'>Introduced (version)</div>
+
+0.5

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -88,7 +88,7 @@ Cost and Usage
 
 <div class='h4-nonindex'>Description</div>
 
-Describes the cost and usage incurred through using or purchasing a provider’s [*resources*](#glossary:resource) or [*services*](#glossary:service).
+Describes the cost and usage incurred through using or purchasing a provider's [*resources*](#glossary:resource) or [*services*](#glossary:service).
 
 <div class='h4-nonindex'>Introduced (version)</div>
 

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -80,14 +80,8 @@ The CostAndUsage dataset adheres to the following requirements:
 
 * CostAndUsage MUST be present.
 * CostAndUsage MUST conform to [ColumnHandling](#columnhandling) requirements.
-* CostAndUsage MUST conform to [CurrencyFormat](#currencyformat) requirements.
-* CostAndUsage MUST conform to [DateTimeFormat](#datetimeformat) requirements.
 * CostAndUsage MUST conform to [DiscountHandling](#discounthandling) requirements.
-* CostAndUsage MUST conform to [KeyValueFormat](#keyvalueformat) requirements.
 * CostAndUsage MUST conform to [NullHandling](#nullhandling) requirements.
-* CostAndUsage MUST conform to [NumericFormat](#numericformat) requirements.
-* CostAndUsage MUST conform to [StringHandling](#stringhandling) requirements.
-* CostAndUsage MUST conform to [UnitFormat](#unitformat) requirements.
 
 <div class='h4-nonindex'>Dataset ID</div>
 

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -88,7 +88,7 @@ Cost and Usage
 
 <div class='h4-nonindex'>Description</div>
 
-Describes the cost and usage incurred by consuming a provider's resources and services.
+Describes the cost and usage incurred through using or purchasing a provider’s [*resources*](#glossary:resource) or [*services*](#glossary:service).
 
 <div class='h4-nonindex'>Introduced (version)</div>
 

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -6,65 +6,65 @@ The specification for the Cost and Usage dataset defines a group of columns that
 
 <div class='h4-nonindex'>Columns</div>
 
-| Column                                                                        | Column Type | Feature Level | Allows Nulls | Data Type | Required |
-| ----------------------------------------------------------------------------- | ----------- | ------------- | ------------ | --------- | -------- |
-| [Billed Cost](#billedcost)                                                    | Metric      | Mandatory     | False        | Decimal   | TRUE     |
-| [Billing Account ID](#billingaccountid)                                       | Dimension   | Mandatory     | False        | String    | TRUE     |
-| [Billing Account Type](#billingaccounttype)                                   | Dimension   | Conditional   | False        | String    | FALSE    |
-| [Billing Currency](#billingcurrency)                                          | Dimension   | Mandatory     | False        | String    | TRUE     |
-| [Billing Period End](#billingperiodend)                                       | Dimension   | Mandatory     | False        | Date/Time | TRUE     |
-| [Billing Period Start](#billingperiodstart)                                   | Dimension   | Mandatory     | False        | Date/Time | TRUE     |
-| [Charge Category](#charge category)                                           | Dimension   | Mandatory     | False        | String    | TRUE     |
-| [Charge Frequency](#chargefrequency)                                          | Dimension   | Recommended   | False        | String    | TRUE     |
-| [Charge Period End](#chargeperiodend)                                         | Dimension   | Mandatory     | False        | Date/Time | TRUE     |
-| [Charge Period Start](#chargeperiodstart)                                     | Dimension   | Mandatory     | False        | Date/Time | TRUE     |
-| [Contracted Cost](#contractedcost)                                            | Metric      | Mandatory     | False        | Decimal   | TRUE     |
-| [Effective Cost](#effectivecost)                                              | Metric      | Mandatory     | False        | Decimal   | TRUE     |
-| [Invoice Issuer](#invoiceissuername)                                          | Dimension   | Mandatory     | False        | String    | TRUE     |
-| [List Cost](#listcost)                                                        | Metric      | Mandatory     | False        | Decimal   | TRUE     |
-| [Provider](#providername)                                                     | Dimension   | Mandatory     | False        | String    | TRUE     |
-| [Publisher](#publishername)                                                   | Dimension   | Mandatory     | False        | String    | TRUE     |
-| [Service Category](#servicecategory)                                          | Dimension   | Mandatory     | False        | String    | TRUE     |
-| [Service Name](#servicename)                                                  | Dimension   | Mandatory     | False        | String    | TRUE     |
-| [Service Subcategory](#servicesubcategory)                                    | Dimension   | Recommended   | False        | String    | FALSE    |
-| [Availability Zone](#availabilityzone)                                        | Dimension   | Recommended   | True         | String    | FALSE    |
-| [Billing Account Name](#billingaccountname)                                   | Dimension   | Mandatory     | True         | String    | TRUE     |
-| [Capacity Reservation ID](#capacityreservationid)                             | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Capacity Reservation Status](#capacityreservationstatus)                     | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Charge Class](#charge class)                                                 | Dimension   | Mandatory     | True         | String    | TRUE     |
-| [Charge Description](#chargedescription)                                      | Dimension   | Mandatory     | True         | String    | TRUE     |
-| [Commitment Discount Category](#commitmentdiscountcategory)                   | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Commitment Discount ID](#commitmentdiscountid)                               | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Commitment Discount Name](#commitmentdiscountname)                           | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Commitment Discount Quantity](#commitmentdiscountquantity)                   | Metric      | Conditional   | True         | Decimal   | TRUE     |
-| [Commitment Discount Status](#commitmentdiscountstatus)                       | Dimension   | Conditional   | True         | String    | FALSE    |
-| [Commitment Discount Type](#commitmentdiscounttype)                           | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Commitment Discount Unit](#commitmentdiscountunit)                           | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Consumed Quantity](#consumedquantity)                                        | Metric      | Conditional   | True         | Decimal   | TRUE     |
-| [Consumed Unit](#consumedunit)                                                | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Contracted Unit Price](#contractedunitprice)                                 | Metric      | Conditional   | True         | Decimal   | FALSE    |
-| [Invoice ID](#invoiceid)                                                      | Dimension   | Recommended   | True         | String    | FALSE    |
-| [List Unit Price](#listunitprice)                                             | Metric      | Conditional   | True         | Decimal   | TRUE     |
-| [Pricing Category](#pricingcategory)                                          | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Pricing Currency](#pricingcurrency)                                          | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Pricing Currency Contracted Unit Price](#pricingcurrencycontractedunitprice) | Metric      | Conditional   | True         | Decimal   | TRUE     |
-| [Pricing Currency Effective Cost](#pricingcurrencyeffectivecost)              | Metric      | Conditional   | True         | Decimal   | TRUE     |
-| [Pricing Currency List Unit Price](#pricingcurrencylistunitprice)             | Metric      | Conditional   | True         | Decimal   | TRUE     |
-| [Pricing Quantity](#pricingquantity)                                          | Metric      | Mandatory     | True         | Decimal   | TRUE     |
-| [Pricing Unit](#pricingunit)                                                  | Dimension   | Mandatory     | True         | String    | TRUE     |
-| [Region ID](#regionid)                                                        | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Region Name](#regionname)                                                    | Dimension   | Conditional   | True         | String    | FALSE    |
-| [Resource ID](#resourceid)                                                    | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Resource Name](#resourcename)                                                | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Resource Type](#resourcetype)                                                | Dimension   | Conditional   | True         | String    | TRUE     |
-| [SKU ID](#skuid)                                                              | Dimension   | Conditional   | True         | String    | TRUE     |
-| [SKU Meter](#skumeter)                                                        | Dimension   | Conditional   | True         | String    | TRUE     |
-| [SKU Price Details](#skupricedetails)                                         | Dimension   | Conditional   | True         | JSON      | TRUE     |
-| [SKU Price ID](#skupriceid)                                                   | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Sub Account ID](#subaccountid)                                               | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Sub Account Name](#subaccountname)                                           | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Sub Account Type](#subaccounttype)                                           | Dimension   | Conditional   | True         | String    | TRUE     |
-| [Tags](#tags)                                                                 | Dimension   | Conditional   | True         | JSON      | TRUE     |
+| Column                                                                        | Column Type | Feature Level | Allows Nulls | Data Type |
+| ----------------------------------------------------------------------------- | ----------- | ------------- | ------------ | --------- |
+| [Billed Cost](#billedcost)                                                    | Metric      | Mandatory     | False        | Decimal   |
+| [Billing Account ID](#billingaccountid)                                       | Dimension   | Mandatory     | False        | String    |
+| [Billing Account Type](#billingaccounttype)                                   | Dimension   | Conditional   | False        | String    |
+| [Billing Currency](#billingcurrency)                                          | Dimension   | Mandatory     | False        | String    |
+| [Billing Period End](#billingperiodend)                                       | Dimension   | Mandatory     | False        | Date/Time |
+| [Billing Period Start](#billingperiodstart)                                   | Dimension   | Mandatory     | False        | Date/Time |
+| [Charge Category](#chargecategory)                                            | Dimension   | Mandatory     | False        | String    |
+| [Charge Frequency](#chargefrequency)                                          | Dimension   | Recommended   | False        | String    |
+| [Charge Period End](#chargeperiodend)                                         | Dimension   | Mandatory     | False        | Date/Time |
+| [Charge Period Start](#chargeperiodstart)                                     | Dimension   | Mandatory     | False        | Date/Time |
+| [Contracted Cost](#contractedcost)                                            | Metric      | Mandatory     | False        | Decimal   |
+| [Effective Cost](#effectivecost)                                              | Metric      | Mandatory     | False        | Decimal   |
+| [Invoice Issuer](#invoiceissuername)                                          | Dimension   | Mandatory     | False        | String    |
+| [List Cost](#listcost)                                                        | Metric      | Mandatory     | False        | Decimal   |
+| [Provider](#providername)                                                     | Dimension   | Mandatory     | False        | String    |
+| [Publisher](#publishername)                                                   | Dimension   | Mandatory     | False        | String    |
+| [Service Category](#servicecategory)                                          | Dimension   | Mandatory     | False        | String    |
+| [Service Name](#servicename)                                                  | Dimension   | Mandatory     | False        | String    |
+| [Service Subcategory](#servicesubcategory)                                    | Dimension   | Recommended   | False        | String    |
+| [Availability Zone](#availabilityzone)                                        | Dimension   | Recommended   | True         | String    |
+| [Billing Account Name](#billingaccountname)                                   | Dimension   | Mandatory     | True         | String    |
+| [Capacity Reservation ID](#capacityreservationid)                             | Dimension   | Conditional   | True         | String    |
+| [Capacity Reservation Status](#capacityreservationstatus)                     | Dimension   | Conditional   | True         | String    |
+| [Charge Class](#charge class)                                                 | Dimension   | Mandatory     | True         | String    |
+| [Charge Description](#chargedescription)                                      | Dimension   | Mandatory     | True         | String    |
+| [Commitment Discount Category](#commitmentdiscountcategory)                   | Dimension   | Conditional   | True         | String    |
+| [Commitment Discount ID](#commitmentdiscountid)                               | Dimension   | Conditional   | True         | String    |
+| [Commitment Discount Name](#commitmentdiscountname)                           | Dimension   | Conditional   | True         | String    |
+| [Commitment Discount Quantity](#commitmentdiscountquantity)                   | Metric      | Conditional   | True         | Decimal   |
+| [Commitment Discount Status](#commitmentdiscountstatus)                       | Dimension   | Conditional   | True         | String    |
+| [Commitment Discount Type](#commitmentdiscounttype)                           | Dimension   | Conditional   | True         | String    |
+| [Commitment Discount Unit](#commitmentdiscountunit)                           | Dimension   | Conditional   | True         | String    |
+| [Consumed Quantity](#consumedquantity)                                        | Metric      | Conditional   | True         | Decimal   |
+| [Consumed Unit](#consumedunit)                                                | Dimension   | Conditional   | True         | String    |
+| [Contracted Unit Price](#contractedunitprice)                                 | Metric      | Conditional   | True         | Decimal   |
+| [Invoice ID](#invoiceid)                                                      | Dimension   | Recommended   | True         | String    |
+| [List Unit Price](#listunitprice)                                             | Metric      | Conditional   | True         | Decimal   |
+| [Pricing Category](#pricingcategory)                                          | Dimension   | Conditional   | True         | String    |
+| [Pricing Currency](#pricingcurrency)                                          | Dimension   | Conditional   | True         | String    |
+| [Pricing Currency Contracted Unit Price](#pricingcurrencycontractedunitprice) | Metric      | Conditional   | True         | Decimal   |
+| [Pricing Currency Effective Cost](#pricingcurrencyeffectivecost)              | Metric      | Conditional   | True         | Decimal   |
+| [Pricing Currency List Unit Price](#pricingcurrencylistunitprice)             | Metric      | Conditional   | True         | Decimal   |
+| [Pricing Quantity](#pricingquantity)                                          | Metric      | Mandatory     | True         | Decimal   |
+| [Pricing Unit](#pricingunit)                                                  | Dimension   | Mandatory     | True         | String    |
+| [Region ID](#regionid)                                                        | Dimension   | Conditional   | True         | String    |
+| [Region Name](#regionname)                                                    | Dimension   | Conditional   | True         | String    |
+| [Resource ID](#resourceid)                                                    | Dimension   | Conditional   | True         | String    |
+| [Resource Name](#resourcename)                                                | Dimension   | Conditional   | True         | String    |
+| [Resource Type](#resourcetype)                                                | Dimension   | Conditional   | True         | String    |
+| [SKU ID](#skuid)                                                              | Dimension   | Conditional   | True         | String    |
+| [SKU Meter](#skumeter)                                                        | Dimension   | Conditional   | True         | String    |
+| [SKU Price Details](#skupricedetails)                                         | Dimension   | Conditional   | True         | JSON      |
+| [SKU Price ID](#skupriceid)                                                   | Dimension   | Conditional   | True         | String    |
+| [Sub Account ID](#subaccountid)                                               | Dimension   | Conditional   | True         | String    |
+| [Sub Account Name](#subaccountname)                                           | Dimension   | Conditional   | True         | String    |
+| [Sub Account Type](#subaccounttype)                                           | Dimension   | Conditional   | True         | String    |
+| [Tags](#tags)                                                                 | Dimension   | Conditional   | True         | JSON      |
 
 <div class='h4-nonindex'>Relationships</div>
 

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -68,7 +68,7 @@ The specification for the Cost and Usage dataset defines a group of columns that
 
 <div class='h4-nonindex'>Relationships</div>
 
-(none)
+None
 
 <div class='h4-nonindex'>Requirements</div>
 


### PR DESCRIPTION
We need to finesse the spec to associate specific attributes with specific datasets.  

Current verbiage is:

> Attributes are requirements that apply across all FOCUS datasets instead of an individual column level.

1) That's not true for all attributes: we apply some at the column level.
2) This means that every attribute is associated with every dataset, which will be problematic/inaccurate as our number of datasets grows beyond one.  For example, Discount Handling has nothing to do with Contracts.

This PR therefore associates the `Cost and Usage` dataset to all the current attributes.

FYI that PR #1350 performs the same association for `Contract Commitment` (or rather, it will, once we get agreement on this PR).