### PR TITLE
AI #1517: Reduce nesting from 3 to 2 levels in CommitmentDiscountQuantity

### DIFF
--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountquantity.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountquantity.md
@@ -15,14 +15,13 @@ The CommitmentDiscountQuantity column adheres to the following requirements:
     * CommitmentDiscountQuantity MUST NOT be null when [ChargeClass](#chargeclass) is not "Correction".
     * CommitmentDiscountQuantity MAY be null when ChargeClass is "Correction".
   * CommitmentDiscountQuantity MUST be null in all other cases.
-* When CommitmentDiscountQuantity is not null, CommitmentDiscountQuantity adheres to the following additional requirements:
-  * CommitmentDiscountQuantity MUST be a valid decimal value.
-  * When ChargeCategory is "Purchase":
-    * CommitmentDiscountQuantity MUST be the quantity of CommitmentDiscountUnit, paid fully or partially upfront, that is eligible for consumption over the *commitment discount's* *period* when [ChargeFrequency](#chargefrequency) is "One-Time".
-    * CommitmentDiscountQuantity MUST be the quantity of CommitmentDiscountUnit that is eligible for consumption for each *charge period* that corresponds with the purchase when ChargeFrequency is "Recurring".
-  * When ChargeCategory is "Usage":
-    * CommitmentDiscountQuantity MUST be the metered quantity of CommitmentDiscountUnit that is consumed in a given *charge period* when [CommitmentDiscountStatus](#commitmentdiscountstatus) is "Used".
-    * CommitmentDiscountQuantity MUST be the remaining, unused quantity of CommitmentDiscountUnit in a given *charge period* when CommitmentDiscountStatus is "Unused".
+* CommitmentDiscountQuantity MUST be a valid decimal value when not null.
+* When CommitmentDiscountQuantity is not null and ChargeCategory is "Purchase", CommitmentDiscountQuantity adheres to the following additional requirements:
+  * CommitmentDiscountQuantity MUST be the quantity of CommitmentDiscountUnit, paid fully or partially upfront, that is eligible for consumption over the *commitment discount's* *term* when [ChargeFrequency](#chargefrequency) is "One-Time".
+  * CommitmentDiscountQuantity MUST be the quantity of CommitmentDiscountUnit that is eligible for consumption for each *charge period* that corresponds with the purchase when ChargeFrequency is "Recurring".
+* When CommitmentDiscountQuantity is not null and ChargeCategory is "Usage":, CommitmentDiscountQuantity adheres to the following additional requirements:
+  * CommitmentDiscountQuantity MUST be the metered quantity of CommitmentDiscountUnit that is consumed in a given *charge period* when [CommitmentDiscountStatus](#commitmentdiscountstatus) is "Used".
+  * CommitmentDiscountQuantity MUST be the remaining, unused quantity of CommitmentDiscountUnit in a given *charge period* when CommitmentDiscountStatus is "Unused".
 
 ## Column ID
 

--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountquantity.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountquantity.md
@@ -19,7 +19,7 @@ The CommitmentDiscountQuantity column adheres to the following requirements:
 * When CommitmentDiscountQuantity is not null and ChargeCategory is "Purchase", CommitmentDiscountQuantity adheres to the following additional requirements:
   * CommitmentDiscountQuantity MUST be the quantity of CommitmentDiscountUnit, paid fully or partially upfront, that is eligible for consumption over the *commitment discount's* *term* when [ChargeFrequency](#chargefrequency) is "One-Time".
   * CommitmentDiscountQuantity MUST be the quantity of CommitmentDiscountUnit that is eligible for consumption for each *charge period* that corresponds with the purchase when ChargeFrequency is "Recurring".
-* When CommitmentDiscountQuantity is not null and ChargeCategory is "Usage":, CommitmentDiscountQuantity adheres to the following additional requirements:
+* When CommitmentDiscountQuantity is not null and ChargeCategory is "Usage", CommitmentDiscountQuantity adheres to the following additional requirements:
   * CommitmentDiscountQuantity MUST be the metered quantity of CommitmentDiscountUnit that is consumed in a given *charge period* when [CommitmentDiscountStatus](#commitmentdiscountstatus) is "Used".
   * CommitmentDiscountQuantity MUST be the remaining, unused quantity of CommitmentDiscountUnit in a given *charge period* when CommitmentDiscountStatus is "Unused".
 


### PR DESCRIPTION
This PR simplifies the structure of several CommitmentDiscountQuantity requirements by reducing their nesting from three to two levels, without introducing any material changes.