### PR TITLE
Changes to the copyright and version in preparation for candidate release and publication

### DIFF
--- a/specification/versions/candidate_release.md
+++ b/specification/versions/candidate_release.md
@@ -1,12 +1,12 @@
 ## Version
 
-v1.4 Candidate Release
+v1.3 Candidate Release
 
 | <span style="color:Red">&#x26A1; Warning</span>                                |
 |:-------------------------------------------------------------------------------|
 | This version is a candidate release but not an official publication            |
 
-Copyright © 2023-2027 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
+Copyright © 2023-2026 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
 
 ## Status of This Document
 

--- a/specification/versions/candidate_release.md
+++ b/specification/versions/candidate_release.md
@@ -1,12 +1,12 @@
 ## Version
 
-v1.2 Candidate Release
+v1.4 Candidate Release
 
 | <span style="color:Red">&#x26A1; Warning</span>                                |
 |:-------------------------------------------------------------------------------|
 | This version is a candidate release but not an official publication            |
 
-Copyright © 2023-2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
+Copyright © 2023-2027 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
 
 ## Status of This Document
 

--- a/specification/versions/main.md
+++ b/specification/versions/main.md
@@ -1,8 +1,8 @@
 ## Version
 
-Publication version 1.2
+Publication version 1.4
 
-Copyright © 2023-2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
+Copyright © 2023-2027 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
 
 ## Status of This Document
 

--- a/specification/versions/main.md
+++ b/specification/versions/main.md
@@ -1,8 +1,8 @@
 ## Version
 
-Publication version 1.4
+Publication version 1.3
 
-Copyright © 2023-2027 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
+Copyright © 2023-2026 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
 
 ## Status of This Document
 

--- a/specification/versions/working_draft.md
+++ b/specification/versions/working_draft.md
@@ -6,7 +6,7 @@ Working Draft (Unversioned)
 |:-------------------------------------------------------------------------------|
 | This version not for publication                                               |
 
-Copyright © 2023-2027 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
+Copyright © 2023-2026 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
 
 ## Status of This Document
 

--- a/specification/versions/working_draft.md
+++ b/specification/versions/working_draft.md
@@ -6,7 +6,7 @@ Working Draft (Unversioned)
 |:-------------------------------------------------------------------------------|
 | This version not for publication                                               |
 
-Copyright © 2023-2025 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
+Copyright © 2023-2027 - FinOps Open Cost and Usage Specification (FOCUS) a Series of the Joint Development Foundation Projects, LLC. Joint Development Foundation [trademark](https://jointdevelopment.org/policies/trademark-policy/), and document use rules apply.
 
 ## Status of This Document
 


### PR DESCRIPTION
These changes are to prepare the candidate release and final publication documents with the correct copyright year and release. The changes should be applied only to the working_draft branch to avoid merging conflicts.