### PR TITLE
AI #1992: Automate comment pinning

### DIFF
--- a/.github/workflows/pin-comment.yml
+++ b/.github/workflows/pin-comment.yml
@@ -1,0 +1,32 @@
+name: Auto-Pin Status Update
+
+on:
+  issue_comment:
+    # Trigger on both new posts and edits
+    types: [created, edited]
+
+jobs:
+  pin-status:
+    # 1. Matches the specific header and emoji
+    # 2. Ensures it only runs on Issues (since PRs don't support pinning)
+    if: |
+      startsWith(github.event.comment.body, '## 🔄 Status Update') && 
+      github.event.issue.pull_request == null
+    
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Pin the Status Update
+        env:
+          # Using GH_TOKEN so the GitHub CLI can authenticate
+          # Using your bot's PAT so it has 'Member' status
+          GH_TOKEN: ${{ secrets.FOCUS_AUTOMATION_PAT }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          echo "Attempting to pin comment $COMMENT_ID as focus-automation..."
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/issues/comments/$COMMENT_ID/pin
+          echo "Pin successful!"

--- a/.github/workflows/pin-comment.yml
+++ b/.github/workflows/pin-comment.yml
@@ -10,7 +10,7 @@ jobs:
     # 1. Matches the specific header and emoji
     # 2. Ensures it only runs on Issues (since PRs don't support pinning)
     if: |
-      startsWith(github.event.comment.body, '## 🔄 Status Update') && 
+      startsWith(github.event.comment.body, '## Status Update') && 
       github.event.issue.pull_request == null
     
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🔄 Automated Status Update Pinning

### 📋 Summary
This PR introduces a GitHub Action that automatically **pins** any issue comment starting with the header `## Status Update`. This ensures that the latest project status is always visible at the top of the issue timeline, regardless of how many subsequent comments are posted.

### 🛠️ Technical Implementation
* **Trigger:** The workflow activates on both `issue_comment: created` and `edited` events.
* **Filtering:** It only targets standard **Issues** (ignoring Pull Requests) that contain the specific "Status Update" Markdown header.
* **Authentication:** Uses a Personal Access Token (`FOCUS_AUTOMATION_PAT`) from the `@focus-automation` account. 
    * *Note:* This was necessary because the default `GITHUB_TOKEN` lacks the "Admin/Moderator" scope required by the GitHub API to perform the `pin` action.
* **CLI Integration:** Leverages the GitHub CLI (`gh api`) to hit the REST API endpoint for pinning.

### 🔐 Security & Permissions
* **Actor:** Actions will appear as **"focus-automation pinned a comment"**.
* **Access Level:** The bot account requires **Write** access to the repository to satisfy the GitHub API's moderation requirements for pinning.
* **Secret Management:** The token is stored securely as a repository secret and is never logged during execution.

### ✅ How to Test
1. Comment on any issue with: `## Status Update` in the [test repo](https://github.com/FinOps-Open-Cost-and-Usage-Spec/test/issues), followed by your text.
2. Verify that the comment is immediately moved to the "Pinned" section at the top.
3. Edit the comment; verify the pin remains or refreshes successfully.