### PR TITLE
Added codeblock alignment check to Makefile to get better warnings 

### DIFF
--- a/specification/Makefile
+++ b/specification/Makefile
@@ -49,6 +49,13 @@ spec.md: $(SPEC_SOURCE_FILES)
 	./validate_includes.py appendix
 	./validate_includes.py appendix/metadata_examples
 	./validate_includes.py appendix/saas_examples
+	
+	@echo "Checking for misaligned code block markers (\`\`\`)..."
+	@find . -type f \( -name "*.md" -o -name "*.mdpp" \) \
+		-exec grep -nH '^[[:space:]][[:space:]]*```$$' {} + 2>/dev/null | \
+	while IFS=: read -r file line _; do \
+		echo "WARNING: Found code block escape that is not aligned to the start of the line in file $$file on line $$line"; \
+	done || true
 	PYTHONPATH=../vendored/ $(MARKDOWNPP) spec.mdpp -o $@
 	$(PYMARKDOWNLNT) --config markdownlnt.cfg scan $(SPEC_SOURCE_MDFILES)
 	$(PYMARKDOWNLNT) --config markdownlnt.cfg scan $@


### PR DESCRIPTION
Added codeblock alignment check to Makefile to get better warnings on formatting errors

This PR will add warnings like 
Checking for misaligned code block markers (```)...
WARNING: Found code block escape that is not aligned to the start of the line in file ./supported_features/resource_usage.md on line 41

if we write end code blocks not at the start of the line which breaks builds. As it's preceded with whitespace these errors are hard to diagnose without a hint. This will not stop the build as it's only a warning.