### PR TITLE
AI #1917: Enhance draft pull request guidelines and comms

### DIFF
--- a/guidelines/development-processes.md
+++ b/guidelines/development-processes.md
@@ -270,7 +270,7 @@ Draft status signals that the author is still actively working on the pull reque
 
 While draft status generally discourages async feedback, authors MAY explicitly invite feedback on specific aspects of a draft PR:
 
-1. **Whitelist/Blacklist Approach:** Authors can leave PR comments indicating which sections are ready for feedback (whitelist) or which sections are not ready (blacklist):
+1. **Allowlist/Denylist Approach:** Authors can leave PR comments indicating which sections are ready for feedback (allowlist) or which sections are not ready (denylist):
    - **More draft than open:** Keep as draft and comment on specific sections ready for feedback
    - **More open than draft:** Mark as open and comment on specific sections not ready for feedback
 

--- a/guidelines/development-processes.md
+++ b/guidelines/development-processes.md
@@ -260,7 +260,30 @@ All Pull Requests must be linked to a parent Issue which tracks the work and the
 
 When a pull request is first opened and still being edited and contributed to by Task Force members, it should be configured to [draft mode](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request), as this signals to other members of the project that the PR is not ready for full review and should be treated as a work in progress. As a PR becomes ready for review, it should be marked as such in GitHub. If after further review and comments it becomes clear that more work is needed, the Pull Request should be moved back to draft mode, enabling the open PRs to be sorted and reviewed.
 
-Draft status signals that the author is still working on the pull request and would prefer direct conversations on your feedback vs asynchronous review/comments. Adding comments to a draft pull request can be disruptive as the author is forced to stop and respond to your comment vs work on getting the PR completed. It would be best to talk directly with the author and especially important that you involve the author if you are having conversations about the pull request with others. Once a PR comes out of draft status, there will be plenty of time for async feedback.
+#### Understanding Draft Status
+
+Draft status signals that the author is still actively working on the pull request and would generally prefer direct conversations about their work-in-progress rather than asynchronous review comments. Adding comments to a draft pull request can be disruptive as the author is forced to stop and respond to your comment vs work on getting the PR completed. It would be best to talk directly with the author and especially important that you involve the author if you are having conversations about the pull request with others.
+
+**For external reviewers and async collaborators:** Draft status means "not ready yet, but will be soon." Once a PR comes out of draft status, there will be plenty of time for async feedback.
+
+#### When Draft PRs May Welcome Feedback
+
+While draft status generally discourages async feedback, authors MAY explicitly invite feedback on specific aspects of a draft PR:
+
+1. **Whitelist/Blacklist Approach:** Authors can leave PR comments indicating which sections are ready for feedback (whitelist) or which sections are not ready (blacklist):
+   - **More draft than open:** Keep as draft and comment on specific sections ready for feedback
+   - **More open than draft:** Mark as open and comment on specific sections not ready for feedback
+
+2. **Assignment as Signal:** Authors MAY assign specific reviewers to a draft PR to explicitly request their feedback, even while the PR remains in draft status.
+
+3. **Task Force Collaboration:** Within a Task Force working on complex topics, members may collaborate more actively on draft PRs when the author has communicated (in TF meetings, Slack, or PR comments) that feedback is welcome on specific aspects.
+
+#### Feedback Expectations
+
+- **Draft PRs:** Reviewers should not expect immediate responses to feedback. Authors may defer addressing comments until the PR moves to open status.
+- **Open PRs:** Authors are expected to be responsive to reviewer feedback in a timely manner.
+
+When in doubt, respect the draft status and wait for the author to mark the PR as ready for review, or communicate directly with the author to ask if feedback would be helpful.
 
 
 ### Reviewing

--- a/guidelines/development-processes.md
+++ b/guidelines/development-processes.md
@@ -280,7 +280,7 @@ While draft status generally discourages async feedback, authors MAY explicitly 
 
 #### Feedback Expectations
 
