### PR TITLE
allocatedmethodid to include Unallocated

### DIFF
--- a/specification/datasets/cost_and_usage/columns/allocatedmethodid.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethodid.md
@@ -8,9 +8,11 @@ The AllocatedMethodId column adheres to the following requirements:
 * AllocatedMethodId MUST be of type String.
 * AllocatedMethodId MUST conform to [StringHandling](#stringhandling) requirements.
 * AllocatedMethodId nullability is defined as follows:
-  * AllocatedMethodId MUST be null when a charge is not related to a provider-calculated split cost allocation.
-  * AllocatedMethodId MUST NOT be null when a charge is related to a provider-calculated split cost allocation.
-* AllocatedMethodId MUST uniquely identify the method used to calculate the split cost allocation in the provider's documentation.
+  * AllocatedMethodId MUST be null when a charge does not qualify for provider-calculated split cost allocation.
+  * AllocatedMethodId MUST NOT be null when a charge qualifies for provider-calculated split cost allocation.
+* When a charge qualifies for for provider-calculated split cost allocation, AllocatedMethodId adheres to the following additional requirements:
+  * AllocatedMethodId MUST uniquely identify the method used to calculate the split cost allocation in the provider's documentation when the charge is the result of provider-calculated split cost allocation.
+  * AllocatedMethodId MUST be "Unallocated" when the charge qualifies for provider-calculated split cost allocation but no split cost allocation was applied.
 
 ## Column ID
 


### PR DESCRIPTION
In conversation, there was discussion around determining whether a charge was allocated, could be allocated but wasn't, or could not be allocated. Here is a proposed solution.