### PR TITLE
AI #1785: Add Invoice Detail and Billing Period datasets - Font Fix Patch

### DIFF
--- a/specification/datasets/invoice_detail/columns/paymentcurrencybilledcost.md
+++ b/specification/datasets/invoice_detail/columns/paymentcurrencybilledcost.md
@@ -24,9 +24,13 @@ In this scenario, the invoice issuer performs currency conversion at the individ
 * **Payment Currency:** EUR
 * **Exchange Rate:** 1.00 USD = 0.92 EUR
 
+<div class="small-table">
+
 | InvoiceDetailId | ChargeCategory | BillingCurrency | BilledCost | PaymentCurrency | PaymentCurrencyBilledCost | PaymentCurrencyInvoiceDetailId |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | ID-001 | Usage | USD | 100.00 | EUR | 92.00 | ID-001 |
+
+</div>
 
 > **Note:** Because the conversion is 1:1, the `PaymentCurrencyInvoiceDetailId` points to the record's own `InvoiceDetailId`.
 
@@ -38,13 +42,18 @@ In this scenario, the invoice issuer tracks usage in the billing currency at a g
 * **Payment Currency:** EUR
 * **Effective Exchange Rate:** 1.00 USD = 0.92 EUR
 
+<div class="small-table">
+
 | InvoiceDetailId | InvoiceDetailDescription | BilledCost | PaymentCurrencyBilledCost | PaymentCurrencyInvoiceDetailId |
 | :--- | :--- | :--- | :--- | :--- |
 | A-101 | Compute Instance A | 45.00 | 0.00 | Z-999 |
 | A-102 | Compute Instance B | 55.00 | 0.00 | Z-999 |
 | Z-999 | Usage in Payment Currency | 0.00 | 92.00 | Z-999 |
 
+</div>
+
 **Logic Breakdown:**
+
 * **Rows A-101 & A-102:** These are "child" records. Their `PaymentCurrencyBilledCost` is 0, so they provide a pointer in `PaymentCurrencyInvoiceDetailId` to Row **Z-999**, where the financial settlement value is stored.
 * **Row Z-999:** This is the "parent" record. It aggregates the costs of the children. To identify itself as the root of this conversion, its `PaymentCurrencyInvoiceDetailId` matches its own `InvoiceDetailId`.
 * **Reconciliation:** A practitioner can now sum all `BilledCost` values where `PaymentCurrencyInvoiceDetailId` is **Z-999** to verify that the $100.00 total matches the 92.00 EUR settlement using the expected exchange rate.

--- a/specification/styles/base.css
+++ b/specification/styles/base.css
@@ -153,3 +153,7 @@ ul.toc.tocdepth2 li.toc.item a {
   line-height: 125%;
   margin-top: 2em;
 }
+
+.small-table table {
+  font-size: 0.65em;
+}


### PR DESCRIPTION
Fixes for font size issues in PDF build
Found issue causing small font in branch 1500-invoice-dataset long tables are forcing the smart scaling to reduce the font of the document
Disabling smart scaling ends up causing truncation of tables so not a good option.
Changing the tables to be vertical could work but is not as the author intended
leading to this the best option to scale the long tables down to reduce the smart scaling causing the whole document to scale.