### PR TITLE
AI #1985: Restructure the JSON Object normative text to be more inline with Requirements Modelling - Option 1

### DIFF
--- a/specification/appendix/appendix.mdpp
+++ b/specification/appendix/appendix.mdpp
@@ -1,4 +1,6 @@
 !INCLUDE "appendix_overview.md",0
+!INCLUDE "examples/allocated_method_details_examples/allocated_method_details_examples.md",1
+!INCLUDE "examples/contract_applied_examples/contract_applied_examples.md",1
 !INCLUDE "commitment_discounts/commitment_discounts.mdpp",1
 !INCLUDE "examples/commitment_discount_flexibility_examples/commitment_discount_flexibility_examples.mdpp",1
 !INCLUDE "metadata_examples/metadata_examples.mdpp",1

--- a/specification/appendix/examples/allocated_method_details_examples/allocated_method_details_examples.md
+++ b/specification/appendix/examples/allocated_method_details_examples/allocated_method_details_examples.md
@@ -1,0 +1,71 @@
+# Examples: Allocated Method Details
+
+The JSON samples in the scenarios below each represent a single allocated record out of the multiple records derived from an origin record for that scenario. The sum AllocatedRatio will add up to 1 (100%) across all allocated records for an origin record, with the AllocatedRatio (or sum of AllocatedRatio) representing the allocated record's portion of the overall origin record.
+
+## Scenario 1: Single UsageUnit value used for allocation
+
+When only a single "UsageUnit" is used to calculate the allocation.
+
+```json
+{
+  "Elements" : [ {
+    "AllocatedRatio" : 0.1,
+    "UsageUnit" : "Hours",
+    "UsageQuantity" : 300
+    }
+  ]
+}
+```
+
+## Scenario 2: Multiple UsageUnit values used for allocation
+
+When multiple "UsageUnit" values are used to calculate the allocation, another object is added to the "Elements" collection.
+
+```json
+{
+  "Elements": [
+    {
+      "AllocatedRatio": 0.05,
+      "UsageUnit": "CPU",
+      "UsageQuantity": 0.5
+    },
+    {
+      "AllocatedRatio": 0.1,
+      "UsageUnit": "Memory",
+      "UsageQuantity": 4
+    }
+  ]
+}
+```
+
+## Scenario 3: Data generator omits keys that are not required
+
+This data generator does not wish to supply the "UsageUnit" or "UsageQuantity" keys but still provides cost allocation with some additional allocation method details. In this case, "UsageUnit" and "UsageQuantity" are omitted, and only the "AllocatedRatio" is supplied.
+
+```json
+{
+  "Elements" : [ {
+    "AllocatedRatio" : 0.45
+    }
+  ]
+}
+```
+
+## Scenario 4: Additional non-FOCUS specified properties
+
+A data generator can add additional properties if they feel more context is helpful or necessary to the practitioner. In this scenario, the data generator is supplying additional context that shows only 0.5 of a unit was used. However, since 1 unit was requested by the service this allocation represents, the allocation is being charged at 1 regardless.
+
+```json
+{
+  "Elements": [
+    {
+      "AllocatedRatio": 0.6,
+      "UsageUnit": "vCPU",
+      "UsageQuantity": 1,
+      "x_ReservedVCPU": 1,
+      "x_UsedVCPU": 0.5,
+      "x_AllocatedVCPU": 1
+    }
+  ]
+}
+```

--- a/specification/appendix/examples/contract_applied_examples/contract_applied_examples.md
+++ b/specification/appendix/examples/contract_applied_examples/contract_applied_examples.md
@@ -1,0 +1,102 @@
+# Examples: Contract Applied
+
+## Scenario 1: Initial contract commitment
+
+A single Cost and Usage charge represents the values stated on a contract and its three contract commitments agreed between a service provider and a customer:
+
+1) 12345: Spend $500k overall.  (This is the value of the contract, and thus ContractID = ContractCommitmentID.)
+2) 23456: Spend $25k on a particular service.
+3) 34567: Consume 100k compute hours on a particular resource type.
+
+The Charge Category is denoted as Purchase, and the Contract ID, Resource ID, and Contract Commitment ID are all denoted as 12345.
+
+```json
+{
+  "ResourceID": "12345",
+  "ChargeCategory": "Purchase",
+  "BilledCost": 500000.00,
+  "EffectiveCost": 0.00,
+  "ContractApplied":
+    {
+      "Elements": [ {
+        "ContractID": "12345",
+        "ContractCommitmentID": "12345",
+        "ContractCommitmentAppliedCost": 500000.00
+      }, {
+        "ContractID": "12345",
+        "ContractCommitmentID": "23456",
+        "ContractCommitmentAppliedCost": 25000.00
+      }, {
+        "ContractID": "12345",
+        "ContractCommitmentID": "34567",
+        "ContractCommitmentAppliedQuantity": 100000.00,
+        "ContractCommitmentAppliedUnit": "compute_hours"
+      } ]
+    }
+```
+
+## Scenario 2: Contract commitment usage with no custom columns
+
+Assume the contract commitment as described in Scenario 1.  Assume that only 50% of cost and usage gets applied to the contract commitments, per the contract terms.
+
+A single Cost and Usage charge for `myResource1` carries Effective Cost of 30 (denominated in USD) and Consumed Quantity of 1 (denominated in compute hours).  The Charge Category is denoted as Usage.
+
+This applies to the contract commitments in the following manner:
+
+```json
+{
+  "ResourceID": "myResource1",
+  "ChargeCategory": "Usage",
+  "BilledCost": 0.00,
+  "EffectiveCost": 30.00,
+  "ConsumedQuantity": 1,
+  "ContractApplied":
+    {
+      "Elements": [ {
+        "ContractID": "12345",
+        "ContractCommitmentID": "12345",
+        "ContractCommitmentAppliedCost": 15.00
+      }, {
+        "ContractID": "12345",
+        "ContractCommitmentID": "23456",
+        "ContractCommitmentAppliedCost": 15.00
+      }, {
+        "ContractID": "12345",
+        "ContractCommitmentID": "34567",
+        "ContractCommitmentAppliedQuantity": 0.50,
+        "ContractCommitmentAppliedUnit": "compute_hours"
+      } ]
+    }
+```
+
+## Scenario 3: Contract commitment usage with custom columns
+
+The same as Scenario 2, except a custom key-value pair `x_ContractCommitmentCostBalance` is provided by the data generator.   This datapoint represents the value remaining on a given contract commitment.
+
+```json
+{
+  "ResourceID": "myResource1",
+  "ChargeCategory": "Usage",
+  "BilledCost": 0.00,
+  "EffectiveCost": 30.00,
+  "ConsumedQuantity": 1,
+  "ContractApplied":
+    {
+      "Elements": [ {
+        "ContractID": "12345",
+        "ContractCommitmentID": "12345",
+        "ContractCommitmentAppliedCost": 15.00,
+        "x_ContractCommitmentCostBalance": 499985.00
+      }, {
+        "ContractID": "12345",
+        "ContractCommitmentID": "23456",
+        "ContractCommitmentAppliedCost": 15.00,
+        "x_ContractCommitmentCostBalance": 24985.00
+      }, {
+        "ContractID": "12345",
+        "ContractCommitmentID": "34567",
+        "ContractCommitmentAppliedQuantity": 0.50,
+        "ContractCommitmentAppliedUnit": "compute_hours"
+      } ]
+    }
+```

--- a/specification/datasets/contract_commitment/columns/columns.mdpp
+++ b/specification/datasets/contract_commitment/columns/columns.mdpp
@@ -3,6 +3,7 @@
 !INCLUDE "contractcommitmentid.md",1
 !INCLUDE "contractcommitmentcategory.md",1
 !INCLUDE "contractcommitmentdescription.md",1
+!INCLUDE "contractcommitmenteligibility.md",1
 !INCLUDE "contractcommitmentperiodend.md",1
 !INCLUDE "contractcommitmentperiodstart.md",1
 !INCLUDE "contractcommitmentquantity.md",1