-- **Draft PRs:** Reviewers should not expect immediate responses to feedback. Authors may defer addressing comments until the PR moves to open status.
+- **Draft PRs:** Reviewers should not expect immediate responses to feedback. Authors may defer and/or resolve comments until the PR moves to open status.
 - **Open PRs:** Authors are expected to be responsive to reviewer feedback in a timely manner.
 
 When in doubt, respect the draft status and wait for the author to mark the PR as ready for review, or communicate directly with the author to ask if feedback would be helpful.

--- a/guidelines/development-processes.md
+++ b/guidelines/development-processes.md
@@ -262,9 +262,9 @@ When a pull request is first opened and still being edited and contributed to by
 
 #### Understanding Draft Status
 
-Draft status signals that the author is still actively working on the pull request and would generally prefer direct conversations about their work-in-progress rather than asynchronous review comments. Adding comments to a draft pull request can be disruptive as the author is forced to stop and respond to your comment vs work on getting the PR completed. It would be best to talk directly with the author and especially important that you involve the author if you are having conversations about the pull request with others.
+Draft status signals that the author is still actively working on the pull request. Early feedback is welcome in open-source development, but reviewers should understand that the author may not respond immediately while the work is still in progress. Adding comments to a draft pull request can create a context-switching cost as the author is pulled between responding and completing the draft. It would be best to talk directly with the author and especially important that you involve the author if you are having conversations about the pull request with others.
 
-**For external reviewers and async collaborators:** Draft status means "not ready yet, but will be soon." Once a PR comes out of draft status, there will be plenty of time for async feedback.
+**For external reviewers and async collaborators:** Draft status means the work is still evolving. Authors may prioritize completing the draft before engaging asynchronously, but there will be plenty of time for async feedback once the PR moves to open status.
 
 #### When Draft PRs May Welcome Feedback
 
@@ -280,10 +280,10 @@ While draft status generally discourages async feedback, authors MAY explicitly 
 
 #### Feedback Expectations
 
-- **Draft PRs:** Reviewers should not expect immediate responses to feedback. Authors may defer and/or resolve comments until the PR moves to open status.
+- **Draft PRs:** Reviewers may provide feedback at any time. Authors may defer and/or resolve comments until the PR moves to open status.
 - **Open PRs:** Authors are expected to be responsive to reviewer feedback in a timely manner.
 
-When in doubt, respect the draft status and wait for the author to mark the PR as ready for review, or communicate directly with the author to ask if feedback would be helpful.
+When in doubt, respect the draft status as a signal that the author may still be iterating, and communicate directly with the author to ask if feedback would be helpful.
 
 
 ### Reviewing


### PR DESCRIPTION
## Summary
Updates the draft PR policy in the Development Processes guidelines to clarify when draft PRs may welcome feedback, particularly for Task Force collaboration on complex topics.

## Changes
### Updated guidelines/development-processes.md:

- Restructured "Drafting" section with clearer subsections
- Added "Understanding Draft Status" to preserve core intent (don't disrupt the author's work)
- Added "When Draft PRs May Welcome Feedback" with three mechanisms:
- Whitelist/Blacklist Approach - Authors can comment on which sections are/aren't ready
- Assignment as Signal - Explicitly assigning reviewers requests feedback
- Task Force Collaboration - TF members can collaborate when the author communicates readiness
- Added "Feedback Expectations" to clarify response timing (draft vs. open)

## Rationale
Current policy felt too rigid for Task Force collaboration on complex topics. This update:

- Preserves the core intent: don't disrupt authors with unwanted feedback
- Adds flexibility for author-requested feedback via concrete mechanisms
- Maintains async feedback support for external/non-TF reviewers
- Uses softer language ("generally prefer", "MAY") to provide guidance, not rigid policy

## Feedback Incorporated
### Maintainers meeting (2026-02-02):
- @shawnalpay: Need concrete proposal with whitelist/blacklist approach
- @ijurica: Assignment can signal feedback wanted
- @kk09v: Current text has soft language indicating intention/guidance
- @Matt-Cowsert: Different expectations for draft vs. open (response timing)
- @udam-stitcher: Open source spirit - feedback will be welcomed, not blocked

### Written feedback from @shawnalpay:
- Proposed whitelist/blacklist concrete examples (PR #1924 draft, PR #1900 open)
- Emphasized async feedback support requirement for non-TF members