### PR TITLE
AI #1961: Address count logic in PR review and thread trackers

### DIFF
--- a/.github/workflows/track-pr-reviews.yml
+++ b/.github/workflows/track-pr-reviews.yml
@@ -105,8 +105,9 @@ jobs:
             ITEM_DATA=$(echo "$ITEM_QUERY" | jq -r --arg PROJ "$PROJECT_ID" '.data.node.projectItems.nodes[] | select(.project.id == $PROJ)')
             ITEM_ID=$(echo "$ITEM_DATA" | jq -r '.id // empty')
             
-            RAW_OLD_APP=$(echo "$ITEM_DATA" | jq -r '.app_val.number')
-            RAW_OLD_REQ=$(echo "$ITEM_DATA" | jq -r '.req_val.number')
+            # Use jq conditional to floor the number if it exists, otherwise return "null" string
+            RAW_OLD_APP=$(echo "$ITEM_DATA" | jq -r 'if .app_val.number != null then (.app_val.number | floor) else "null" end')
+            RAW_OLD_REQ=$(echo "$ITEM_DATA" | jq -r 'if .req_val.number != null then (.req_val.number | floor) else "null" end')
 
             OLD_APP=$(echo "$ITEM_DATA" | jq -r '.app_val.number // 0 | floor')
             OLD_REQ=$(echo "$ITEM_DATA" | jq -r '.req_val.number // 0 | floor')

--- a/.github/workflows/track-pr-reviews.yml
+++ b/.github/workflows/track-pr-reviews.yml
@@ -5,7 +5,8 @@ on:
     - cron: '0 */4 * * *'  # Runs every 4 hours
   pull_request:
     types: 
-      - review_requested
+      - opened
+      - reopened
   pull_request_review:
     types: 
       - submitted
