### PR TITLE
AI #1516: Address ambiguous normative requirement for EffectiveCost

### DIFF
--- a/specification/datasets/cost_and_usage/columns/effectivecost.md
+++ b/specification/datasets/cost_and_usage/columns/effectivecost.md
@@ -16,7 +16,7 @@ The EffectiveCost column adheres to the following requirements:
 * EffectiveCost MUST be a valid decimal value.
 * EffectiveCost MUST be 0 when [ChargeCategory](#chargecategory) is "Purchase" and the purchase is intended to cover future eligible *charges*.
 * EffectiveCost MUST be denominated in the BillingCurrency.
-* The sum of EffectiveCost in a given *billing period* may not match the sum of the invoices received for the same *billing period* for a [*billing account*](#glossary:billing-account).
+* The sum of EffectiveCost in a given *billing period* MAY differ from the sum of the invoices received for the same *billing period* for a [*billing account*](#glossary:billing-account).
 * When ChargeCategory is not "Usage" or "Purchase", EffectiveCost adheres to the following additional requirements:
   * EffectiveCost of a *charge* calculated based on other *charges* (e.g., when the ChargeCategory is "Tax") MUST be calculated based on the EffectiveCost of those related *charges*.
   * EffectiveCost of a *charge* unrelated to other *charges* (e.g., when the ChargeCategory is "Credit") MUST match the [BilledCost](#billedcost).


### PR DESCRIPTION

This PR clarifies an ambiguous EffectiveCost requirement. The original wording:

> * The sum of EffectiveCost in a given billing period **may not match the sum** of the invoices received for the same billing period for a billing account.

This phrasing is ambiguous due to the use of "may not", which can be interpreted either as a possibility ("might not match") or as a soft prohibition ("is not allowed to match").

Suggestion:

> * The sum of EffectiveCost in a given billing period **MAY differ from the sum** of the invoices received for the same billing period for a billing account.

This removes ambiguity without introducing any material change.
