### PR TITLE
AI #1906: Hotfixes to Requirements Model 1.2

### DIFF
--- a/specification/requirements_model/releases/1.2/model_details.json
+++ b/specification/requirements_model/releases/1.2/model_details.json
@@ -1,6 +1,6 @@
 {
   "Details": {
-    "ModelVersion": "1.2",
+    "ModelVersion": "1.2.0.1",
     "FOCUSVersion": "1.2"
   }
 }

--- a/specification/requirements_model/releases/1.2/model_rules/columns/commitmentdiscountstatus.json
+++ b/specification/requirements_model/releases/1.2/model_rules/columns/commitmentdiscountstatus.json
@@ -104,7 +104,7 @@
       "MustSatisfy": "CommitmentDiscountStatus MUST be null when CommitmentDiscountId is null.",
       "Keyword": "MUST",
       "Requirement": {
-        "CheckFunction": "CheckNotValue",
+        "CheckFunction": "CheckValue",
         "ColumnName": "CommitmentDiscountStatus",
         "Value": null
       },

--- a/specification/requirements_model/releases/1.2/model_rules/columns/resourcetype.json
+++ b/specification/requirements_model/releases/1.2/model_rules/columns/resourcetype.json
@@ -158,7 +158,7 @@
       },
       "Condition": {
         "CheckFunction": "CheckNotValue",
-        "CheckCondition": "ResourceId",
+        "ColumnName": "ResourceId",
         "Value": null
       },
       "Dependencies": [


### PR DESCRIPTION
Corrections that have been identified in the 1.2.0 version of the Requirements Model. 
TF-RM discussed the versioning approach and has decided its better to use a slightly unorthodox 4 decimal model so 1.2.0.1 as if FOCUS releases a 1.2.1 version of the spec the Model version will end up in conflict. So 1.2.0.1 is what this PR implements. 
Signed-off-by: Mike Fuller <mike@finops.org>