--- a/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
@@ -1,0 +1,322 @@
+# Contract Commitment Eligibility
+
+Contract Commitment Eligibility is a structured definition of the specific entities to which a [*contract commitment*](#glossary:contract-commitment) applies, with both inclusionary and exclusionary logic, as well as the portion of cost or usage that is applicable.
+
+## Requirements
+
+ContractCommitmentEligibility adheres to the following requirements:
+
+* ContractCommitmentEligibility MUST be of type String.
+* ContractCommitmentEligibility MUST conform to [StringHandling](#attributes.stringhandling) requirements.
+* ContractCommitmentEligibility MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
+* ContractCommitmentEligibility MUST NOT be null.
+* ContractCommitmentEligibility MUST conform to [ContractCommitmentEligibilityObject](#datasets.costandusage.contractcommitmenteligibility.contractcommitmenteligibilityobject) requirements.
+
+## Contract Commitment Eligibility Object
+
+Contract Commitment Eligibility consists of a valid JSON object which contains a set of top-level property keys.  These keys define entity-based inclusionary and exclusionary logic, as well as the portion of relevant cost and/or usage that is applicable to the *contract commitment*.
+
+### Object Requirements
+
+The ContractCommitmentEligibilityObject adheres to the following requirements:
+
+TODO
+
+### Schema Structure
+
+ContractCommitmentEligibility contains a structured JSON object defining the logical boundaries and the applicability percentage of a commitment.
+
+#### Top-Level Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `IsGlobalScope` | Boolean | No | If `true`, the commitment applies to all resources. Defaults to `false`. |
+| `IsComplexScope` | Boolean | No | If `true`, indicates logic exceeds schema capabilities. Defaults to `false`. |
+| `Applicability` | Object | No | The fractional mapping for metrics. If omitted, both `Cost` and `Usage` keys default to `1.0`. |
+| `InclusionOperator` | String | Conditional | Required only if `IsGlobalScope` and `IsComplexScope` are both `false` or null. Valid values: `AND`, `OR`. |
+| `Inclusions` | Array | Conditional | Required only if `IsGlobalScope` and `IsComplexScope` are both `false` or null. List of `Rule` objects defining the boundary. |
+| `ExclusionOperator` | String | No | Defines the relationship for `Exclusions`. Valid values: `AND`, `OR`. Defaults to `OR`. |
+| `Exclusions` | Array | No | List of `Rule` objects defining entities to be removed from the boundary. |
+
+#### Rule Object
+
+Rules are evaluated against the column values of the resource being analyzed.
+
+| Key | Type | Description |
+| :--- | :--- | :--- |
+| `Dimension` | String | A valid FOCUS Column Name (e.g., `ProviderAccountId`, `RegionId`). |
+| `Operator` | String | The comparison logic to apply. Must be one of the Supported Operators. |
+| `Values` | Array | A list of strings to compare. A value of `["*"]` acts as a global wildcard. |
+| `Applicability` | Object | Optional. The specific fraction of applicability for resources matching this rule. Overrides the top-level `Applicability`. |
+
+#### Applicability Object
+
+To ensure schema stability and avoid polymorphic type-checking, `Applicability` MUST be an object. If a key is omitted, it is assumed to be `1.0`.
+
+| Key | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `Cost` | Decimal | 1.0 | Percentage applicable to `ContractCommitmentCost`. |
+| `Usage` | Decimal | 1.0 | Percentage applicable to `ContractCommitmentQuantity`. |
+
+#### Supported Operators
+
+| Operator | Logic | Usage Example |
+| :--- | :--- | :--- |
+| `In` | Exact match against any item in the list. | `["us-east-1", "us-west-2"]` |
+| `NotIn` | Does not match any item in the list. | `["123456789"]` |
+| `StartsWith` | String prefix match. | `["prod-"]` |
+| `NotStartsWith` | Does not begin with the specified prefix. | `["test-"]` |
+| `Contains` | Substring match anywhere in the value. | `["database"]` |
+| `NotContains` | Substring is not present in the value. | `["sandbox"]` |
+| `EndsWith` | String suffix match. | `["-temp"]` |
+| `Exists` | Checks if the dimension is present and not null. | `Values` can be `["*"]` |
+| `DoesNotExist` | Checks if the dimension is missing or null. | `Values` can be `["*"]` |
+
+#### Wildcard Handling
+
+ContractCommitmentEligibility uses a reserved string to represent global or unrestricted boundaries within a specific Dimension.
+
+| Reserved Value | Description | Supported Operators |
+| :--- | :--- | :--- |
+| `"*"` | Represents all possible values for the specified Dimension. | `In`, `Contains` |
+
+#### Wildcard Behavior Rules
+
+1. **Inclusion Logic:** When `["*"]` is used in an Inclusion rule, the rule evaluates to `True` for every resource, effectively making the commitment "Organization-wide" for that specific Dimension.
+2. **Exclusion Logic:** When `["*"]` is used in an Exclusion rule, the rule evaluates to `True` for every resource, effectively excluding all resources (this is typically used only in combination with `ExclusionOperator: "AND"` for surgical filtering).
+3. **Implicit Wildcards:** If a Dimension (e.g., `RegionId`) is omitted entirely from the `Inclusions` array, it is treated as an implicit wildcard (unrestricted) unless the `InclusionOperator` is set to `AND`.
+
+### Examples
+
+#### Global Scope and Applicability
+
+If the commitment is 100% applicable to all resources, the `Applicability` object can be omitted entirely.
+
+```json
+{
+  "IsGlobalScope": true
+}
+```
+
+#### Global Scope with Specific Exceptions
+
+Organization-wide coverage **except** for Database services running in BillingAccountId 123456789012.
+
+```json
+{
+  "IsGlobalScope": true,
+  "ExclusionOperator": "AND",
+  "Exclusions": [
+    {
+      "Dimension": "BillingAccountId",
+      "Operator": "In",
+      "Values": ["123456789012"]
+    },
+    {
+      "Dimension": "ServiceCategory",
+      "Operator": "In",
+      "Values": ["Database"]
+    }
+  ]
+}
+```
+
+#### Regional Scope
+
+A commitment purchased for a specific region (e.g., `us-east-1`). Since `IsGlobalScope` and `IsComplexScope` are omitted, they default to `false`, requiring the inclusion block.
+
+```json
+{
+  "InclusionOperator": "OR",
+  "Inclusions": [
+    {
+      "Dimension": "RegionId",
+      "Operator": "In",
+      "Values": ["us-east-1"]
+    }
+  ]
+}
+```
+
+#### Regional Compute Commitment with Exceptions
+
+Applies to Compute in `us-east-1` and `us-west-2`, excluding any resources or services tagged with an `Environment` of `Sandbox`.
+
+```json
+{
+  "InclusionOperator": "AND",
+  "Inclusions": [
+    {
+      "Dimension": "RegionId",
+      "Operator": "In",
+      "Values": ["us-east-1", "us-west-2"]
+    },
+    {
+      "Dimension": "ServiceCategory",
+      "Operator": "In",
+      "Values": ["Compute"]
+    }
+  ],
+  "ExclusionOperator": "OR",
+  "Exclusions": [
+    {
+      "Dimension": "Tags",
+      "Operator": "Contains",
+      "Values": ["\"Environment\": \"Sandbox\""]
+    }
+  ]
+}
+```
+
+#### Regional Applicability
+
+A commitment that applies fully to `us-east-1` but only 50% of cost and usage in `us-west-2` is eligible. Note the use of the object even for symmetrical applicability.
+
+```json
+{
+  "InclusionOperator": "OR",
+  "Inclusions": [
+    {
+      "Dimension": "RegionId",
+      "Operator": "In",
+      "Values": ["us-east-1"]
+    },
+    {
+      "Dimension": "RegionId",
+      "Operator": "In",
+      "Values": ["us-west-2"],
+      "Applicability": {
+        "Cost": 0.5,
+        "Usage": 0.5
+      }
+    }
+  ]
+}
+```
+
+#### Granular Applicability (Partial Object)
+
+A scenario where 100% of Marketplace **Usage** counts toward a volume commitment, but only 50% of the **Cost** is applicable for financial credit. The engine defaults the missing `Usage` key to `1.0`.
+
+```json
+{
+  "InclusionOperator": "OR",
+  "Inclusions": [
+    {
+      "Dimension": "InvoiceIssuerName",
+      "Operator": "In",
+      "Values": ["Cloud Marketplace"],
+      "Applicability": {
+        "Cost": 0.5
+      }
+    }
+  ]
+}
+```
+
+#### Complex Fallback
+
+A commitment with dynamic or conditional logic that requires calculation against the total aggregate of cost or usage.
+
+```json
+{
+  "IsComplexScope": true
+}
+```
+
+#### JTD Schema
+
+```json
+{
+  "definitions": {
+    "applicabilityObject": {
+      "optionalProperties": {
+        "Cost": { "type": "float64" },
+        "Usage": { "type": "float64" }
+      },
+      "additionalProperties": false
+    },
+    "eligibilityRule": {
+      "properties": {
+        "Dimension": { "type": "string" },
+        "Operator": { "type": "string" },
+        "Values": { "elements": { "type": "string" } }
+      },
+      "optionalProperties": {
+        "Applicability": { "ref": "applicabilityObject" }
+      }
+    }
+  },
+  "optionalProperties": {
+    "IsGlobalScope": { "type": "boolean" },
+    "IsComplexScope": { "type": "boolean" },
+    "Applicability": { "ref": "applicabilityObject" },
+    "InclusionOperator": { "enum": ["AND", "OR"] },
+    "Inclusions": { "elements": { "ref": "eligibilityRule" } },
+    "ExclusionOperator": { "enum": ["AND", "OR"] },
+    "Exclusions": { "elements": { "ref": "eligibilityRule" } }
+  }
+}
+```
+
+### Implementation Guidance
+
+#### Processing Workflow
+
+The evaluation of a resource against a commitment eligibility MUST follow a strict linear progression:
+
+1. **Normalization:** Convert the resource attribute and the Scope `Values` to a consistent case (default: lowercase) for comparison.
+2. **Inclusion Evaluation:** Iterate through `Inclusions`. If a match is found, record the rule-level `Applicability` if present. Apply `InclusionOperator`. If result is `False`, terminate.
+3. **Exclusion Evaluation:** Iterate through `Exclusions`. If `True`, terminate evaluation.
+4. **Applicability Resolution:**
+   * **Inheritance:** A matching rule's `Applicability` object takes precedence over the top-level object.
+   * **Defaulting:** If a metric key (`Cost` or `Usage`) is missing within a provided `Applicability` object, the engine MUST default that specific value to `1.0`.
+   * **Rule-level Priority:** Use the `Applicability` from the matching inclusion rule. If multiple rules match under `OR`, the engine MUST use the highest percentage for each respective metric.
+   * **Fallback:** Use the top-level `Applicability` if no rule-level value is provided.
+
+#### Integration with Commitment Logic
+
+The evaluation of **Applicability** percentages must be contextually aligned with the [Contract Commitment Model](#datasets.contractcommitment.contractcommitmentmodel) and [Contract Commitment Interval](#datasets.contractcommitment.contractcommitmentinterval):
+
+* **Continuous Models:** The `Applicability` percentages (Cost/Usage) MUST be applied to each discrete unit of activity within the **Interval** (e.g., every hour). If the commitment is not fully utilized by the applicable resources within that specific hour, the remaining capacity expires.
+* **Discontinuous Models:** The `Applicability` percentages determine the portion of aggregate activity that counts toward the commitment fulfillment over the entire **Interval** (e.g., the full year).
+
+#### Dependency Logic
+
+1. **Consistency:** Engines SHOULD expect an object and SHOULD NOT support scalar (Decimal/Float) values for this field to ensure compatibility with typed database schemas.
+2. **Conflict Resolution:** If `IsGlobalScope` is `true`, rule-level applicability in the `Inclusions` array is ignored in favor of the top-level `Applicability` attribute.
+
+### Object ID
+
+AllocatedMethodDetailsObject
+
+### Object Display Name
+
+Allocated Method Details Object
+
+## Column ID
+
+ContractCommitmentEligibility
+
+## Display Name
+
+Contract Commitment Eligibility
+
+## Description
+
+A structured definition of the specific entities to which a contract commitment applies, including inclusion/exclusion logic and applicability percentages.
+
+## Content Constraints
+
+| Constraint | Value |
+| :--- | :--- |
+| Dataset | [Contract Commitment](#datasets.contractcommitment) |
+| Column type | Dimension |
+| Feature level | Mandatory |
+| Allows nulls | False |
+| Data type | JSON |
+| Value format | [JSON Object Format](#attributes.jsonobjectformat) |
+
+## Introduced (version)
+
+1.4

--- a/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
@@ -4,29 +4,117 @@ Contract Commitment Eligibility is a structured definition of the specific entit
 
 ## Requirements
 
-ContractCommitmentEligibility adheres to the following requirements:
+### Column Requirements
+
+The ContractCommitmentEligibility column adheres to the following requirements:
 
 * ContractCommitmentEligibility MUST be of type String.
 * ContractCommitmentEligibility MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * ContractCommitmentEligibility MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
 * ContractCommitmentEligibility MUST NOT be null.
-* ContractCommitmentEligibility MUST conform to [ContractCommitmentEligibilityObject](#datasets.costandusage.contractcommitmenteligibility.contractcommitmenteligibilityobject) requirements.
+* ContractCommitmentEligibility MUST conform to [ContractCommitmentEligibilityObject](#datasets.contractcommitment.contractcommitmenteligibility.contractcommitmenteligibilityobject) requirements.
 
 ## Contract Commitment Eligibility Object
 
-Contract Commitment Eligibility consists of a valid JSON object which contains a set of top-level property keys.  These keys define entity-based inclusionary and exclusionary logic, as well as the portion of relevant cost and/or usage that is applicable to the *contract commitment*.
+Contract Commitment Eligibility consists of a valid JSON object which contains a set of top-level property keys. These keys define entity-based inclusionary and exclusionary logic, as well as the portion of relevant cost and/or usage that is applicable to the *contract commitment*.
+
+The following sub-sections detail the normative requirements for the overall Eligiblity Object and its children Applicability Object and Rule Object.  For a logical overview of the expected content for the Eligiblity Object, see the [Schema Structure](#datasets.contractcommitment.contractcommitmenteligibility.schemastructure) and [Examples](#datasets.contractcommitment.contractcommitmenteligibility.examples sections.
 
 ### Object Requirements
 
 The ContractCommitmentEligibilityObject adheres to the following requirements:
 
-TODO
+* ContractCommitmentEligibilityObject top-level property keys adhere to the following requirements:
+  * ContractCommitmentEligibilityObject MAY have a top-level property key "IsGlobalScope".
+  * ContractCommitmentEligibilityObject MAY have a top-level property key "IsComplexScope".
+  * ContractCommitmentEligibilityObject MAY have a top-level property key "Applicability".
+  * ContractCommitmentEligibilityObject MUST have a top-level property key "InclusionOperator" if ContractCommitmentEligibilityObject.IsGlobalScope and ContractCommitmentEligibilityObject.IsComplexScope are both `false` or null.
+  * ContractCommitmentEligibilityObject MUSt have a top-level property key "Inclusions" if ContractCommitmentEligibilityObject.IsGlobalScope and ContractCommitmentEligibilityObject.IsComplexScope are both `false` or null.
+  * ContractCommitmentEligibilityObject MAY have a top-level property key "ExclusionOperator".
+  * ContractCommitmentEligibilityObject MAY have a top-level property key "Exclusions".
+  * ContractCommitmentEligibilityObject MAY contain additional data generator-defined top-level property keys.
+  * ContractCommitmentEligibilityObject property keys MUST begin with the string "x_" unless it is a FOCUS-defined property key.
+* ContractCommitmentEligibilityObject.IsGlobalScope adheres to the following requirements:
+  * ContractCommitmentEligibilityObject.IsGlobalScope MUST be of type Boolean.
+  * ContractCommitmentEligibilityObject.IsGlobalScope MUST NOT be null.
+  * ContractCommitmentEligibilityObject.IsGlobalScope MUST be `true` if the *contract commitment* applies to all resources.
+* ContractCommitmentEligibilityObject.IsComplexScope adheres to the following requirements:
+  * ContractCommitmentEligibilityObject.IsComplexScope MUST be of type Boolean.
+  * ContractCommitmentEligibilityObject.IsComplexScope MUST NOT be null.
+  * ContractCommitmentEligibilityObject.IsComplexScope MUST be `true` if the *contract commitment's* eligibility logic exceeds schema capabilities.
+* ContractCommitmentEligibilityObject.Applicability adheres to the following requirements:
+  * ContractCommitmentEligibilityObject.Applicability MUST be of type JSON Object.
+  * ContractCommitmentEligibilityObject.Applicability MUST NOT be null.
+  * ContractCommitmentEligibilityObject.Applicability MUST conform to [ContractCommitmentEligibilityApplicabilityObject](#datasets.contractcommitment.contractcommitmenteligibility.contractcommitmenteligibilityapplicabilityobject) requirements.
+* ContractCommitmentEligibilityObject.InclusionOperator adheres to the following requirements:
+  * ContractCommitmentEligibilityObject.InclusionOperator MUST be of type String.
+  * ContractCommitmentEligibilityObject.InclusionOperator MUST NOT be null.
+  * ContractCommitmentEligibilityObject.InclusionOperator MUST be either "AND" or "OR".
+  * ContractCommitmentEligibilityObject.InclusionOperator MUST be present if ContractCommitmentEligibilityObject.Inclusions is present.
+* ContractCommitmentEligibilityObject.Inclusions adheres to the following requirements:
+  * ContractCommitmentEligibilityObject.Inclusions MUST be of type Array.
+  * ContractCommitmentEligibilityObject.Inclusions MUST NOT be null.
+  * ContractCommitmentEligibilityObject.Inclusions MUST NOT be present if ContractCommitmentEligibilityObject.IsGlobalScope is `true`.
+  * ContractCommitmentEligibilityObject.Inclusions[\*] MUST be of type JSON Object.
+  * ContractCommitmentEligibilityObject.Inclusions[\*] MUST conform to [ContractCommitmentEligibilityRuleObject](#datasets.contractcommitment.contractcommitmenteligibility.contractcommitmenteligibilityruleobject) requirements.
+* ContractCommitmentEligibilityObject.ExclusionOperator adheres to the following requirements:
+  * ContractCommitmentEligibilityObject.ExclusionOperator MUST be of type String.
+  * ContractCommitmentEligibilityObject.ExclusionOperator MUST NOT be null.
+  * ContractCommitmentEligibilityObject.ExclusionOperator MUST be either "AND" or "OR".
+* ContractCommitmentEligibilityObject.Exclusions adheres to the following requirements:
+  * ContractCommitmentEligibilityObject.Exclusions MUST be of type Array.
+  * ContractCommitmentEligibilityObject.Exclusions MUST NOT be null.
+  * ContractCommitmentEligibilityObject.Exclusions[\*] MUST be of type JSON Object.
+  * ContractCommitmentEligibilityObject.Exclusions[\*] MUST conform to [ContractCommitmentEligibilityRuleObject](#datasets.contractcommitment.contractcommitmenteligibility.contractcommitmenteligibilityruleobject) requirements.  
 
-### Schema Structure
+### Applicability Object Requirements
+
+The ContractCommitmentEligibilityApplicabilityObject adheres to the following requirements:
+
+* ContractCommitmentEligibilityApplicabilityObject property keys adhere to the following requirements:
+  * ContractCommitmentEligibilityApplicabilityObject MAY have a property key "Cost".
+  * ContractCommitmentEligibilityApplicabilityObject MAY have a property key "Usage".
+* ContractCommitmentEligibilityApplicabilityObject.Cost adheres to the following requirements:
+  * ContractCommitmentEligibilityApplicabilityObject.Cost MUST be of type Decimal.
+  * ContractCommitmentEligibilityApplicabilityObject.Cost MUST NOT be null.
+  * ContractCommitmentEligibilityApplicabilityObject.Cost MUST conform to [NumericFormat](#attributes.numericformat) requirements.
+  * ContractCommitmentEligibilityApplicabilityObject.Cost MUST represent the fraction of the charge's cost eligible for the commitment (0.0 to 1.0).
+* ContractCommitmentEligibilityApplicabilityObject.Usage adheres to the following requirements:
+  * ContractCommitmentEligibilityApplicabilityObject.Usage MUST be of type Decimal.
+  * ContractCommitmentEligibilityApplicabilityObject.Usage MUST NOT be null.
+  * ContractCommitmentEligibilityApplicabilityObject.Usage MUST conform to [NumericFormat](#attributes.numericformat) requirements.
+  * ContractCommitmentEligibilityApplicabilityObject.Usage MUST represent the fraction of the charge's usage quantity eligible for the commitment (0.0 to 1.0).
+
+### Rule Object Requirements
+
+The ContractCommitmentEligibilityRuleObject adheres to the following requirements:
+
+* ContractCommitmentEligibilityRuleObject property keys adhere to the following requirements:
+  * ContractCommitmentEligibilityRuleObject MUST have a property key "Dimension".
+  * ContractCommitmentEligibilityRuleObject MUST have a property key "Operator".
+  * ContractCommitmentEligibilityRuleObject MUST have a property key "Values".
+  * ContractCommitmentEligibilityRuleObject MAY have a property key "Applicability".
+* ContractCommitmentEligibilityRuleObject.Dimension adheres to the following requirements:
+  * ContractCommitmentEligibilityRuleObject.Dimension MUST be of type String.
+  * ContractCommitmentEligibilityRuleObject.Dimension MUST NOT be null.
+  * ContractCommitmentEligibilityRuleObject.Dimension SHOULD represent a column in the FOCUS [Cost and Usage dataset](#datasets.costandusage).
+* ContractCommitmentEligibilityRuleObject.Operator adheres to the following requirements:
+  * ContractCommitmentEligibilityRuleObject.Operator MUST be of type String.
+  * ContractCommitmentEligibilityRuleObject.Operator MUST NOT be null.
+  * ContractCommitmentEligibilityRuleObject.Operator MUST be one of the [Supported Operators](#datasets.contractcommitment.contractcommitmenteligibility.supported-operators).
+* ContractCommitmentEligibilityRuleObject.Values adheres to the following requirements:
+  * ContractCommitmentEligibilityRuleObject.Values MUST be of type Array.
+  * ContractCommitmentEligibilityRuleObject.Values MUST NOT be null.
+  * ContractCommitmentEligibilityRuleObject.Values[\*] MUST be of type String.
+* ContractCommitmentEligibilityRuleObject.Applicability adheres to the following requirements:
+  * ContractCommitmentEligibilityRuleObject.Applicability MUST be of type JSON Object.
+  * ContractCommitmentEligibilityRuleObject.Applicability MUST conform to [ContractCommitmentEligibilityApplicabilityObject](#datasets.contractcommitment.contractcommitmenteligibility.contractcommitmenteligibilityapplicabilityobject) requirements.
+
+## Schema Structure
 
 ContractCommitmentEligibility contains a structured JSON object defining the logical boundaries and the applicability percentage of a commitment.
 
-#### Top-Level Properties
+### Top-Level Properties
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
@@ -38,9 +126,7 @@ ContractCommitmentEligibility contains a structured JSON object defining the log
 | `ExclusionOperator` | String | No | Defines the relationship for `Exclusions`. Valid values: `AND`, `OR`. Defaults to `OR`. |
 | `Exclusions` | Array | No | List of `Rule` objects defining entities to be removed from the boundary. |
 
-#### Rule Object
-
-Rules are evaluated against the column values of the resource being analyzed.
+### Rule Object
 
 | Key | Type | Description |
 | :--- | :--- | :--- |
@@ -49,16 +135,14 @@ Rules are evaluated against the column values of the resource being analyzed.
 | `Values` | Array | A list of strings to compare. A value of `["*"]` acts as a global wildcard. |
 | `Applicability` | Object | Optional. The specific fraction of applicability for resources matching this rule. Overrides the top-level `Applicability`. |
 
-#### Applicability Object
-
-To ensure schema stability and avoid polymorphic type-checking, `Applicability` MUST be an object. If a key is omitted, it is assumed to be `1.0`.
+### Applicability Object
 
 | Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `Cost` | Decimal | 1.0 | Percentage applicable to `ContractCommitmentCost`. |
 | `Usage` | Decimal | 1.0 | Percentage applicable to `ContractCommitmentQuantity`. |
 
-#### Supported Operators
+### Supported Operators
 
 | Operator | Logic | Usage Example |
 | :--- | :--- | :--- |
@@ -72,7 +156,7 @@ To ensure schema stability and avoid polymorphic type-checking, `Applicability` 
 | `Exists` | Checks if the dimension is present and not null. | `Values` can be `["*"]` |
 | `DoesNotExist` | Checks if the dimension is missing or null. | `Values` can be `["*"]` |
 
-#### Wildcard Handling
+### Wildcard Handling
 
 ContractCommitmentEligibility uses a reserved string to represent global or unrestricted boundaries within a specific Dimension.
 
@@ -80,15 +164,15 @@ ContractCommitmentEligibility uses a reserved string to represent global or unre
 | :--- | :--- | :--- |
 | `"*"` | Represents all possible values for the specified Dimension. | `In`, `Contains` |
 
-#### Wildcard Behavior Rules
+### Wildcard Behavior Rules
 
 1. **Inclusion Logic:** When `["*"]` is used in an Inclusion rule, the rule evaluates to `True` for every resource, effectively making the commitment "Organization-wide" for that specific Dimension.
 2. **Exclusion Logic:** When `["*"]` is used in an Exclusion rule, the rule evaluates to `True` for every resource, effectively excluding all resources (this is typically used only in combination with `ExclusionOperator: "AND"` for surgical filtering).
 3. **Implicit Wildcards:** If a Dimension (e.g., `RegionId`) is omitted entirely from the `Inclusions` array, it is treated as an implicit wildcard (unrestricted) unless the `InclusionOperator` is set to `AND`.
 
-### Examples
+## Examples
 
-#### Global Scope and Applicability
+### Global Scope and Applicability
 
 If the commitment is 100% applicable to all resources, the `Applicability` object can be omitted entirely.
 
@@ -98,7 +182,7 @@ If the commitment is 100% applicable to all resources, the `Applicability` objec
 }
 ```
 
-#### Global Scope with Specific Exceptions
+### Global Scope with Specific Exceptions
 
 Organization-wide coverage **except** for Database services running in BillingAccountId 123456789012.
 
@@ -121,7 +205,7 @@ Organization-wide coverage **except** for Database services running in BillingAc
 }
 ```
 
-#### Regional Scope
+### Regional Scope
 
 A commitment purchased for a specific region (e.g., `us-east-1`). Since `IsGlobalScope` and `IsComplexScope` are omitted, they default to `false`, requiring the inclusion block.
 
@@ -138,7 +222,7 @@ A commitment purchased for a specific region (e.g., `us-east-1`). Since `IsGloba
 }
 ```
 
-#### Regional Compute Commitment with Exceptions
+### Regional Compute Commitment with Exceptions
 
 Applies to Compute in `us-east-1` and `us-west-2`, excluding any resources or services tagged with an `Environment` of `Sandbox`.
 
@@ -168,7 +252,7 @@ Applies to Compute in `us-east-1` and `us-west-2`, excluding any resources or se
 }
 ```
 
-#### Regional Applicability
+### Regional Applicability
 
 A commitment that applies fully to `us-east-1` but only 50% of cost and usage in `us-west-2` is eligible. Note the use of the object even for symmetrical applicability.
 
@@ -194,7 +278,7 @@ A commitment that applies fully to `us-east-1` but only 50% of cost and usage in
 }
 ```
 
-#### Granular Applicability (Partial Object)
+### Granular Applicability (Partial Object)
 
 A scenario where 100% of Marketplace **Usage** counts toward a volume commitment, but only 50% of the **Cost** is applicable for financial credit. The engine defaults the missing `Usage` key to `1.0`.
 
@@ -214,7 +298,7 @@ A scenario where 100% of Marketplace **Usage** counts toward a volume commitment
 }
 ```
 
-#### Complex Fallback
+### Complex Fallback
 
 A commitment with dynamic or conditional logic that requires calculation against the total aggregate of cost or usage.
 
@@ -224,7 +308,7 @@ A commitment with dynamic or conditional logic that requires calculation against
 }
 ```
 
-#### JTD Schema
+### JTD Schema
 
 ```json
 {
@@ -259,9 +343,9 @@ A commitment with dynamic or conditional logic that requires calculation against
 }
 ```
 
-### Implementation Guidance
+## Implementation Guidance
 
-#### Processing Workflow
+### Processing Workflow
 
 The evaluation of a resource against a commitment eligibility MUST follow a strict linear progression:
 
@@ -274,25 +358,25 @@ The evaluation of a resource against a commitment eligibility MUST follow a stri
    * **Rule-level Priority:** Use the `Applicability` from the matching inclusion rule. If multiple rules match under `OR`, the engine MUST use the highest percentage for each respective metric.
    * **Fallback:** Use the top-level `Applicability` if no rule-level value is provided.
 
-#### Integration with Commitment Logic
+### Integration with Commitment Logic
 
 The evaluation of **Applicability** percentages must be contextually aligned with the [Contract Commitment Model](#datasets.contractcommitment.contractcommitmentmodel) and [Contract Commitment Interval](#datasets.contractcommitment.contractcommitmentinterval):
 
 * **Continuous Models:** The `Applicability` percentages (Cost/Usage) MUST be applied to each discrete unit of activity within the **Interval** (e.g., every hour). If the commitment is not fully utilized by the applicable resources within that specific hour, the remaining capacity expires.
 * **Discontinuous Models:** The `Applicability` percentages determine the portion of aggregate activity that counts toward the commitment fulfillment over the entire **Interval** (e.g., the full year).
 
-#### Dependency Logic
+### Dependency Logic
 
 1. **Consistency:** Engines SHOULD expect an object and SHOULD NOT support scalar (Decimal/Float) values for this field to ensure compatibility with typed database schemas.
 2. **Conflict Resolution:** If `IsGlobalScope` is `true`, rule-level applicability in the `Inclusions` array is ignored in favor of the top-level `Applicability` attribute.
 
 ### Object ID
 
-AllocatedMethodDetailsObject
+ContractCommitmentEligibilityObject
 
 ### Object Display Name
 
-Allocated Method Details Object
+Contract Commitment Eligibility Object
 
 ## Column ID
 
@@ -316,6 +400,7 @@ A structured definition of the specific entities to which a contract commitment 
 | Allows nulls | False |
 | Data type | JSON |
 | Value format | [JSON Object Format](#attributes.jsonobjectformat) |
+| Object          | [ContractCommitmentEligibilityObject](#datasets.contractcommitment.contractcommitmenteligibility.contractcommitmenteligibilityobject)
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
@@ -66,14 +66,6 @@ The AllocatedMethodDetailsObject adheres to the following requirements:
     * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity MUST conform to [NumericFormat](#attributes.numericformat) requirements.
     * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity SHOULD capture the quantity or volume of the AllocatedMethodDetailsObject.Elements[\*].UsageUnit measured by the data generator that was used to determine the AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio value.
 
-### Object ID
-
-AllocatedMethodDetailsObject
-
-### Object Display Name
-
-Allocated Method Details Object
-
 ### Array of Objects
 
 The parent array is called `Elements` and contains one or more objects which communicate information about how an allocated record was calculated.
@@ -147,6 +139,14 @@ Usage Quantity communicates the volume that was consumed or used, denominated in
 ```
 
 NOTE: The above JSON Type Definition (JTD) is an approximation of the expected contents of this column, but it should not be considered normative because it cannot accurately describe the normative requirements (above) for AllocatedMethodDetails. Where there are discrepancies, deference will be given to the normative requirements. For example, [NumericFormat](#attributes.numericformat) allows for multiple numeric data types and precisions, but JTD requires both to be specified; other numeric data types and precisions allowable under NumericFormat are considered valid.
+
+### Object ID
+
+AllocatedMethodDetailsObject
+
+### Object Display Name
+
+Allocated Method Details Object
 
 ## Column ID
 

--- a/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
@@ -6,8 +6,6 @@ Allocated Method Details consists of a valid JSON object which contains an array
 
 ## Requirements
 
-### Column Requirements
-
 The AllocatedMethodDetails column adheres to the following requirements:
 
 * AllocatedMethodDetails MUST be of type String.
@@ -37,21 +35,18 @@ The AllocatedMethodDetailsObject adheres to the following requirements:
 * AllocatedMethodDetailsObject MUST have a top-level property key "Elements".
 * AllocatedMethodDetailsObject MAY contain additional data generator-defined top-level property keys, in addition to AllocatedMethodDetailsObject.Elements.
 * AllocatedMethodDetailsObject MUST have property keys that begin with the string "x_" unless it is the top-level property key "Elements".
-
 * AllocatedMethodDetailsObject.Elements MUST adhere to the following requirements:
   * AllocatedMethodDetailsObject.Elements MUST be of type Array.
   * AllocatedMethodDetailsObject.Elements[\*] MUST be of type JSON object.
   * AllocatedMethodDetailsObject.Elements[\*] MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
   * AllocatedMethodDetailsObject.Elements[\*] MAY contain data generator-defined allocation properties.
   * AllocatedMethodDetailsObject.Elements[\*] MUST have property keys that begin with the string "x_" unless it is a FOCUS-defined allocation property.
-  
   * The AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio property key adheres to the following requirements:
     * AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio MUST be present inside each AllocatedMethodDetailsObject.Elements object.
     * AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio MUST be of type Decimal.
     * AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio MUST conform to [NumericFormat](#attributes.numericformat) requirements.
     * AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio MUST represent the allocated charge's percentage of the origin charge.
     * Values for all AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio properties across all allocated charges related to a single origin charge MUST sum up to 1 (100%).
-  
   * The AllocatedMethodDetailsObject.Elements[\*].UsageUnit property key adheres to the following requirements:
     * AllocatedMethodDetailsObject.Elements[\*].UsageUnit MUST be present inside an AllocatedMethodDetailsObject.Elements object if AllocatedMethodDetailsObject.Elements[*].UsageQuantity allocation property is present in that AllocatedMethodDetailsObject.Elements object
     * AllocatedMethodDetailsObject.Elements[\*].UsageUnit MAY be present inside an AllocatedMethodDetailsObject.Elements object if AllocatedMethodDetailsObject.Elements[*].UsageQuantity allocation property is not present in that AllocatedMethodDetailsObject.Elements object
@@ -59,7 +54,6 @@ The AllocatedMethodDetailsObject adheres to the following requirements:
     * AllocatedMethodDetailsObject.Elements[\*].UsageUnit MUST conform to StringHandling requirements.
     * AllocatedMethodDetailsObject.Elements[\*].UsageUnit SHOULD conform to [UnitFormat](#attributes.unitformat) requirements.
     * AllocatedMethodDetailsObject.Elements[\*].UsageUnit MUST represent the unit or component of data generator's documented [AllocationMethod](#datasets.costandusage.allocatedmethodid) which was used to determine the AllocatedMethodDetailsObject.Elements[*].AllocatedRatio value.
-  
   * The AllocatedMethodDetailsObject.Elements[\*].UsageQuantity property key adheres to the following requirements:
     * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity MUST be present inside an AllocatedMethodDetailsObject.Elements object if AllocatedMethodDetailsObject.Elements[*].UsageUnit allocation property is present in that AllocatedMethodDetailsObject.Elements object
     * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity MUST be of type Decimal.
@@ -83,8 +77,6 @@ The `Elements` array contains one or more objects, each of which contains the fo
 | AllocatedRatio | Numeric | True | Percentage of overall cost derived from corresponding method and metric. |
 | UsageUnit | [String](#attributes.stringhandling) | Conditional | Unit being measured used to calculate allocation. |
 | UsageQuantity | Numeric | False | Volume of UsageUnit consumed or used. |
-
-### Descriptions
 
 The following property keys are used for allocation properties to facilitate querying data across allocations and across data generators. Focus-defined property keys will appear in the list below and data generator-defined property keys will be prefixed with "x_" to make them easy to identify as well as prevent collisions.
 

--- a/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
@@ -122,7 +122,7 @@ The `Elements` array contains one or more objects, each of which contains the fo
 | UsageUnit | [String](#attributes.stringhandling) | Conditional | Unit being measured used to calculate allocation. |
 | UsageQuantity | Numeric | False | Volume of UsageUnit consumed or used. |
 
-#### Descriptions
+### Descriptions
 
 The following property keys are used for allocation properties to facilitate querying data across allocations and across data generators. Focus-defined property keys will appear in the list below and data generator-defined property keys will be prefixed with "x_" to make them easy to identify as well as prevent collisions.
 

--- a/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
@@ -16,35 +16,7 @@ The AllocatedMethodDetails column adheres to the following requirements:
 * AllocatedMethodDetails nullability is defined as follows:
   * AllocatedMethodDetails MUST be null when a charge is not related to a data generator-calculated split cost allocation.
   * AllocatedMethodDetails SHOULD NOT be null when a charge is related to a data generator-calculated split cost allocation.
-* AllocatedMethodDetails MUST conform to [AllocatedMethodDetailsObject](#datasets.costandusage.allocatedmethoddetailsobject) requirements when AllocatedMethodDetails is not null.
-
-## Column ID
-
-AllocatedMethodDetails
-
-## Display Name
-
-Allocated Method Details
-
-## Description
-
-A set of properties describing how resources are allocated in data generator-defined split cost allocation.
-
-## Content Constraints
-
-| Constraint      | Value                                                |
-| :-------------- | :--------------------------------------------------- |
-| Dataset         | [Cost and Usage](#datasets.costandusage)             |
-| Column type     | Dimension                                            |
-| Feature level   | Recommended                                          |
-| Allows nulls    | True                                                 |
-| Data type       | JSON                                                 |
-| Value format    | [JSON Object Format](#attributes.jsonobjectformat)   |
-| Object          | [AllocatedMethodDetailsObject](#datasets.costandusage.allocatedmethoddetails.allocatedmethoddetailsobject)
-
-## Introduced (version)
-
-1.3
+* AllocatedMethodDetails MUST conform to [AllocatedMethodDetailsObject](#datasets.costandusage.allocatedmethoddetails.allocatedmethoddetailsobject) requirements when AllocatedMethodDetails is not null.
 
 ## Allocated Method Details Object
 
@@ -94,15 +66,13 @@ The AllocatedMethodDetailsObject adheres to the following requirements:
     * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity MUST conform to [NumericFormat](#attributes.numericformat) requirements.
     * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity SHOULD capture the quantity or volume of the AllocatedMethodDetailsObject.Elements[\*].UsageUnit measured by the data generator that was used to determine the AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio value.
 
-## Object ID
+### Object ID
 
 AllocatedMethodDetailsObject
 
-## Object Display Name
+### Object Display Name
 
 Allocated Method Details Object
-
-## Overview
 
 ### Array of Objects
 
@@ -138,7 +108,7 @@ Usage Unit communicates the aspect of the documented Allocation Method Id being 
 
 Usage Quantity communicates the volume that was consumed or used, denominated in the Usage Unit property value.
 
-### Example
+### Object Example
 
 ```json
 {
@@ -178,74 +148,30 @@ Usage Quantity communicates the volume that was consumed or used, denominated in
 
 NOTE: The above JSON Type Definition (JTD) is an approximation of the expected contents of this column, but it should not be considered normative because it cannot accurately describe the normative requirements (above) for AllocatedMethodDetails. Where there are discrepancies, deference will be given to the normative requirements. For example, [NumericFormat](#attributes.numericformat) allows for multiple numeric data types and precisions, but JTD requires both to be specified; other numeric data types and precisions allowable under NumericFormat are considered valid.
 
-## Example Scenarios
+## Column ID
 
-The JSON samples in the scenarios below each represent a single allocated record out of the multiple records derived from an origin record for that scenario. The sum AllocatedRatio will add up to 1 (100%) across all allocated records for an origin record, with the AllocatedRatio (or sum of AllocatedRatio) representing the allocated record's portion of the overall origin record.
+AllocatedMethodDetails
 
-### Scenario 1: Single "UsageUnit" value used for allocation
+## Display Name
 
-When only a single "UsageUnit" is used to calculate the allocation.
+Allocated Method Details
 
-```json
-{
-  "Elements" : [ {
-    "AllocatedRatio" : 0.1,
-    "UsageUnit" : "Hours",
-    "UsageQuantity" : 300
-    }
-  ]
-}
-```
+## Description
 
-### Scenario 2: Multiple "UsageUnit" values used for allocation
+A set of properties describing how resources are allocated in data generator-defined split cost allocation.
 
-When multiple "UsageUnit" values are used to calculate the allocation, another object is added to the "Elements" collection.
+## Content Constraints
 
-```json
-{
-  "Elements": [
-    {
-      "AllocatedRatio": 0.05,
-      "UsageUnit": "CPU",
-      "UsageQuantity": 0.5
-    },
-    {
-      "AllocatedRatio": 0.1,
-      "UsageUnit": "Memory",
-      "UsageQuantity": 4
-    }
-  ]
-}
-```
+| Constraint      | Value                                                |
+| :-------------- | :--------------------------------------------------- |
+| Dataset         | [Cost and Usage](#datasets.costandusage)             |
+| Column type     | Dimension                                            |
+| Feature level   | Recommended                                          |
+| Allows nulls    | True                                                 |
+| Data type       | JSON                                                 |
+| Value format    | [JSON Object Format](#attributes.jsonobjectformat)   |
+| Object          | [AllocatedMethodDetailsObject](#datasets.costandusage.allocatedmethoddetails.allocatedmethoddetailsobject)
 
-### Scenario 3: Data generator omits keys that are not required
+## Introduced (version)
 
-This data generator does not wish to supply the "UsageUnit" or "UsageQuantity" keys but still provides cost allocation with some additional allocation method details. In this case, "UsageUnit" and "UsageQuantity" are omitted, and only the "AllocatedRatio" is supplied.
-
-```json
-{
-  "Elements" : [ {
-    "AllocatedRatio" : 0.45
-    }
-  ]
-}
-```
-
-### Scenario 4: Additional non-FOCUS specified properties
-
-A data generator can add additional properties if they feel more context is helpful or necessary to the practitioner. In this scenario, the data generator is supplying additional context that shows only 0.5 of a unit was used. However, since 1 unit was requested by the service this allocation represents, the allocation is being charged at 1 regardless.
-
-```json
-{
-  "Elements": [
-    {
-      "AllocatedRatio": 0.6,
-      "UsageUnit": "vCPU",
-      "UsageQuantity": 1,
-      "x_ReservedVCPU": 1,
-      "x_UsedVCPU": 0.5,
-      "x_AllocatedVCPU": 1
-    }
-  ]
-}
-```
+1.3

--- a/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
@@ -2,15 +2,7 @@
 
 Allocated Method Details provides information about how resources are allocated when usage records are split to support cost allocation requirements.
 
-Allocated Method Details consists of a valid JSON object which contains an array consisting of key-value objects describing the one or more factors that determined the split cost allocation. Each object consists of FOCUS-defined keys but can be extended to provide additional details about the allocation.
-
-The FOCUS-defined properties are:
-
-* `Allocated Ratio`: The ratio of a [*charge*](#glossary:charge) that this allocation represents.
-* `Usage Unit`: Unit being measured used to calculate this allocation.
-* `Usage Quantity`: The quantity of units used denominated by the defined usage unit.
-
-In addition to these, a data generator may include one or more custom properties, also denoted as key-value pairs.
+Allocated Method Details consists of a valid JSON object which contains an array consisting of key-value objects describing the one or more factors that determined the split cost allocation. Each object consists of FOCUS-defined property keys but can be extended to provide additional details about the allocation.
 
 ## Requirements
 
@@ -24,57 +16,91 @@ The AllocatedMethodDetails column adheres to the following requirements:
 * AllocatedMethodDetails nullability is defined as follows:
   * AllocatedMethodDetails MUST be null when a charge is not related to a data generator-calculated split cost allocation.
   * AllocatedMethodDetails SHOULD NOT be null when a charge is related to a data generator-calculated split cost allocation.
+* AllocatedMethodDetails MUST conform to [AllocatedMethodDetailsObject](#datasets.costandusage.allocatedmethoddetailsobject) requirements when AllocatedMethodDetails is not null.
 
-### Object Schema Requirements
+## Column ID
 
-Allocated Method Details consists of a valid JSON object which contains an array of key-value objects describing the one or more factors (allocation properties) that determined the split cost allocation. Each object consists of FOCUS-defined keys but can be extended to provide additional details about the allocation.
+AllocatedMethodDetails
 
-When AllocatedMethodDetails is not null, the JsonObjectFormat for AllocatedMethodDetails adheres to the following requirements:
+## Display Name
 
-* AllocatedMethodDetails MUST have a top-level key "Elements" which contains an array.
-* Each item in "Elements" MUST be an object.
-  * Objects inside "Elements" MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
-    * FOCUS-defined allocation properties adhere to the following additional requirements:
-      * Allocation property key MUST match the spelling and casing specified for the FOCUS-defined property.
-      * Allocation property value MUST be of the type specified for that property.
-      * Allocation properties MUST adhere to additional normative requirements specific to that property.
-    * Data generator-defined allocation properties MAY be included in "Elements".
-      * Allocation property keys MUST begin with the string "x_" unless it is a FOCUS-defined allocation property.
-* AllocatedMethodDetails root object MAY contain additional data generator-defined items, in addition to "Elements".
+Allocated Method Details
 
-### Content Requirements
+## Description
 
-The following keys are used for allocation properties to facilitate querying data across allocations and across data generators. Focus-defined keys will appear in the list below and data generator-defined keys will be prefixed with "x_" to make them easy to identify as well as prevent collisions.
+A set of properties describing how resources are allocated in data generator-defined split cost allocation.
 
-<b>Allocated Ratio</b>
+## Content Constraints
 
-Allocated Ratio communicates the percentage of the [*Origin Charge*](#glossary:origin-charge) that this [*Allocated Charge*](#glossary:allocated-charge) derived from the corresponding [Allocated Method Id](#datasets.costandusage.allocatedmethodid) and Usage Unit property.
+| Constraint      | Value                                                |
+| :-------------- | :--------------------------------------------------- |
+| Dataset         | [Cost and Usage](#datasets.costandusage)             |
+| Column type     | Dimension                                            |
+| Feature level   | Recommended                                          |
+| Allows nulls    | True                                                 |
+| Data type       | JSON                                                 |
+| Value format    | [JSON Object Format](#attributes.jsonobjectformat)   |
+| Object          | [AllocatedMethodDetailsObject](#datasets.costandusage.allocatedmethoddetails.allocatedmethoddetailsobject)
 
-The "AllocatedRatio" property adheres to the following requirements:
+## Introduced (version)
 
-* "AllocatedRatio" MUST be included inside each "Elements" object.
-* Values for "AllocatedRatio" MUST be a decimal value compatible with [NumericFormat](#attributes.numericformat) representing the allocated charge's percentage of the origin charge.
-* Values for all "AllocatedRatio" properties across all allocated charges related to a single origin charge MUST sum up to 1 (100%).
+1.3
 
-<b>Usage Unit</b>
+## Allocated Method Details Object
 
-Usage Unit communicates the aspect of the documented Allocation Method Id being used to calculate the Allocated Ratio property and what is being measured by Usage Quantity property.
+Allocated Method Details consists of a valid JSON object with a top level key of Elements containing an Array of entry objects. Each entry object consists of FOCUS-defined property keys but can be extended to provide additional details about the allocation.
 
-The "UsageUnit" property adheres to the following requirements:
+The FOCUS-defined properties are:
 
-* "UsageUnit" MUST be included inside an "Elements" object if "UsageQuantity" allocation property is included in that "Elements" object, otherwise "UsageUnit" MAY be included in each "Elements" object.
-* Values for "UsageUnit" MUST capture the unit or component of data generator's documented [AllocationMethod](#datasets.costandusage.allocatedmethodid) that was used to determine the "AllocatedRatio" value.
-* Values for "UsageUnit" SHOULD conform to [UnitFormat](#attributes.unitformat) requirements.
+* `Allocated Ratio`: The ratio of a [*charge*](#glossary:charge) that this allocation represents.
+* `Usage Unit`: Unit being measured used to calculate this allocation.
+* `Usage Quantity`: The quantity of units used denominated by the defined usage unit.
 
-<b>Usage Quantity</b>
+In addition to these, a data generator may include one or more custom properties, also denoted as key-value pairs.
 
-Usage Quantity communicates the volume that was consumed or used, denominated in the Usage Unit property value.
+### Object Requirements
 
-The "UsageQuantity" property adheres to the following requirements:
+The AllocatedMethodDetailsObject adheres to the following requirements:
 
-* "UsageQuantity" MAY be included inside an "Elements" object when that "Elements" object contains a "UsageUnit" allocation property.
-* Values for "UsageQuantity" MUST be compatible with NumericFormat.
-* Values for "UsageQuantity" SHOULD capture the quantity or volume of the "UsageUnit" measured by the data generator that was used to determine the "AllocatedRatio" value.
+* AllocatedMethodDetailsObject MUST have a top-level property key "Elements".
+* AllocatedMethodDetailsObject MAY contain additional data generator-defined top-level property keys, in addition to AllocatedMethodDetailsObject.Elements.
+* AllocatedMethodDetailsObject MUST have property keys that begin with the string "x_" unless it is the top-level property key "Elements".
+
+* AllocatedMethodDetailsObject.Elements MUST adhere to the following requirements:
+  * AllocatedMethodDetailsObject.Elements MUST be of type Array.
+  * AllocatedMethodDetailsObject.Elements[\*] MUST be of type JSON object.
+  * AllocatedMethodDetailsObject.Elements[\*] MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
+  * AllocatedMethodDetailsObject.Elements[\*] MAY contain data generator-defined allocation properties.
+  * AllocatedMethodDetailsObject.Elements[\*] MUST have property keys that begin with the string "x_" unless it is a FOCUS-defined allocation property.
+  
+  * The AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio property key adheres to the following requirements:
+    * AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio MUST be present inside each AllocatedMethodDetailsObject.Elements object.
+    * AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio MUST be of type Decimal.
+    * AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio MUST conform to [NumericFormat](#attributes.numericformat) requirements.
+    * AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio MUST represent the allocated charge's percentage of the origin charge.
+    * Values for all AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio properties across all allocated charges related to a single origin charge MUST sum up to 1 (100%).
+  
+  * The AllocatedMethodDetailsObject.Elements[\*].UsageUnit property key adheres to the following requirements:
+    * AllocatedMethodDetailsObject.Elements[\*].UsageUnit MUST be present inside an AllocatedMethodDetailsObject.Elements object if AllocatedMethodDetailsObject.Elements[*].UsageQuantity allocation property is present in that AllocatedMethodDetailsObject.Elements object
+    * AllocatedMethodDetailsObject.Elements[\*].UsageUnit MAY be present inside an AllocatedMethodDetailsObject.Elements object if AllocatedMethodDetailsObject.Elements[*].UsageQuantity allocation property is not present in that AllocatedMethodDetailsObject.Elements object
+    * AllocatedMethodDetailsObject.Elements[\*].UsageUnit MUST be of type String.
+    * AllocatedMethodDetailsObject.Elements[\*].UsageUnit MUST conform to StringHandling requirements.
+    * AllocatedMethodDetailsObject.Elements[\*].UsageUnit SHOULD conform to [UnitFormat](#attributes.unitformat) requirements.
+    * AllocatedMethodDetailsObject.Elements[\*].UsageUnit MUST represent the unit or component of data generator's documented [AllocationMethod](#datasets.costandusage.allocatedmethodid) which was used to determine the AllocatedMethodDetailsObject.Elements[*].AllocatedRatio value.
+  
+  * The AllocatedMethodDetailsObject.Elements[\*].UsageQuantity property key adheres to the following requirements:
+    * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity MUST be present inside an AllocatedMethodDetailsObject.Elements object if AllocatedMethodDetailsObject.Elements[*].UsageUnit allocation property is present in that AllocatedMethodDetailsObject.Elements object
+    * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity MUST be of type Decimal.
+    * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity MUST conform to [NumericFormat](#attributes.numericformat) requirements.
+    * AllocatedMethodDetailsObject.Elements[\*].UsageQuantity SHOULD capture the quantity or volume of the AllocatedMethodDetailsObject.Elements[\*].UsageUnit measured by the data generator that was used to determine the AllocatedMethodDetailsObject.Elements[\*].AllocatedRatio value.
+
+## Object ID
+
+AllocatedMethodDetailsObject
+
+## Object Display Name
+
+Allocated Method Details Object
 
 ## Overview
 
@@ -95,6 +121,22 @@ The `Elements` array contains one or more objects, each of which contains the fo
 | AllocatedRatio | Numeric | True | Percentage of overall cost derived from corresponding method and metric. |
 | UsageUnit | [String](#attributes.stringhandling) | Conditional | Unit being measured used to calculate allocation. |
 | UsageQuantity | Numeric | False | Volume of UsageUnit consumed or used. |
+
+#### Descriptions
+
+The following property keys are used for allocation properties to facilitate querying data across allocations and across data generators. Focus-defined property keys will appear in the list below and data generator-defined property keys will be prefixed with "x_" to make them easy to identify as well as prevent collisions.
+
+<b>Allocated Ratio</b>
+
+Allocated Ratio communicates the percentage of the [*Origin Charge*](#glossary:origin-charge) that this [*Allocated Charge*](#glossary:allocated-charge) derived from the corresponding [Allocated Method Id](#datasets.costandusage.allocatedmethodid) and Usage Unit property.
+
+<b>Usage Unit</b>
+
+Usage Unit communicates the aspect of the documented Allocation Method Id being used to calculate the Allocated Ratio property and what is being measured by Usage Quantity property.
+
+<b>Usage Quantity</b>
+
+Usage Quantity communicates the volume that was consumed or used, denominated in the Usage Unit property value.
 
 ### Example
 
@@ -207,30 +249,3 @@ A data generator can add additional properties if they feel more context is help
   ]
 }
 ```
-
-## Column ID
-
-AllocatedMethodDetails
-
-## Display Name
-
-Allocated Method Details
-
-## Description
-
-A set of properties describing how resources are allocated in data generator-defined split cost allocation.
-
-## Content Constraints
-
-| Constraint      | Value                                                |
-| :-------------- | :--------------------------------------------------- |
-| Dataset         | [Cost and Usage](#datasets.costandusage)             |
-| Column type     | Dimension                                            |
-| Feature level   | Recommended                                          |
-| Allows nulls    | True                                                 |
-| Data type       | JSON                                                 |
-| Value format    | [JSON Object Format](#attributes.jsonobjectformat)   |
-
-## Introduced (version)
-
-1.3

--- a/specification/datasets/cost_and_usage/columns/contractapplied.md
+++ b/specification/datasets/cost_and_usage/columns/contractapplied.md
@@ -4,8 +4,6 @@ Contract Applied is a set of properties that associate a charge with one or more
 
 ## Requirements
 
-### Column Requirements
-
 The ContractApplied column adheres to the following requirements:
 
 * ContractApplied MUST be of type String.
@@ -44,7 +42,6 @@ The ContractAppliedObject adheres to the following requirements:
   * ContractAppliedObject.Elements[\*] MAY contain data generator-defined allocation properties.
   * ContractAppliedObject.Elements[\*] MUST have property keys that begin with the string "x_" unless it is a FOCUS-defined allocation property.
   * ContractAppliedObject.Elements[\*] MUST have custom key-value pairs documented by the data generator.
-
   * The ContractAppliedObject.Elements[\*].ContractId property key adheres to the following requirements:
     * ContractAppliedObject.Elements[\*].ContractId MUST be present inside each ContractAppliedObject.Elements object.
     * ContractAppliedObject.Elements[\*].ContractId MUST be of type String.
@@ -55,7 +52,6 @@ The ContractAppliedObject adheres to the following requirements:
     * When ContractAppliedObject.Elements[\*].ContractId is not null, ContractAppliedObject.Elements[\*].ContractId adheres to the following additional requirements:
       * ContractAppliedObject.Elements[\*].ContractId MUST be a unique identifier within the service provider.
       * ContractAppliedObject.Elements[\*].ContractId SHOULD be a fully-qualified identifier.
-
   * The ContractAppliedObject.Elements[\*].ContractCommitmentID property key adheres to the following requirements:
     * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be present inside each ContractAppliedObject.Elements object.
     * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be of type String.
@@ -69,7 +65,6 @@ The ContractAppliedObject adheres to the following requirements:
       * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST have one and only one parent ContractAppliedObject.Elements[\*].ContractID.
       * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be equal to ResourceID when ChargeCategory is "Purchase".
       * ContractAppliedObject.Elements[\*].ContractCommitmentID MAY be equal to ContractAppliedObject.Elements[\*].ContractID.
-
   * The ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost property key adheres to the following requirements:
     * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST be present inside each ContractAppliedObject.Elements object.
     * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST be of type Decimal.
@@ -79,7 +74,6 @@ The ContractAppliedObject adheres to the following requirements:
     * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost nullability is defined as follows:
       * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST NOT be null when ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity is null.
       * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MAY be null in all other cases.
-
   * The ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity property key adheres to the following requirements:
     * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST be present inside each ContractAppliedObject.Elements object.
     * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST be of type Decimal.
@@ -89,7 +83,6 @@ The ContractAppliedObject adheres to the following requirements:
     * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity nullability is defined as follows:
       * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST NOT be null when ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost is null.
       * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MAY be null in all other cases.
-
   * The ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit property key adheres to the following requirements:
     * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit MUST be present inside each ContractAppliedObject.Elements object.
     * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit MUST be of type String.
@@ -118,8 +111,6 @@ The `Elements` array contains one or more objects, each of which contains the fo
 | ContractCommitmentAppliedCost     | Dimension   | Conditional   | True         | Numeric   |
 | ContractCommitmentAppliedQuantity | Dimension   | Conditional   | True         | Numeric   |
 | ContractCommitmentAppliedUnit     | Dimension   | Conditional   | True         | String    |
-
-### Descriptions
 
 The following keys are used for contract application properties to facilitate querying data across allocations and across service providers. FOCUS-defined keys will appear in the list below, and custom keys will be prefixed with "x_" to make them easy to identify as well as prevent collisions.
 

--- a/specification/datasets/cost_and_usage/columns/contractapplied.md
+++ b/specification/datasets/cost_and_usage/columns/contractapplied.md
@@ -13,34 +13,7 @@ The ContractApplied column adheres to the following requirements:
 * ContractApplied MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
 * ContractApplied nullability is defined as follows:
   * ContractApplied MUST NOT be null when one or more *contract commitments* are applied to the *charge*.
-* ContractApplied MUST conform to [AllocatedMethodDetailsObject](#datasets.costandusage.contractappliedobject) requirements when ContractApplied is not null.
-
-## Column ID
-
-ContractApplied
-
-## Display Name
-
-Contract Applied
-
-## Description
-
-A set of properties that associate a charge with one or more [*contract commitments*](#glossary:contract-commitment).
-
-## Content Constraints
-
-| Constraint      | Value                                                |
-| :-------------- | :----------------------------------------------------|
-| Dataset         | [Cost and Usage](#datasets.costandusage)             |
-| Column type     | Dimension and Metric                                 |
-| Feature level   | Conditional                                          |
-| Allows nulls    | True                                                 |
-| Data type       | JSON                                                 |
-| Value format    | [JSON Object Format](#attributes.jsonobjectformat)   |
-
-## Introduced (version)
-
-1.3
+* ContractApplied MUST conform to [AllocatedMethodDetailsObject](#datasets.costandusage.contractapplied.contractappliedobject) requirements when ContractApplied is not null.
 
 ## Contract Applied Object
 
@@ -126,16 +99,6 @@ The ContractAppliedObject adheres to the following requirements:
       * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit MUST be null when ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity is null.
       * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit MUST NOT be null when ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity is not null.
 
-## Object ID
-
-ContractAppliedObject
-
-## Object Display Name
-
-Contract Applied Object
-
-## Overview
-
 ### Array of Objects
 
 The parent array is called `Elements` and contains one or more objects which communicate information about how an allocated record was calculated.
@@ -180,7 +143,7 @@ Contract Commitment Applied Quantity represents the quantity of the charge appli
 
 The Contract Commitment Applied Unit represents a service-provider-specified measurement unit for the usage declared in Contract Commitment Applied Quantity. Contract Commitment Applied Unit complements the Contract Commitment Applied Quantity metric.
 
-### Example
+### Object Example
 
 ```json
 {
@@ -223,105 +186,37 @@ The Contract Commitment Applied Unit represents a service-provider-specified mea
 
 NOTE: The above JSON Type Definition (JTD) is an approximation of the expected contents of this column, but it should not be considered normative because it cannot accurately describe the normative requirements (above) for ContractApplied. Where there are discrepancies, deference will be given to the normative requirements. For example, [NumericFormat](#attributes.numericformat) allows for multiple numeric data types and precisions, but JTD requires both to be specified; other numeric data types and precisions allowable under NumericFormat are considered valid.
 
-## Example Scenarios
+### Object ID
 
-### Scenario 1: Initial contract commitment
+ContractAppliedObject
 
-A single Cost and Usage charge represents the values stated on a contract and its three contract commitments agreed between a service provider and a customer:
+### Object Display Name
 
-1) 12345: Spend $500k overall.  (This is the value of the contract, and thus ContractID = ContractCommitmentID.)
-2) 23456: Spend $25k on a particular service.
-3) 34567: Consume 100k compute hours on a particular resource type.
+Contract Applied Object
 
-The Charge Category is denoted as Purchase, and the Contract ID, Resource ID, and Contract Commitment ID are all denoted as 12345.
+## Column ID
 
-```json
-{
-  "ResourceID": "12345",
-  "ChargeCategory": "Purchase",
-  "BilledCost": 500000.00,
-  "EffectiveCost": 0.00,
-  "ContractApplied":
-    {
-      "Elements": [ {
-        "ContractID": "12345",
-        "ContractCommitmentID": "12345",
-        "ContractCommitmentAppliedCost": 500000.00
-      }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "23456",
-        "ContractCommitmentAppliedCost": 25000.00
-      }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "34567",
-        "ContractCommitmentAppliedQuantity": 100000.00,
-        "ContractCommitmentAppliedUnit": "compute_hours"
-      } ]
-    }
-```
+ContractApplied
 
-### Scenario 2: Contract commitment usage with no custom columns
+## Display Name
 
-Assume the contract commitment as described in Scenario 1.  Assume that only 50% of cost and usage gets applied to the contract commitments, per the contract terms.
+Contract Applied
 
-A single Cost and Usage charge for `myResource1` carries Effective Cost of 30 (denominated in USD) and Consumed Quantity of 1 (denominated in compute hours).  The Charge Category is denoted as Usage.
+## Description
 
-This applies to the contract commitments in the following manner:
+A set of properties that associate a charge with one or more [*contract commitments*](#glossary:contract-commitment).
 
-```json
-{
-  "ResourceID": "myResource1",
-  "ChargeCategory": "Usage",
-  "BilledCost": 0.00,
-  "EffectiveCost": 30.00,
-  "ConsumedQuantity": 1,
-  "ContractApplied":
-    {
-      "Elements": [ {
-        "ContractID": "12345",
-        "ContractCommitmentID": "12345",
-        "ContractCommitmentAppliedCost": 15.00
-      }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "23456",
-        "ContractCommitmentAppliedCost": 15.00
-      }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "34567",
-        "ContractCommitmentAppliedQuantity": 0.50,
-        "ContractCommitmentAppliedUnit": "compute_hours"
-      } ]
-    }
-```
+## Content Constraints
 
-### Scenario 3: Contract commitment usage with custom columns
+| Constraint      | Value                                                |
+| :-------------- | :----------------------------------------------------|
+| Dataset         | [Cost and Usage](#datasets.costandusage)             |
+| Column type     | Dimension and Metric                                 |
+| Feature level   | Conditional                                          |
+| Allows nulls    | True                                                 |
+| Data type       | JSON                                                 |
+| Value format    | [JSON Object Format](#attributes.jsonobjectformat)   |
 
-The same as Scenario 2, except a custom key-value pair `x_ContractCommitmentCostBalance` is provided by the data generator.   This datapoint represents the value remaining on a given contract commitment.
+## Introduced (version)
 
-```json
-{
-  "ResourceID": "myResource1",
-  "ChargeCategory": "Usage",
-  "BilledCost": 0.00,
-  "EffectiveCost": 30.00,
-  "ConsumedQuantity": 1,
-  "ContractApplied":
-    {
-      "Elements": [ {
-        "ContractID": "12345",
-        "ContractCommitmentID": "12345",
-        "ContractCommitmentAppliedCost": 15.00,
-        "x_ContractCommitmentCostBalance": 499985.00
-      }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "23456",
-        "ContractCommitmentAppliedCost": 15.00,
-        "x_ContractCommitmentCostBalance": 24985.00
-      }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "34567",
-        "ContractCommitmentAppliedQuantity": 0.50,
-        "ContractCommitmentAppliedUnit": "compute_hours"
-      } ]
-    }
-```
+1.3

--- a/specification/datasets/cost_and_usage/columns/contractapplied.md
+++ b/specification/datasets/cost_and_usage/columns/contractapplied.md
@@ -134,9 +134,9 @@ ContractAppliedObject
 
 Contract Applied Object
 
-### Overview
+## Overview
 
-#### Array of Objects
+### Array of Objects
 
 The parent array is called `Elements` and contains one or more objects which communicate information about how an allocated record was calculated.
 
@@ -144,7 +144,7 @@ The parent array is called `Elements` and contains one or more objects which com
 | ----- | ---- | ---------- | ----------- |
 | Elements | Array | True | The parent array containing one or more objects which communicate information about how contract commitments were applied to the charge. |
 
-#### Object Entries
+### Object Entries
 
 The `Elements` array contains one or more objects, each of which contains the following entries:
 
@@ -186,11 +186,11 @@ The Contract Commitment Applied Unit represents a service-provider-specified mea
 {
   "Elements" : [ {
     "ContractID" : "12345",
-    ContractAppliedObject.Elements[\*].ContractCommitmentID : "23456",
+    "ContractCommitmentID" : "23456",
     "ContractCommitmentAppliedCost" : 500000.00
   }, {
     "ContractID" : "12345",
-    ContractAppliedObject.Elements[\*].ContractCommitmentID : "34567",
+    "ContractCommitmentID" : "34567",
     "ContractCommitmentAppliedQuantity" : 10000.00,
     "ContractCommitmentAppliedUnit" : "compute_hours"
   } ]
@@ -206,7 +206,7 @@ The Contract Commitment Applied Unit represents a service-provider-specified mea
       "elements": {
         "properties": {
           "ContractID": { "type": "string" },
-          ContractAppliedObject.Elements[\*].ContractCommitmentID: { "type": "string" }
+          "ContractCommitmentID": { "type": "string" }
         },
         "optionalProperties": {
           "ContractCommitmentAppliedCost": { "type": "float64" },
@@ -245,15 +245,15 @@ The Charge Category is denoted as Purchase, and the Contract ID, Resource ID, an
     {
       "Elements": [ {
         "ContractID": "12345",
-        ContractAppliedObject.Elements[\*].ContractCommitmentID: "12345",
+        "ContractCommitmentID": "12345",
         "ContractCommitmentAppliedCost": 500000.00
       }, {
         "ContractID": "12345",
-        ContractAppliedObject.Elements[\*].ContractCommitmentID: "23456",
+        "ContractCommitmentID": "23456",
         "ContractCommitmentAppliedCost": 25000.00
       }, {
         "ContractID": "12345",
-        ContractAppliedObject.Elements[\*].ContractCommitmentID: "34567",
+        "ContractCommitmentID": "34567",
         "ContractCommitmentAppliedQuantity": 100000.00,
         "ContractCommitmentAppliedUnit": "compute_hours"
       } ]
@@ -279,15 +279,15 @@ This applies to the contract commitments in the following manner:
     {
       "Elements": [ {
         "ContractID": "12345",
-        ContractAppliedObject.Elements[\*].ContractCommitmentID: "12345",
+        "ContractCommitmentID": "12345",
         "ContractCommitmentAppliedCost": 15.00
       }, {
         "ContractID": "12345",
-        ContractAppliedObject.Elements[\*].ContractCommitmentID: "23456",
+        "ContractCommitmentID": "23456",
         "ContractCommitmentAppliedCost": 15.00
       }, {
         "ContractID": "12345",
-        ContractAppliedObject.Elements[\*].ContractCommitmentID: "34567",
+        "ContractCommitmentID": "34567",
         "ContractCommitmentAppliedQuantity": 0.50,
         "ContractCommitmentAppliedUnit": "compute_hours"
       } ]
@@ -309,17 +309,17 @@ The same as Scenario 2, except a custom key-value pair `x_ContractCommitmentCost
     {
       "Elements": [ {
         "ContractID": "12345",
-        ContractAppliedObject.Elements[\*].ContractCommitmentID: "12345",
+        "ContractCommitmentID": "12345",
         "ContractCommitmentAppliedCost": 15.00,
         "x_ContractCommitmentCostBalance": 499985.00
       }, {
         "ContractID": "12345",
-        ContractAppliedObject.Elements[\*].ContractCommitmentID: "23456",
+        "ContractCommitmentID": "23456",
         "ContractCommitmentAppliedCost": 15.00,
         "x_ContractCommitmentCostBalance": 24985.00
       }, {
         "ContractID": "12345",
-        ContractAppliedObject.Elements[\*].ContractCommitmentID: "34567",
+        "ContractCommitmentID": "34567",
         "ContractCommitmentAppliedQuantity": 0.50,
         "ContractCommitmentAppliedUnit": "compute_hours"
       } ]

--- a/specification/datasets/cost_and_usage/columns/contractapplied.md
+++ b/specification/datasets/cost_and_usage/columns/contractapplied.md
@@ -2,6 +2,50 @@
 
 Contract Applied is a set of properties that associate a charge with one or more [*contract commitments*](#glossary:contract-commitment), denoted as key-value pairs in a JSON object.  Contract Applied allows the practitioner to track the progress of the commitments to which they have agreed with a service provider.
 
+## Requirements
+
+### Column Requirements
+
+The ContractApplied column adheres to the following requirements:
+
+* ContractApplied MUST be of type String.
+* ContractApplied MUST conform to [StringHandling](#attributes.stringhandling) requirements.
+* ContractApplied MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
+* ContractApplied nullability is defined as follows:
+  * ContractApplied MUST NOT be null when one or more *contract commitments* are applied to the *charge*.
+* ContractApplied MUST conform to [AllocatedMethodDetailsObject](#datasets.costandusage.contractappliedobject) requirements when ContractApplied is not null.
+
+## Column ID
+
+ContractApplied
+
+## Display Name
+
+Contract Applied
+
+## Description
+
+A set of properties that associate a charge with one or more [*contract commitments*](#glossary:contract-commitment).
+
+## Content Constraints
+
+| Constraint      | Value                                                |
+| :-------------- | :----------------------------------------------------|
+| Dataset         | [Cost and Usage](#datasets.costandusage)             |
+| Column type     | Dimension and Metric                                 |
+| Feature level   | Conditional                                          |
+| Allows nulls    | True                                                 |
+| Data type       | JSON                                                 |
+| Value format    | [JSON Object Format](#attributes.jsonobjectformat)   |
+
+## Introduced (version)
+
+1.3
+
+## Contract Applied Object
+
+Contract Applied Object consists of a valid JSON object which contains an array of key-value objects describing the one or more contract commitments applied to the charge. Each object consists of FOCUS-defined property keys but can be extended to provide additional details about the contract application.
+
 The FOCUS-defined properties are:
 
 * `Contract ID`: The unique identifier representing a single contract.
@@ -12,124 +56,87 @@ The FOCUS-defined properties are:
 
 In addition to these, a data generator may include one or more custom properties, also denoted as key-value pairs.
 
-## Requirements
+### Object Requirements
 
-### Column Requirements
+The ContractAppliedObject adheres to the following requirements:
 
-The ContractApplied column adheres to the following requirements:
+* ContractAppliedObject MUST have a top-level property key "Elements".
+* ContractAppliedObject MAY contain additional data generator-defined root object property keys, in addition to ContractAppliedObject.Elements.
+* ContractAppliedObject MUST have property keys that begin with the string "x_" unless it is the top-level property key "Elements".
+* ContractAppliedObject.Elements MUST adhere to the following requirements:
+  * ContractAppliedObject.Elements MUST be of type Array.
+  * ContractAppliedObject.Elements[\*] MUST be of type JSON object.
+  * ContractAppliedObject.Elements[\*] MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
+  * ContractAppliedObject.Elements[\*] MUST NOT have nested property key-value pairs.
+  * ContractAppliedObject.Elements[\*] MAY contain data generator-defined allocation properties.
+  * ContractAppliedObject.Elements[\*] MUST have property keys that begin with the string "x_" unless it is a FOCUS-defined allocation property.
+  * ContractAppliedObject.Elements[\*] MUST have custom key-value pairs documented by the data generator.
 
-* ContractApplied MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
-* ContractApplied MUST NOT be null when one or more *contract commitments* are applied to the *charge*.
+  * The ContractAppliedObject.Elements[\*].ContractId property key adheres to the following requirements:
+    * ContractAppliedObject.Elements[\*].ContractId MUST be present inside each ContractAppliedObject.Elements object.
+    * ContractAppliedObject.Elements[\*].ContractId MUST be of type String.
+    * ContractAppliedObject.Elements[\*].ContractId MUST conform to [StringHandling](#attributes.stringhandling) requirements.
+    * ContractAppliedObject.Elements[\*].ContractId nullability is defined as follows:
+      * ContractAppliedObject.Elements[\*].ContractId MUST be null when a [*charge*](#glossary:charge) is not related to a *contract commitment*.
+      * ContractAppliedObject.Elements[\*].ContractId MUST NOT be null when a *charge* is related to a *contract commitment*.
+    * When ContractAppliedObject.Elements[\*].ContractId is not null, ContractAppliedObject.Elements[\*].ContractId adheres to the following additional requirements:
+      * ContractAppliedObject.Elements[\*].ContractId MUST be a unique identifier within the service provider.
+      * ContractAppliedObject.Elements[\*].ContractId SHOULD be a fully-qualified identifier.
 
-### Object Schema Requirements
+  * The ContractAppliedObject.Elements[\*].ContractCommitmentID property key adheres to the following requirements:
+    * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be present inside each ContractAppliedObject.Elements object.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be of type String.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST conform to [StringHandling](#attributes.stringhandling) requirements.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentID nullability is defined as follows:
+      * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be null when a [*charge*](#glossary:charge) is not related to a *contract commitment*.
+      * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST NOT be null when a *charge* is related to a *contract commitment*.
+    * When ContractAppliedObject.Elements[\*].ContractCommitmentID is not null, ContractAppliedObject.Elements[\*].ContractCommitmentID adheres to the following additional requirements:
+      * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be a unique identifier within the service provider.
+      * ContractAppliedObject.Elements[\*].ContractCommitmentID SHOULD be a fully-qualified identifier.
+      * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST have one and only one parent ContractAppliedObject.Elements[\*].ContractID.
+      * ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be equal to ResourceID when ChargeCategory is "Purchase".
+      * ContractAppliedObject.Elements[\*].ContractCommitmentID MAY be equal to ContractAppliedObject.Elements[\*].ContractID.
 
-Contract Applied consists of a valid JSON object which contains an array of key-value objects describing the one or more contract commitments applied to the charge. Each object consists of FOCUS-defined keys but can be extended to provide additional details about the contract application.
+  * The ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost property key adheres to the following requirements:
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST be present inside each ContractAppliedObject.Elements object.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST be of type Decimal.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST be a valid decimal value.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST conform to [NumericFormat](#attributes.numericformat) requirements.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST be denominated in the BillingCurrency.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost nullability is defined as follows:
+      * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST NOT be null when ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity is null.
+      * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MAY be null in all other cases.
 
-* If ContractApplied is not null, ContractApplied adheres to the following requirements:
-  * ContractApplied MUST have a top-level key "Elements" which contains an array.
-  * ContractApplied root object MAY contain custom objects, in addition to "Elements".
-  * Each item in "Elements" MUST be an object.
-  * "Elements" objects MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
-  * "Elements" objects MUST contain key-value pairs (contract application properties).
-  * Contract application property keys SHOULD conform to [PascalCase](#glossary:pascalcase) format.
-  * "Elements" objects MUST contain four key-value pairs, representing "ContractCommitmentID", "ContractCommitmentAppliedCost", "ContractCommitmentAppliedQuantity", and "ContractCommitmentAppliedUnit".
-  * "Elements" objects MAY contain custom key-value pairs, representing additional datapoints provided by the data generator.
-  * When custom key-value pairs within "Elements" objects are present:
-    * Contract application property custom key-value pairs MUST be prefixed with a consistent `x_` prefix to identify them as external, custom columns and distinguish them from FOCUS columns to avoid conflicts in future releases.
-    * Contract application property custom key-value pairs MUST be documented by the data generator.
-    * Contract application property custom key-value pairs MUST NOT be nested.
-  * FOCUS-defined contract application properties adhere to the following additional requirements:
-    * Contract application property key MUST match the spelling and casing specified for the FOCUS-defined property.
-    * Contract application property value MUST be of the type specified for that property.
-    * Contract application property MUST adhere to additional normative requirements specific to that property.
-  * Contract application property keys MUST begin with the string "x_" unless it is a FOCUS-defined allocation property.
+  * The ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity property key adheres to the following requirements:
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST be present inside each ContractAppliedObject.Elements object.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST be of type Decimal.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST be a valid decimal value.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST conform to [NumericFormat](#attributes.numericformat) requirements.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST be denominated in the ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity nullability is defined as follows:
+      * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST NOT be null when ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost is null.
+      * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MAY be null in all other cases.
 
-### Content Requirements
+  * The ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit property key adheres to the following requirements:
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit MUST be present inside each ContractAppliedObject.Elements object.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit MUST be of type String.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit MUST conform to [StringHandling](#attributes.stringhandling) requirements.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit SHOULD conform to [UnitFormat](#attributes.unitformat) requirements.
+    * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit nullability is defined as follows:
+      * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit MUST be null when ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity is null.
+      * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit MUST NOT be null when ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity is not null.
 
-The following keys are used for contract application properties to facilitate querying data across allocations and across service providers. FOCUS-defined keys will appear in the list below, and custom keys will be prefixed with "x_" to make them easy to identify as well as prevent collisions.
+## Object ID
 
-<b>Contract ID</b>
+ContractAppliedObject
 
-Contract ID is a service-provider-assigned identifier for a contract describing the agreed terms between a service provider and a customer.  Contracts can include commitment to a certain amount of spend or usage over an agreed period of time.
+## Object Display Name
 
-The "ContractId" property adheres to the following requirements:
+Contract Applied Object
 
-* "ContractId" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider supports *contract commitments*.
-* "ContractId" MUST be of type String.
-* "ContractId" MUST conform to [StringHandling](#attributes.stringhandling) requirements.
-* "ContractId" nullability is defined as follows:
-  * "ContractId" MUST be null when a [*charge*](#glossary:charge) is not related to a *contract commitment*.
-  * "ContractId" MUST NOT be null when a *charge* is related to a *contract commitment*.
-* When "ContractId" is not null, "ContractId" adheres to the following additional requirements:
-  * "ContractId" MUST be a unique identifier within the service provider.
-  * "ContractId" SHOULD be a fully-qualified identifier.
+### Overview
 
-<b>Contract Commitment ID</b>
-
-A Contract Commitment ID is a service-provider-assigned identifier describing an agreement agreed between a service provider and a customer.  Contracts can include commitment to a certain amount of spend or usage over an agreed period of time.
-
-The "ContractCommitmentID" property adheres to the following requirements:
-
-* "ContractCommitmentID" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider supports *contract commitments*.
-* "ContractCommitmentID" MUST be of type String.
-* "ContractCommitmentID" MUST conform to [StringHandling](#attributes.stringhandling) requirements.
-* "ContractCommitmentID" nullability is defined as follows:
-  * "ContractCommitmentID" MUST be null when a [*charge*](#glossary:charge) is not related to a *contract commitment*.
-  * "ContractCommitmentID" MUST NOT be null when a *charge* is related to a *contract commitment*.
-* When "ContractCommitmentID" is not null, "ContractCommitmentID" adheres to the following additional requirements:
-  * "ContractCommitmentID" MUST be a unique identifier within the service provider.
-  * "ContractCommitmentID" SHOULD be a fully-qualified identifier.
-  * "ContractCommitmentID" MUST have one and only one parent "ContractID".
-  * "ContractCommitmentID" MUST be equal to ResourceID when ChargeCategory is "Purchase".
-  * "ContractCommitmentID" MAY be equal to "ContractID".
-
-<b>Contract Commitment Applied Cost</b>
-
-Contract Commitment Applied Cost represents the cost of the charge applied to the contract line item.  Contract Commitment Applied Cost is associated with the contract line item via Contract Commitment ID.  Contract Commitment Applied Cost is commonly used for monitoring the progress towards fulfilling contractual commitments that may facilitate discounts for [*resources*](#glossary:resource) or [*services*](#glossary:service) as agreed between a service provider and a customer.
-
-The "ContractCommitmentAppliedCost" property adheres to the following requirements:
-
-* "ContractCommitmentAppliedCost" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider associates the *charge's* value with one or more *contract commitments*.
-* "ContractCommitmentAppliedCost" MUST be of type Decimal.
-* "ContractCommitmentAppliedCost" MUST conform to [NumericFormat](#attributes.numericformat) requirements.
-* "ContractCommitmentAppliedCost" nullability is defined as follows:
-  * "ContractCommitmentAppliedCost" MUST NOT be null when "ContractCommitmentAppliedQuantity" is null.
-  * "ContractCommitmentAppliedCost" MAY be null in all other cases.
-* "ContractCommitmentAppliedCost" MUST be a valid decimal value.
-* "ContractCommitmentAppliedCost" MUST be denominated in the BillingCurrency.
-
-<b>Contract Commitment Applied Quantity</b>
-
-Contract Commitment Applied Quantity represents the quantity of the charge applied to the contract line item.  Contract Commitment Applied Quantity is associated with the contract line item via Contract Commitment ID.  Contract Commitment Applied Quantity is commonly used for monitoring the progress towards fulfilling contractual commitments that may facilitate discounts for [*resources*](#glossary:resource) or [*services*](#glossary:service) as agreed between a service provider and a customer.
-
-The "ContractCommitmentAppliedQuantity" property adheres to the following requirements:
-
-* "ContractCommitmentAppliedQuantity" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider associates the *charge's* quantity with one or more *contract commitments*.
-* "ContractCommitmentAppliedQuantity" MUST be of type Decimal.
-* "ContractCommitmentAppliedQuantity" MUST conform to [NumericFormat](#attributes.numericformat) requirements.
-* "ContractCommitmentAppliedQuantity" nullability is defined as follows:
-  * "ContractCommitmentAppliedQuantity" MUST NOT be null when "ContractCommitmentAppliedCost" is null.
-  * "ContractCommitmentAppliedQuantity" MAY be null in all other cases.
-* "ContractCommitmentAppliedQuantity" MUST be a valid decimal value.
-* "ContractCommitmentAppliedQuantity" MUST be denominated in the "ContractCommitmentAppliedUnit".
-
-<b>Contract Commitment Applied Unit</b>
-
-The Contract Commitment Applied Unit represents a service-provider-specified measurement unit for the usage declared in Contract Commitment Applied Quantity. Contract Commitment Applied Unit complements the Contract Commitment Applied Quantity metric.
-
-The "ContractCommitmentAppliedUnit" property adheres to the following requirements:
-
-* "ContractCommitmentAppliedUnit" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider associates the *charge's* quantity with one or more *contract commitments*.
-* "ContractCommitmentAppliedUnit" MUST be of type String.
-* "ContractCommitmentAppliedUnit" MUST conform to [StringHandling](#attributes.stringhandling) requirements.
-* "ContractCommitmentAppliedUnit" SHOULD conform to [UnitFormat](#attributes.unitformat) requirements.
-* "ContractCommitmentAppliedUnit" nullability is defined as follows:
-  * "ContractCommitmentAppliedUnit" MUST be null when "ContractCommitmentAppliedQuantity" is null.
-  * "ContractCommitmentAppliedUnit" MUST NOT be null when "ContractCommitmentAppliedQuantity" is not null.
-
-## Overview
-
-### Array of Objects
+#### Array of Objects
 
 The parent array is called `Elements` and contains one or more objects which communicate information about how an allocated record was calculated.
 
@@ -137,7 +144,7 @@ The parent array is called `Elements` and contains one or more objects which com
 | ----- | ---- | ---------- | ----------- |
 | Elements | Array | True | The parent array containing one or more objects which communicate information about how contract commitments were applied to the charge. |
 
-### Object Entries
+#### Object Entries
 
 The `Elements` array contains one or more objects, each of which contains the following entries:
 
@@ -149,17 +156,41 @@ The `Elements` array contains one or more objects, each of which contains the fo
 | ContractCommitmentAppliedQuantity | Dimension   | Conditional   | True         | Numeric   |
 | ContractCommitmentAppliedUnit     | Dimension   | Conditional   | True         | String    |
 
+### Descriptions
+
+The following keys are used for contract application properties to facilitate querying data across allocations and across service providers. FOCUS-defined keys will appear in the list below, and custom keys will be prefixed with "x_" to make them easy to identify as well as prevent collisions.
+
+<b>Contract ID</b>
+
+Contract ID is a service-provider-assigned identifier for a contract describing the agreed terms between a service provider and a customer.  Contracts can include commitment to a certain amount of spend or usage over an agreed period of time.
+
+<b>Contract Commitment ID</b>
+
+A Contract Commitment ID is a service-provider-assigned identifier describing an agreement agreed between a service provider and a customer.  Contracts can include commitment to a certain amount of spend or usage over an agreed period of time.
+
+<b>Contract Commitment Applied Cost</b>
+
+Contract Commitment Applied Cost represents the cost of the charge applied to the contract line item.  Contract Commitment Applied Cost is associated with the contract line item via Contract Commitment ID.  Contract Commitment Applied Cost is commonly used for monitoring the progress towards fulfilling contractual commitments that may facilitate discounts for [*resources*](#glossary:resource) or [*services*](#glossary:service) as agreed between a service provider and a customer.
+
+<b>Contract Commitment Applied Quantity</b>
+
+Contract Commitment Applied Quantity represents the quantity of the charge applied to the contract line item.  Contract Commitment Applied Quantity is associated with the contract line item via Contract Commitment ID.  Contract Commitment Applied Quantity is commonly used for monitoring the progress towards fulfilling contractual commitments that may facilitate discounts for [*resources*](#glossary:resource) or [*services*](#glossary:service) as agreed between a service provider and a customer.
+
+<b>Contract Commitment Applied Unit</b>
+
+The Contract Commitment Applied Unit represents a service-provider-specified measurement unit for the usage declared in Contract Commitment Applied Quantity. Contract Commitment Applied Unit complements the Contract Commitment Applied Quantity metric.
+
 ### Example
 
 ```json
 {
   "Elements" : [ {
     "ContractID" : "12345",
-    "ContractCommitmentID" : "23456",
+    ContractAppliedObject.Elements[\*].ContractCommitmentID : "23456",
     "ContractCommitmentAppliedCost" : 500000.00
   }, {
     "ContractID" : "12345",
-    "ContractCommitmentID" : "34567",
+    ContractAppliedObject.Elements[\*].ContractCommitmentID : "34567",
     "ContractCommitmentAppliedQuantity" : 10000.00,
     "ContractCommitmentAppliedUnit" : "compute_hours"
   } ]
@@ -175,7 +206,7 @@ The `Elements` array contains one or more objects, each of which contains the fo
       "elements": {
         "properties": {
           "ContractID": { "type": "string" },
-          "ContractCommitmentID": { "type": "string" }
+          ContractAppliedObject.Elements[\*].ContractCommitmentID: { "type": "string" }
         },
         "optionalProperties": {
           "ContractCommitmentAppliedCost": { "type": "float64" },
@@ -214,15 +245,15 @@ The Charge Category is denoted as Purchase, and the Contract ID, Resource ID, an
     {
       "Elements": [ {
         "ContractID": "12345",
-        "ContractCommitmentID": "12345",
+        ContractAppliedObject.Elements[\*].ContractCommitmentID: "12345",
         "ContractCommitmentAppliedCost": 500000.00
       }, {
         "ContractID": "12345",
-        "ContractCommitmentID": "23456",
+        ContractAppliedObject.Elements[\*].ContractCommitmentID: "23456",
         "ContractCommitmentAppliedCost": 25000.00
       }, {
         "ContractID": "12345",
-        "ContractCommitmentID": "34567",
+        ContractAppliedObject.Elements[\*].ContractCommitmentID: "34567",
         "ContractCommitmentAppliedQuantity": 100000.00,
         "ContractCommitmentAppliedUnit": "compute_hours"
       } ]
@@ -248,15 +279,15 @@ This applies to the contract commitments in the following manner:
     {
       "Elements": [ {
         "ContractID": "12345",
-        "ContractCommitmentID": "12345",
+        ContractAppliedObject.Elements[\*].ContractCommitmentID: "12345",
         "ContractCommitmentAppliedCost": 15.00
       }, {
         "ContractID": "12345",
-        "ContractCommitmentID": "23456",
+        ContractAppliedObject.Elements[\*].ContractCommitmentID: "23456",
         "ContractCommitmentAppliedCost": 15.00
       }, {
         "ContractID": "12345",
-        "ContractCommitmentID": "34567",
+        ContractAppliedObject.Elements[\*].ContractCommitmentID: "34567",
         "ContractCommitmentAppliedQuantity": 0.50,
         "ContractCommitmentAppliedUnit": "compute_hours"
       } ]
@@ -278,46 +309,19 @@ The same as Scenario 2, except a custom key-value pair `x_ContractCommitmentCost
     {
       "Elements": [ {
         "ContractID": "12345",
-        "ContractCommitmentID": "12345",
+        ContractAppliedObject.Elements[\*].ContractCommitmentID: "12345",
         "ContractCommitmentAppliedCost": 15.00,
         "x_ContractCommitmentCostBalance": 499985.00
       }, {
         "ContractID": "12345",
-        "ContractCommitmentID": "23456",
+        ContractAppliedObject.Elements[\*].ContractCommitmentID: "23456",
         "ContractCommitmentAppliedCost": 15.00,
         "x_ContractCommitmentCostBalance": 24985.00
       }, {
         "ContractID": "12345",
-        "ContractCommitmentID": "34567",
+        ContractAppliedObject.Elements[\*].ContractCommitmentID: "34567",
         "ContractCommitmentAppliedQuantity": 0.50,
         "ContractCommitmentAppliedUnit": "compute_hours"
       } ]
     }
 ```
-
-## Column ID
-
-ContractApplied
-
-## Display Name
-
-Contract Applied
-
-## Description
-
-A set of properties that associate a charge with one or more [*contract commitments*](#glossary:contract-commitment).
-
-## Content Constraints
-
-| Constraint      | Value                                                |
-| :-------------- | :----------------------------------------------------|
-| Dataset         | [Cost and Usage](#datasets.costandusage)             |
-| Column type     | Dimension and Metric                                 |
-| Feature level   | Conditional                                          |
-| Allows nulls    | True                                                 |
-| Data type       | JSON                                                 |
-| Value format    | [JSON Object Format](#attributes.jsonobjectformat)   |
-
-## Introduced (version)
-
-1.3


### PR DESCRIPTION
### Summary
This PR proposes restructuring the normative text for JSON Objects to align better with requirements modeling. It organizes the content into a hierarchical structure—separating requirements, object details, and column definitions—and moves detailed example scenarios to the appendix. This approach focuses on clarifying and organizing the existing textual definitions without introducing a new schema format.

**Alternative Option:**
For the approach using JSON Schema instead of structured text, see **[PR #2007](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/2007)**.

Signed-off-by: Mike Fuller <mike@finops.org>