@@ -22,7 +23,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'pull_request' && github.event.action == 'review_requested') || 
+      (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')) || 
       (github.event_name == 'pull_request_review' && github.event.review.state != 'commented')
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/track-pr-reviews.yml
+++ b/.github/workflows/track-pr-reviews.yml
@@ -66,13 +66,25 @@ jobs:
           APP_FIELD_ID=$(echo "$PROJ_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "PR Approvals") | .id')
           REQ_FIELD_ID=$(echo "$PROJ_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "PR Change Requests") | .id')
 
-          # 3. Loop PRs
+          # 3. Loop through identified PRs
           for PR_NUM in "${PR_LIST[@]}"; do
             echo "--- Processing PR #$PR_NUM ---"
 
-            PR_METADATA=$(gh pr view "$PR_NUM" --json id,createdAt,reviews --limit 1000)
-            PR_NODE_ID=$(echo "$PR_METADATA" | jq -r '.id')
-            CREATED_AT=$(echo "$PR_METADATA" | jq -r '.createdAt')
+            PR_BASE=$(gh pr view "$PR_NUM" --json id,createdAt)
+            PR_NODE_ID=$(echo "$PR_BASE" | jq -r '.id')
+            CREATED_AT=$(echo "$PR_BASE" | jq -r '.createdAt')
+
+            REVIEWS_RAW=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUM/reviews" --paginate)
+
+            REVIEWS_JSON=$(echo "$REVIEWS_RAW" | jq -s -c '
+              add 
+              | map({state: .state, author: {login: .user.login}, submittedAt: .submitted_at}) 
+              | map(select(.state != "COMMENTED")) 
+              | group_by(.author.login) 
+              | map(sort_by(.submittedAt) | .[-1])')
+
+            APP_COUNT=$(echo "$REVIEWS_JSON" | jq 'map(select(.state == "APPROVED")) | length')
+            REQ_COUNT=$(echo "$REVIEWS_JSON" | jq 'map(select(.state == "CHANGES_REQUESTED")) | length')
 
             ITEM_QUERY=$(gh api graphql -f query='
               query($node: ID!) {
@@ -90,14 +102,9 @@ jobs:
                 }
               }' -f node="$PR_NODE_ID")
 
-            REVIEWS_JSON=$(echo "$PR_METADATA" | jq -c '.reviews | map(select(.state != "COMMENTED")) | group_by(.author.login) | map(sort_by(.submittedAt) | .[-1])')
-            APP_COUNT=$(echo "$REVIEWS_JSON" | jq 'map(select(.state == "APPROVED")) | length')
-            REQ_COUNT=$(echo "$REVIEWS_JSON" | jq 'map(select(.state == "CHANGES_REQUESTED")) | length')
-
             ITEM_DATA=$(echo "$ITEM_QUERY" | jq -r --arg PROJ "$PROJECT_ID" '.data.node.projectItems.nodes[] | select(.project.id == $PROJ)')
             ITEM_ID=$(echo "$ITEM_DATA" | jq -r '.id // empty')
             
-            # Detect if fields are truly null/blank
             RAW_OLD_APP=$(echo "$ITEM_DATA" | jq -r '.app_val.number')
             RAW_OLD_REQ=$(echo "$ITEM_DATA" | jq -r '.req_val.number')
 
@@ -112,8 +119,7 @@ jobs:
                 mutation($project: ID!, $content: ID!) {
                   addProjectV2ItemById(input: {projectId: $project, contentId: $content}) { item { id } }
                 }' -f project="$PROJECT_ID" -f content="$PR_NODE_ID" | jq -r '.data.addProjectV2ItemById.item.id')
-                # Since it was just added, we force update
-                IS_NEW_ITEM=true
+              IS_NEW_ITEM=true
             else
               IS_NEW_ITEM=false
             fi

--- a/.github/workflows/track-pr-reviews.yml
+++ b/.github/workflows/track-pr-reviews.yml
@@ -70,13 +70,14 @@ jobs:
           for PR_NUM in "${PR_LIST[@]}"; do
             echo "--- Processing PR #$PR_NUM ---"
 
-            PR_QUERY=$(gh api graphql -f query='
-              query($org: String!, $repo: String!, $num: Int!) {
-                repository(owner: $org, name: $repo) {
-                  pullRequest(number: $num) {
-                    id
-                    createdAt
-                    reviews(first: 100) { nodes { state author { login } submittedAt } }
+            PR_METADATA=$(gh pr view "$PR_NUM" --json id,createdAt,reviews --limit 1000)
+            PR_NODE_ID=$(echo "$PR_METADATA" | jq -r '.id')
+            CREATED_AT=$(echo "$PR_METADATA" | jq -r '.createdAt')
+
+            ITEM_QUERY=$(gh api graphql -f query='
+              query($node: ID!) {
+                node(id: $node) {
+                  ... on PullRequest {
                     projectItems(first: 10) {
                       nodes {
                         project { id }
@@ -87,16 +88,13 @@ jobs:
                     }
                   }
                 }
-              }' -f org="$ORG" -f repo="${{ github.event.repository.name }}" -F num=$PR_NUM)
+              }' -f node="$PR_NODE_ID")
 
-            PR_NODE_ID=$(echo "$PR_QUERY" | jq -r '.data.repository.pullRequest.id')
-            CREATED_AT=$(echo "$PR_QUERY" | jq -r '.data.repository.pullRequest.createdAt')
-            
-            REVIEWS_JSON=$(echo "$PR_QUERY" | jq -c '.data.repository.pullRequest.reviews.nodes | map(select(.state != "COMMENTED")) | group_by(.author.login) | map(sort_by(.submittedAt) | .[-1])')
+            REVIEWS_JSON=$(echo "$PR_METADATA" | jq -c '.reviews | map(select(.state != "COMMENTED")) | group_by(.author.login) | map(sort_by(.submittedAt) | .[-1])')
             APP_COUNT=$(echo "$REVIEWS_JSON" | jq 'map(select(.state == "APPROVED")) | length')
             REQ_COUNT=$(echo "$REVIEWS_JSON" | jq 'map(select(.state == "CHANGES_REQUESTED")) | length')
 
-            ITEM_DATA=$(echo "$PR_QUERY" | jq -r --arg PROJ "$PROJECT_ID" '.data.repository.pullRequest.projectItems.nodes[] | select(.project.id == $PROJ)')
+            ITEM_DATA=$(echo "$ITEM_QUERY" | jq -r --arg PROJ "$PROJECT_ID" '.data.node.projectItems.nodes[] | select(.project.id == $PROJ)')
             ITEM_ID=$(echo "$ITEM_DATA" | jq -r '.id // empty')
             
             # Detect if fields are truly null/blank
@@ -114,8 +112,8 @@ jobs:
                 mutation($project: ID!, $content: ID!) {
                   addProjectV2ItemById(input: {projectId: $project, contentId: $content}) { item { id } }
                 }' -f project="$PROJECT_ID" -f content="$PR_NODE_ID" | jq -r '.data.addProjectV2ItemById.item.id')
-              # Since it was just added, we force update
-              IS_NEW_ITEM=true
+                # Since it was just added, we force update
+                IS_NEW_ITEM=true
             else
               IS_NEW_ITEM=false
             fi

--- a/.github/workflows/track-pr-reviews.yml
+++ b/.github/workflows/track-pr-reviews.yml
@@ -92,7 +92,7 @@ jobs:
             PR_NODE_ID=$(echo "$PR_QUERY" | jq -r '.data.repository.pullRequest.id')
             CREATED_AT=$(echo "$PR_QUERY" | jq -r '.data.repository.pullRequest.createdAt')
             
-            REVIEWS_JSON=$(echo "$PR_QUERY" | jq -c '.data.repository.pullRequest.reviews.nodes | group_by(.author.login) | map(sort_by(.submittedAt) | .[-1])')
+            REVIEWS_JSON=$(echo "$PR_QUERY" | jq -c '.data.repository.pullRequest.reviews.nodes | map(select(.state != "COMMENTED")) | group_by(.author.login) | map(sort_by(.submittedAt) | .[-1])')
             APP_COUNT=$(echo "$REVIEWS_JSON" | jq 'map(select(.state == "APPROVED")) | length')
             REQ_COUNT=$(echo "$REVIEWS_JSON" | jq 'map(select(.state == "CHANGES_REQUESTED")) | length')
 

--- a/.github/workflows/track-pr-threads.yml
+++ b/.github/workflows/track-pr-threads.yml
@@ -1,11 +1,19 @@
 name: Sync PR Open Thread Counts
+
 on:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 */4 * * *'  # Catch silent "Resolve" clicks
   pull_request_review_comment:
-    types: [created, deleted]
+    types: 
+      - created
+      - deleted
+  pull_request_review:
+    types:
+      - submitted
   pull_request:
-    types: [ready_for_review]
+    types: 
+      - opened
+      - reopened
   workflow_dispatch:
     inputs:
       pr_number:
@@ -19,7 +27,8 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request_review_comment' ||
-      (github.event_name == 'pull_request' && github.event.action == 'ready_for_review')
+      github.event_name == 'pull_request_review' ||
+      (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))
     concurrency:
       group: sync-threads-${{ github.event.pull_request.id || 'bulk' }}
       cancel-in-progress: true
@@ -36,6 +45,8 @@ jobs:
           FIELD_NAME: "PR Open Threads"
           SINGLE_PR: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         run: |
+          set -e
+
           # 1. Fetch Project and Field IDs
           PROJ_DATA=$(gh api graphql -f query='
             query($org: String!, $p_num: Int!) {
@@ -58,7 +69,7 @@ jobs:
           # 2. Identify PRs
           if [ -n "$SINGLE_PR" ]; then
             echo "Processing single PR: #$SINGLE_PR"
-            PR_LIST=($SINGLE_PR)
+            PR_LIST=("$SINGLE_PR")
           else
             echo "Running bulk sync for all open PRs..."
             PR_LIST=($(gh pr list --state open --json number --jq '.[].number'))
@@ -68,31 +79,36 @@ jobs:
           for NUM in "${PR_LIST[@]}"; do
             echo "--- Processing PR #$NUM ---"
             
-            # Fetch Threads and Node ID via GraphQL (Native API call)
-            PR_DATA=$(gh api graphql -f query='
-              query($org: String!, $repo: String!, $num: Int!) {
+            # Fetch ALL threads using GraphQL + Auto-Pagination
+            # We must include $endCursor in the query so the CLI knows how to paginate.
+            PR_DATA_FULL=$(gh api graphql --paginate -f query='
+              query($org: String!, $repo: String!, $num: Int!, $endCursor: String) {
                 repository(owner: $org, name: $repo) {
                   pullRequest(number: $num) {
                     id
-                    reviewThreads(first: 100) {
+                    reviewThreads(first: 100, after: $endCursor) {
+                      pageInfo { hasNextPage endCursor }
                       nodes { isResolved }
                     }
                   }
                 }
               }' -f org="$ORG" -f repo="${{ github.event.repository.name }}" -F num=$NUM)
 
-            PR_NODE_ID=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequest.id')
-            COUNT=$(echo "$PR_DATA" | jq -r '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length // 0')
+            # Extract Node ID (safe to take from the first page of results)
+            # We use `jq -s` to handle the stream of JSON pages
+            PR_NODE_ID=$(echo "$PR_DATA_FULL" | jq -s -r '.[0].data.repository.pullRequest.id')
+            
+            # Count ALL unresolved threads across ALL pages
+            COUNT=$(echo "$PR_DATA_FULL" | jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
 
             if [ -z "$PR_NODE_ID" ] || [ "$PR_NODE_ID" == "null" ]; then 
               echo "PR #$NUM not found. Skipping."
               continue
             fi
 
-            # DEBUG OUTPUT
             echo "Debug: PR #$NUM Summary - Open Threads found: $COUNT"
 
-            # 4. Resolve Item ID (The Fix for PR #1882)
+            # 4. Resolve Item ID
             ITEM_ID=$(gh api graphql -f query='
               mutation($project: ID!, $content: ID!) {
                 addProjectV2ItemById(input: {projectId: $project, contentId: $content}) { 


### PR DESCRIPTION
The PR review tracker was under-reporting approvals and requests for changes on the PRs for a couple of reasons:

* Those who had approved or requested changes, then later commented, were being suppressed.  That has been addressed.
* Some community activity in larger PRs was being missed due to some limitations in how that code was written.  It has now been refactored to paginate through the entire activity to fetch the entire history, not just a subset.

This PR also addresses how numbers were being passed to the logger.  Instead of "1.0 -> 2", it now correctly shows "1 -> 2".

This PR also updates the triggers for both the review and thread tracker scripts to be more targeted to their purpose.