### PR TITLE
AI #1961: Eliminate race condition for PR Open Threads YAML

### DIFF
--- a/.github/workflows/track-pr-threads.yml
+++ b/.github/workflows/track-pr-threads.yml
@@ -1,19 +1,23 @@
 name: Sync PR Open Thread Counts
 
 on:
+  # 1. Safety Net: Runs every 4 hours to catch silent "Resolve" clicks
   schedule:
-    - cron: '0 */4 * * *'  # Catch silent "Resolve" clicks
+    - cron: '0 */4 * * *'
+
+  # 2. The Main Trigger: catches single replies AND batch reviews
   pull_request_review_comment:
     types: 
       - created
       - deleted
-  pull_request_review:
-    types:
-      - submitted
+
+  # 3. Initialization: Sets the count when a PR is first created
   pull_request:
     types: 
       - opened
       - reopened
+
+  # 4. Manual Override
   workflow_dispatch:
     inputs:
       pr_number:
@@ -23,19 +27,30 @@ on:
 jobs:
   sync:
     name: Sync PR Open Thread Counts
+    runs-on: ubuntu-latest
+    
+    # Run only if it's a Schedule/Dispatch OR a relevant PR event
     if: >
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request_review_comment' ||
-      github.event_name == 'pull_request_review' ||
       (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))
+
+    # THE QUEUE STRATEGY
     concurrency:
+      # Group by PR so we don't block updates for other PRs
       group: sync-threads-${{ github.event.pull_request.id || 'bulk' }}
-      cancel-in-progress: true
-    runs-on: ubuntu-latest
+      # FALSE = Runs line up single-file. No cancellations. All Green Checks.
+      cancel-in-progress: false
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      # Safety Sleep: Ensures the API is consistent even for the very first job in the queue
+      - name: Wait for API Consistency
+        if: github.event_name == 'pull_request_review_comment'
+        run: sleep 5
 
       - name: Calculate and Sync
         env:
@@ -128,5 +143,7 @@ jobs:
             else
               echo "Error: Could not resolve Item ID for PR #$NUM."
             fi
+            
+            # Small throttle for the loop, just in case
             sleep 1
           done


### PR DESCRIPTION
When someone issues a review, the PR Open Threads YAML was issuing triggers on both `pull_request_review` and `pull_request_review_comment`.  

I am eliminating the former trigger and now only using the latter.  In the case of a review with multiple comments issued simultaneously, I am letting all of them run in sequence instead of cancelling, in order to reduce the noise of cancellation that users have been receiving notifications for.