### PR TITLE
AI #2005: JSON refactor: tweak schema and requirements logic

### DIFF
--- a/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
@@ -33,7 +33,6 @@ The ContractCommitmentEligibilityObject adheres to the following requirements:
 * ContractCommitmentEligibilityObject.Inclusions[*].Applicability.Usage MUST represent the fraction of the charge's usage quantity eligible for the commitment (0.0 to 1.0).
 * ContractCommitmentEligibilityObject.Inclusions[\*].Dimension SHOULD represent a column in the FOCUS [Cost and Usage dataset](#datasets.costandusage).
 * ContractCommitmentEligibilityObject.Exclusions[\*].Dimension SHOULD represent a column in the FOCUS [Cost and Usage dataset](#datasets.costandusage).
-* ContractCommitmentEligibilityObject MAY contain additional properties prefixed with x_ (PascalCase) to support vendor-specific extensions.
 * ContractCommitmentEligibilityObject.Inclusions[*].Values MUST contain only the single string "*" if the wildcard is present.
 * ContractCommitmentEligibilityObject.Exclusions[*].Values MUST contain only the single string "*" if the wildcard is present.
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
@@ -273,10 +273,10 @@ The evaluation of a resource against a commitment eligibility MUST follow a stri
 
 ### Integration with Commitment Logic
 
-The evaluation of **Applicability** percentages must be contextually aligned with the [Contract Commitment Model](#datasets.contractcommitment.contractcommitmentmodel) and [Contract Commitment Interval](#datasets.contractcommitment.contractcommitmentinterval):
+The evaluation of **Applicability** percentages must be contextually aligned with the [Contract Commitment Model](#datasets.contractcommitment.contractcommitmentmodel) and [Contract Commitment Fulfillment Interval](#datasets.contractcommitment.contractcommitmentfulfillmentinterval):
 
-* **Continuous Models:** The `Applicability` percentages (Cost/Usage) MUST be applied to each discrete unit of activity within the **Interval** (e.g., every hour). If the commitment is not fully utilized by the applicable resources within that specific hour, the remaining capacity expires.
-* **Discontinuous Models:** The `Applicability` percentages determine the portion of aggregate activity that counts toward the commitment fulfillment over the entire **Interval** (e.g., the full year).
+* **Continuous Models:** The `Applicability` percentages (Cost/Usage) MUST be applied to each discrete unit of activity within the **Fulfillment Interval** (e.g., every hour). If the commitment is not fully utilized by the applicable resources within that specific hour, the remaining capacity expires.
+* **Discontinuous Models:** The `Applicability` percentages determine the portion of aggregate activity that counts toward the commitment fulfillment over the entire **Fulfillment Interval** (e.g., the full year).
 
 ### Dependency Logic
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmenteligibility.md
@@ -29,8 +29,13 @@ The ContractCommitmentEligibilityObject adheres to the following requirements:
 * ContractCommitmentEligibilityObject.IsComplexScope MUST be `true` if the *contract commitment's* eligibility logic exceeds schema capabilities.
 * ContractCommitmentEligibilityObject.Applicability.Cost MUST represent the fraction of the charge's cost eligible for the commitment (0.0 to 1.0).
 * ContractCommitmentEligibilityObject.Applicability.Usage MUST represent the fraction of the charge's usage quantity eligible for the commitment (0.0 to 1.0).
+* ContractCommitmentEligibilityObject.Inclusions[*].Applicability.Cost MUST represent the fraction of the charge's cost eligible for the commitment (0.0 to 1.0).
+* ContractCommitmentEligibilityObject.Inclusions[*].Applicability.Usage MUST represent the fraction of the charge's usage quantity eligible for the commitment (0.0 to 1.0).
 * ContractCommitmentEligibilityObject.Inclusions[\*].Dimension SHOULD represent a column in the FOCUS [Cost and Usage dataset](#datasets.costandusage).
 * ContractCommitmentEligibilityObject.Exclusions[\*].Dimension SHOULD represent a column in the FOCUS [Cost and Usage dataset](#datasets.costandusage).
+* ContractCommitmentEligibilityObject MAY contain additional properties prefixed with x_ (PascalCase) to support vendor-specific extensions.
+* ContractCommitmentEligibilityObject.Inclusions[*].Values MUST contain only the single string "*" if the wildcard is present.
+* ContractCommitmentEligibilityObject.Exclusions[*].Values MUST contain only the single string "*" if the wildcard is present.
 
 ## Schema Structure
 
@@ -84,7 +89,7 @@ ContractCommitmentEligibility uses a reserved string to represent global or unre
 
 | Reserved Value | Description | Supported Operators |
 | :--- | :--- | :--- |
-| `"*"` | Represents all possible values for the specified Dimension. | `In`, `Contains` |
+| `"*"` | Represents all possible values for the specified Dimension. | `In`, `Contains`, `Exists`, `DoesNotExist` |
 
 ### Wildcard Behavior Rules
 
@@ -139,6 +144,28 @@ A commitment purchased for a specific region (e.g., `us-east-1`). Since `IsGloba
       "Dimension": "RegionId",
       "Operator": "In",
       "Values": ["us-east-1"]
+    }
+  ]
+}
+```
+
+### Custom Scope
+
+A commitment that is only applicable to a specific value (Pay-As-You-Go) for a custom entity (x_BillingModel) in the `us-east-1` region.
+
+```json
+{
+  "InclusionOperator": "OR",
+  "Inclusions": [
+    {
+      "Dimension": "RegionId",
+      "Operator": "In",
+      "Values": ["us-east-1"]
+    },
+    {
+      "Dimension": "x_BillingModel",
+      "Operator": "In",
+      "Values": ["Pay-As-You-Go"]
     }
   ]
 }

--- a/specification/datasets/cost_and_usage/columns/contractapplied.md
+++ b/specification/datasets/cost_and_usage/columns/contractapplied.md
@@ -48,7 +48,7 @@ The ContractAppliedObject adheres to the following requirements:
 
 The parent array is called `Elements` and contains one or more objects which communicate information about how an allocated record was calculated.
 
-| Key | ValueType | Required | Description |
+| Key | Value Type | Required | Description |
 | ----- | ---- | ---------- | ----------- |
 | Elements | Array | True | The parent array containing one or more objects which communicate information about how contract commitments were applied to the charge. |
 
@@ -56,10 +56,10 @@ The parent array is called `Elements` and contains one or more objects which com
 
 The `Elements` array contains one or more objects, each of which contains the following entries:
 
-| Key | ValueType | Required | Description |
+| Key | Value Type | Feature Level | Description |
 | ----- | ---- | ---------- | ----------- |
-| ContractId | String | True | Unique identifier for the contract. |
-| ContractCommitmentId | String | True | Unique identifier for the contract commitment term. |
+| ContractId | String | Required | Unique identifier for the contract. |
+| ContractCommitmentId | String | Required | Unique identifier for the contract commitment term. |
 | ContractCommitmentAppliedCost | Metric | Conditional | Cost value of the charge applied to the contract commitment. |
 | ContractCommitmentAppliedQuantity | Metric | Conditional | Quantity of usage applied to the contract commitment. |
 | ContractCommitmentAppliedUnit | String | Conditional | Unit of measure for the applied quantity. Required if Quantity is present. |

--- a/specification/datasets/cost_and_usage/columns/contractapplied.md
+++ b/specification/datasets/cost_and_usage/columns/contractapplied.md
@@ -11,7 +11,7 @@ The ContractApplied column adheres to the following requirements:
 * ContractApplied MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
 * ContractApplied nullability is defined as follows:
   * ContractApplied MUST NOT be null when one or more *contract commitments* are applied to the *charge*.
-* ContractApplied MUST conform to [AllocatedMethodDetailsObject](#datasets.costandusage.contractapplied.contractappliedobject) requirements when ContractApplied is not null.
+* ContractApplied MUST conform to [ContractAppliedObject](#datasets.costandusage.contractapplied.contractappliedobject) requirements when ContractApplied is not null.
 
 ## Contract Applied Object
 
@@ -33,14 +33,13 @@ The ContractAppliedObject adheres to the following requirements:
 
 * ContractAppliedObject MUST conform to the [ContractAppliedObjectSchema](#schemas.datasets.costandusage.contractappliedobjectschema) JSON Schema.
 * ContractAppliedObject.Elements[\*] MUST NOT have nested property key-value pairs.
-* ContractAppliedObject.Elements[\*] MUST have custom key-value pairs documented by the data generator.
 * ContractAppliedObject.Elements[\*].ContractId MUST be a unique identifier within the service provider.
 * ContractAppliedObject.Elements[\*].ContractId SHOULD be a fully-qualified identifier.
-* ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be a unique identifier within the service provider.
-* ContractAppliedObject.Elements[\*].ContractCommitmentID SHOULD be a fully-qualified identifier.
-* ContractAppliedObject.Elements[\*].ContractCommitmentID MUST have one and only one parent ContractAppliedObject.Elements[\*].ContractID.
-* ContractAppliedObject.Elements[\*].ContractCommitmentID MUST be equal to ResourceID when ChargeCategory is "Purchase".
-* ContractAppliedObject.Elements[\*].ContractCommitmentID MAY be equal to ContractAppliedObject.Elements[\*].ContractID.
+* ContractAppliedObject.Elements[\*].ContractCommitmentId MUST be a unique identifier within the service provider.
+* ContractAppliedObject.Elements[\*].ContractCommitmentId SHOULD be a fully-qualified identifier.
+* ContractAppliedObject.Elements[\*].ContractCommitmentId MUST have one and only one parent ContractAppliedObject.Elements[\*].ContractId.
+* ContractAppliedObject.Elements[\*].ContractCommitmentId MUST be equal to ResourceID when ChargeCategory is "Purchase".
+* ContractAppliedObject.Elements[\*].ContractCommitmentId MAY be equal to ContractAppliedObject.Elements[\*].ContractId.
 * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedCost MUST be denominated in the BillingCurrency.
 * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedQuantity MUST be denominated in the ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit.
 * ContractAppliedObject.Elements[\*].ContractCommitmentAppliedUnit SHOULD conform to [UnitFormat](#attributes.unitformat) requirements.
@@ -57,13 +56,13 @@ The parent array is called `Elements` and contains one or more objects which com
 
 The `Elements` array contains one or more objects, each of which contains the following entries:
 
-| Key                               | Key Type    | Feature Level | Allows Nulls | Data Type |
-| --------------------------------- | ----------- | ------------- | ------------ | --------- |
-| ContractID                        | Dimension   | Conditional   | False        | String    |
-| ContractCommitmentID              | Dimension   | Conditional   | False        | String    |
-| ContractCommitmentAppliedCost     | Dimension   | Conditional   | True         | Numeric   |
-| ContractCommitmentAppliedQuantity | Dimension   | Conditional   | True         | Numeric   |
-| ContractCommitmentAppliedUnit     | Dimension   | Conditional   | True         | String    |
+| Key | ValueType | Required | Description |
+| ----- | ---- | ---------- | ----------- |
+| ContractId | String | True | Unique identifier for the contract. |
+| ContractCommitmentId | String | True | Unique identifier for the contract commitment term. |
+| ContractCommitmentAppliedCost | Metric | Conditional | Cost value of the charge applied to the contract commitment. |
+| ContractCommitmentAppliedQuantity | Metric | Conditional | Quantity of usage applied to the contract commitment. |
+| ContractCommitmentAppliedUnit | String | Conditional | Unit of measure for the applied quantity. Required if Quantity is present. |
 
 The following keys are used for contract application properties to facilitate querying data across allocations and across service providers. FOCUS-defined keys will appear in the list below, and custom keys will be prefixed with "x_" to make them easy to identify as well as prevent collisions.
 
@@ -92,12 +91,12 @@ The Contract Commitment Applied Unit represents a service-provider-specified mea
 ```json
 {
   "Elements" : [ {
-    "ContractID" : "12345",
-    "ContractCommitmentID" : "23456",
+    "ContractId" : "12345",
+    "ContractCommitmentId" : "23456",
     "ContractCommitmentAppliedCost" : 500000.00
   }, {
-    "ContractID" : "12345",
-    "ContractCommitmentID" : "34567",
+    "ContractId" : "12345",
+    "ContractCommitmentId" : "34567",
     "ContractCommitmentAppliedQuantity" : 10000.00,
     "ContractCommitmentAppliedUnit" : "compute_hours"
   } ]

--- a/specification/schemas/datasets/contract_commitment/contractcommitmenteligibilityobjectschema.json
+++ b/specification/schemas/datasets/contract_commitment/contractcommitmenteligibilityobjectschema.json
@@ -63,6 +63,35 @@
                     "description": "Optional rule-level applicability that overrides top-level"
                 }
             },
+            "allOf": [
+                {
+                    "description": "Wildcard constraint: If '*' is used, it must be the only value and Operator must be compatible.",
+                    "if": {
+                        "properties": {
+                            "Values": {
+                                "contains": {
+                                    "const": "*"
+                                }
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "Values": {
+                                "maxItems": 1
+                            },
+                            "Operator": {
+                                "enum": [
+                                    "In",
+                                    "Contains",
+                                    "Exists",
+                                    "DoesNotExist"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ],
             "additionalProperties": false
         }
     },
@@ -114,37 +143,32 @@
     },
     "allOf": [
         {
+            "description": "If neither Global nor Complex scope is active, Inclusions are required.",
             "if": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "IsGlobalScope": {
-                                "const": false
-                            }
-                        }
-                    },
-                    {
-                        "properties": {
-                            "IsComplexScope": {
-                                "const": false
-                            }
-                        }
-                    },
-                    {
-                        "not": {
+                "not": {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "IsGlobalScope": {
+                                    "const": true
+                                }
+                            },
                             "required": [
                                 "IsGlobalScope"
                             ]
-                        }
-                    },
-                    {
-                        "not": {
+                        },
+                        {
+                            "properties": {
+                                "IsComplexScope": {
+                                    "const": true
+                                }
+                            },
                             "required": [
                                 "IsComplexScope"
                             ]
                         }
-                    }
-                ]
+                    ]
+                }
             },
             "then": {
                 "required": [
@@ -154,12 +178,16 @@
             }
         },
         {
+            "description": "If IsGlobalScope is true, Inclusions must be empty or omitted.",
             "if": {
                 "properties": {
                     "IsGlobalScope": {
                         "const": true
                     }
-                }
+                },
+                "required": [
+                    "IsGlobalScope"
+                ]
             },
             "then": {
                 "not": {

--- a/specification/schemas/datasets/cost_and_usage/contractappliedobjectschema.json
+++ b/specification/schemas/datasets/cost_and_usage/contractappliedobjectschema.json
@@ -16,17 +16,14 @@
                 "type": "object",
                 "required": [
                     "ContractId",
-                    "ContractCommitmentID",
-                    "ContractCommitmentAppliedCost",
-                    "ContractCommitmentAppliedQuantity",
-                    "ContractCommitmentAppliedUnit"
+                    "ContractCommitmentId"
                 ],
                 "properties": {
                     "ContractId": {
                         "type": "string",
                         "description": "Unique identifier for the contract"
                     },
-                    "ContractCommitmentID": {
+                    "ContractCommitmentId": {
                         "type": "string",
                         "description": "Unique identifier for the contract commitment term"
                     },
@@ -54,36 +51,37 @@
                 },
                 "allOf": [
                     {
-                        "if": {
-                            "properties": {
-                                "ContractCommitmentAppliedQuantity": {
-                                    "type": "null"
-                                }
-                            }
-                        },
-                        "then": {
-                            "properties": {
-                                "ContractCommitmentAppliedUnit": {
-                                    "type": "null"
-                                }
-                            }
-                        }
-                    },
-                    {
+                        "description": "Unit is required if Quantity is present and not null",
                         "if": {
                             "properties": {
                                 "ContractCommitmentAppliedQuantity": {
                                     "type": "number"
                                 }
-                            }
+                            },
+                            "required": [
+                                "ContractCommitmentAppliedQuantity"
+                            ]
                         },
                         "then": {
-                            "properties": {
-                                "ContractCommitmentAppliedUnit": {
-                                    "type": "string"
-                                }
-                            }
+                            "required": [
+                                "ContractCommitmentAppliedUnit"
+                            ]
                         }
+                    },
+                    {
+                        "description": "At least one metric (Cost or Quantity) must be present",
+                        "anyOf": [
+                            {
+                                "required": [
+                                    "ContractCommitmentAppliedCost"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "ContractCommitmentAppliedQuantity"
+                                ]
+                            }
+                        ]
                     }
                 ],
                 "patternProperties": {


### PR DESCRIPTION
## Key Changes

### 1. ContractCommitmentEligibility
* **Schema Logic Fix:** Corrected the validation logic for `IsGlobalScope` and `IsComplexScope`. The schema now correctly requires `Inclusions` *only* if both global and complex flags are false (previously, valid global scopes were failing validation).
* **Wildcard Hardening:**
    * Enforced that if `"*"` is used as a value, it must be the only item in the array.
    * Updated the **Supported Operators** table to explicitly allow `Exists` and `DoesNotExist` when using the wildcard, resolving a conflict between the text and schema.
* **Normative Requirements:** Added missing `MUST` requirements for nested `Applicability` objects to ensure the 0.0-1.0 bounds are enforced at all levels.

### 2. ContractApplied
* **Casing Standardization:** Updated all ID references to use PascalCase (`ContractId`, `ContractCommitmentId`) instead of acronyms (`ID`) to align with FOCUS attribute naming standards.
* **Conditional Schema Logic:**
    * **Metrics:** Implemented `anyOf` logic to ensure at least one metric (`AppliedCost` or `AppliedQuantity`) is present in every entry.
    * **Units:** Implemented `if/then` logic to enforce that `ContractCommitmentAppliedUnit` is required if (and only if) `ContractCommitmentAppliedQuantity` is present.
* **Text Corrections:** Fixed copy-paste errors in the Requirements section (which incorrectly referenced `AllocatedMethodDetails`) and corrected the "Key Type" table to correctly identify Cost/Quantity as **Metrics** rather than Dimensions.

### 3. AllocatedMethodDetails

* **None!** I analyzed this, and it looks good!