### PR TITLE
AI #1925: Update Makefile to run HTML/PDF build against appropriate subfolders

### DIFF
--- a/specification/Makefile
+++ b/specification/Makefile
@@ -45,8 +45,6 @@ spec.md: $(SPEC_SOURCE_FILES)
 	./validate_includes.py datasets/cost_and_usage/columns
 	./validate_includes.py datasets/contract_commitment
 	./validate_includes.py datasets/contract_commitment/columns
-	./validate_includes.py datasets/invoice_detail
-	./validate_includes.py datasets/invoice_detail/columns
 	./validate_includes.py attributes
 	./validate_includes.py metadata
 	./validate_includes.py metadata/data_generator

--- a/specification/Makefile
+++ b/specification/Makefile
@@ -40,7 +40,13 @@ spec.md: $(SPEC_SOURCE_FILES)
 	  cp versions/${STYLE}.md version.md; \
 	fi
 	./validate_includes.py supported_features
+	./validate_includes.py datasets
+	./validate_includes.py datasets/cost_and_usage
 	./validate_includes.py datasets/cost_and_usage/columns
+	./validate_includes.py datasets/contract_commitment
+	./validate_includes.py datasets/contract_commitment/columns
+	./validate_includes.py datasets/invoice_detail
+	./validate_includes.py datasets/invoice_detail/columns
 	./validate_includes.py attributes
 	./validate_includes.py metadata
 	./validate_includes.py metadata/data_generator

--- a/specification/datasets/data_model.md
+++ b/specification/datasets/data_model.md
@@ -1,3 +1,3 @@
-This document is where we declare the overall data model of the various tables in FOCUS.
+# Datasets
 
-It provides a high-level overview of the data model, including the relationships between different tables and the key attributes of each table.
+FOCUS defines many individual datasets made up of a selected set of columns which abide by the attributes outlined in this FOCUS Specification.

--- a/specification/datasets/datasets.mdpp
+++ b/specification/datasets/datasets.mdpp
@@ -1,6 +1,3 @@
-# Datasets
-
-FOCUS defines many individual datasets made up of a selected set of columns which abide by the attributes outlined in this FOCUS Specification.
-
+!INCLUDE "data_model.md",0
 !INCLUDE "cost_and_usage/cost_and_usage.mdpp",1
 !INCLUDE "contract_commitment/contract_commitment.mdpp",1


### PR DESCRIPTION
This PR adds entries for missing subfolders to the Makefile for validation.  It also revises the data_model.md, which was sitting out there but wasn't being used.  (This was an error that wasn't being caught because the Makefile wasn't checking that folder.)