### PR TITLE
AI #1914: Reclassify unit price columns from Metric to Dimension

### DIFF
--- a/specification/datasets/cost_and_usage/columns/contractedunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/contractedunitprice.md
@@ -41,7 +41,7 @@ The agreed-upon unit price for a single Pricing Unit of the associated SKU, incl
 
 | Constraint      | Value                                |
 |:----------------|:-------------------------------------|
-| Column type     | Metric                               |
+| Column type     | Dimension                            |
 | Feature level   | Conditional                          |
 | Allows nulls    | True                                 |
 | Data type       | Decimal                              |

--- a/specification/datasets/cost_and_usage/columns/listunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/listunitprice.md
@@ -40,7 +40,7 @@ The suggested service-provider-published unit price for a single Pricing Unit of
 
 | Constraint      | Value                                |
 |:----------------|:-------------------------------------|
-| Column type     | Metric                               |
+| Column type     | Dimension                            |
 | Feature level   | Conditional                          |
 | Allows nulls    | True                                 |
 | Data type       | Decimal                              |

--- a/specification/datasets/cost_and_usage/columns/pricingcurrencycontractedunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcurrencycontractedunitprice.md
@@ -42,7 +42,7 @@ The agreed-upon unit price for a single Pricing Unit of the associated SKU, incl
 
 | Constraint      | Value                                |
 |:----------------|:-------------------------------------|
-| Column type     | Metric                               |
+| Column type     | Dimension                            |
 | Feature level   | Conditional                          |
 | Allows nulls    | True                                 |
 | Data type       | Decimal                              |

--- a/specification/datasets/cost_and_usage/columns/pricingcurrencylistunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcurrencylistunitprice.md
@@ -42,7 +42,7 @@ The suggested service-provider-published unit price for a single Pricing Unit of
 
 | Constraint      | Value                                |
 |:----------------|:-------------------------------------|
-| Column type     | Metric                               |
+| Column type     | Dimension                            |
 | Feature level   | Conditional                          |
 | Allows nulls    | True                                 |
 | Data type       | Decimal                              |


### PR DESCRIPTION
## Summary

Reclassifies 4 unit price columns from Metric to Dimension. Unit prices are not summable and conflict with aggregation semantics — summing unit prices when rows are aggregated produces meaningless values.

## Changes

| Column | Change |
|--------|--------|
| ListUnitPrice | Metric → Dimension |
| ContractedUnitPrice | Metric → Dimension |
| PricingCurrencyListUnitPrice | Metric → Dimension |
| PricingCurrencyContractedUnitPrice | Metric → Dimension |

## Rationale

- Unit prices represent per-unit rates, not additive quantities
- Summing unit prices across rows (e.g., during row aggregation) produces meaningless results
- Classifying them as Dimension ensures they are treated as grouping attributes rather than summable values

Split from PR #1816 (Dataset Configuration) per reviewer feedback.

## Test plan

- [ ] Build succeeds
- [ ] No other columns reference unit price column types

🤖 Generated with [Claude Code](https://claude.ai/claude-code)