### PR TITLE
AI #1508: Add Requirements subheader to every column definition

### DIFF
--- a/specification/datasets/cost_and_usage/columns/allocatedmethodid.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethodid.md
@@ -2,7 +2,7 @@
 
 Allocated Method ID is the unique identifier for the [allocated method](#glossary:allocated-method) defined by the provider which was used for the [Provider-Calculated Split Cost Allocation](#providercalculatedsplitcosthandling). This unique identifier can be used to find how the [allocated charge](#glossary:allocated-charge) was calculated in the provider's documentation.
 
-The AllocatedMethodId column adheres to the following requirements:
+## Requirements
 
 * AllocatedMethodId MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports provider-calculated split cost allocation.
 * AllocatedMethodId MUST be of type String.

--- a/specification/datasets/cost_and_usage/columns/allocatedmethodid.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethodid.md
@@ -4,6 +4,8 @@ Allocated Method ID is the unique identifier for the [allocated method](#glossar
 
 ## Requirements
 
+AllocatedMethodId adheres to the following requirements:
+
 * AllocatedMethodId MUST be present in a [*FOCUS dataset*](#glossary:FOCUS-dataset) when the provider supports provider-calculated split cost allocation.
 * AllocatedMethodId MUST be of type String.
 * AllocatedMethodId MUST conform to [StringHandling](#stringhandling) requirements.


### PR DESCRIPTION
This PR demonstrates how to execute on AI #1508.

This pattern would need to be repeated for every column definition in the specification.