### PR TITLE
AI #2040: Address 1.3 errata in Spec and RM

### DIFF
--- a/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
+++ b/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
@@ -20,7 +20,7 @@ An attribute that allows data generators to offer more detailed cost and usage i
   * [AllocatedMethodId](#datasets.costandusage.allocatedmethodid)
   * [AllocatedResourceId](#datasets.costandusage.allocatedresourceid)
   * [AllocatedResourceName](#datasets.costandusage.allocatedresourcename)
-  * [AllocatedResourceTags](#datasets.costandusage.allocatedtags)
+  * [AllocatedTags](#datasets.costandusage.allocatedtags)
 * A FOCUS dataset SHOULD include the following column when the data generator supports data generator-calculated split cost allocation:
   * [AllocatedMethodDetails](#datasets.costandusage.allocatedmethoddetails)
 * Allocated charge records in a FOCUS dataset MUST sum up to the origin charge record for all aggregatable metric columns.

--- a/specification/datasets/cost_and_usage/columns/contractapplied.md
+++ b/specification/datasets/cost_and_usage/columns/contractapplied.md
@@ -32,7 +32,7 @@ Contract Applied consists of a valid JSON object which contains an array of key-
   * "Elements" objects MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
   * "Elements" objects MUST contain key-value pairs (contract application properties).
   * Contract application property keys SHOULD conform to [PascalCase](#glossary:pascalcase) format.
-  * "Elements" objects MUST contain four key-value pairs, representing "ContractCommitmentID", "ContractCommitmentAppliedCost", "ContractCommitmentAppliedQuantity", and "ContractCommitmentAppliedUnit".
+  * "Elements" objects MUST contain five key-value pairs, representing "ContractId", "ContractCommitmentId", "ContractCommitmentAppliedCost", "ContractCommitmentAppliedQuantity", and "ContractCommitmentAppliedUnit".
   * "Elements" objects MAY contain custom key-value pairs, representing additional datapoints provided by the data generator.
   * When custom key-value pairs within "Elements" objects are present:
     * Contract application property custom key-value pairs MUST be prefixed with a consistent `x_` prefix to identify them as external, custom columns and distinguish them from FOCUS columns to avoid conflicts in future releases.
@@ -42,7 +42,7 @@ Contract Applied consists of a valid JSON object which contains an array of key-
     * Contract application property key MUST match the spelling and casing specified for the FOCUS-defined property.
     * Contract application property value MUST be of the type specified for that property.
     * Contract application property MUST adhere to additional normative requirements specific to that property.
-  * Contract application property keys MUST begin with the string "x_" unless it is a FOCUS-defined allocation property.
+  * Contract application property keys MUST begin with the string "x_" unless it is a FOCUS-defined application property.
 
 ### Content Requirements
 
@@ -54,7 +54,7 @@ Contract ID is a service-provider-assigned identifier for a contract describing 
 
 "ContractId" property MUST adhere to the following requirements:
 
-* "ContractId" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider supports *contract commitments*.
+* "ContractId" MUST be present in an Elements object within ContractApplied when the service provider supports *contract commitments*.
 * "ContractId" MUST be of type String.
 * "ContractId" MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * "ContractId" nullability is defined as follows:
@@ -68,20 +68,20 @@ Contract ID is a service-provider-assigned identifier for a contract describing 
 
 A Contract Commitment ID is a service-provider-assigned identifier describing an agreement agreed between a service provider and a customer.  Contracts can include commitment to a certain amount of spend or usage over an agreed period of time.
 
-"ContractCommitmentID" property MUST adhere to the following requirements:
+"ContractCommitmentId" property MUST adhere to the following requirements:
 
-* "ContractCommitmentID" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider supports *contract commitments*.
-* "ContractCommitmentID" MUST be of type String.
-* "ContractCommitmentID" MUST conform to [StringHandling](#attributes.stringhandling) requirements.
-* "ContractCommitmentID" nullability is defined as follows:
-  * "ContractCommitmentID" MUST be null when a [*charge*](#glossary:charge) is not related to a *contract commitment*.
-  * "ContractCommitmentID" MUST NOT be null when a *charge* is related to a *contract commitment*.
-* When "ContractCommitmentID" is not null, "ContractCommitmentID" MUST adhere to the following requirements:
-  * "ContractCommitmentID" MUST be a unique identifier within the service provider.
-  * "ContractCommitmentID" SHOULD be a fully-qualified identifier.
-  * "ContractCommitmentID" MUST have one and only one parent "ContractID".
-  * "ContractCommitmentID" MUST be equal to ResourceID when ChargeCategory is "Purchase".
-  * "ContractCommitmentID" MAY be equal to "ContractID".
+* "ContractCommitmentId" MUST be present in an Elements object within ContractApplied when the service provider supports *contract commitments*.
+* "ContractCommitmentId" MUST be of type String.
+* "ContractCommitmentId" MUST conform to [StringHandling](#attributes.stringhandling) requirements.
+* "ContractCommitmentId" nullability is defined as follows:
+  * "ContractCommitmentId" MUST be null when a [*charge*](#glossary:charge) is not related to a *contract commitment*.
+  * "ContractCommitmentId" MUST NOT be null when a *charge* is related to a *contract commitment*.
+* When "ContractCommitmentId" is not null, "ContractCommitmentId" MUST adhere to the following requirements:
+  * "ContractCommitmentId" MUST be a unique identifier within the service provider.
+  * "ContractCommitmentId" SHOULD be a fully-qualified identifier.
+  * "ContractCommitmentId" MUST have one and only one parent "ContractId".
+  * "ContractCommitmentId" MUST be equal to ResourceId when ChargeCategory is "Purchase".
+  * "ContractCommitmentId" MAY be equal to "ContractId".
 
 <b>Contract Commitment Applied Cost</b>
 
@@ -89,7 +89,7 @@ Contract Commitment Applied Cost represents the cost of the charge applied to th
 
 "ContractCommitmentAppliedCost" property MUST adhere to the following requirements:
 
-* "ContractCommitmentAppliedCost" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider associates the *charge's* value with one or more *contract commitments*.
+* "ContractCommitmentAppliedCost" MUST be present in an Elements object within ContractApplied when the service provider associates the *charge's* value with one or more *contract commitments*.
 * "ContractCommitmentAppliedCost" MUST be of type Decimal.
 * "ContractCommitmentAppliedCost" MUST conform to [NumericFormat](#attributes.numericformat) requirements.
 * "ContractCommitmentAppliedCost" MUST adhere to the following nullability requirements:
@@ -104,7 +104,7 @@ Contract Commitment Applied Quantity represents the quantity of the charge appli
 
 "ContractCommitmentAppliedQuantity" property MUST adhere to the following requirements:
 
-* "ContractCommitmentAppliedQuantity" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider associates the *charge's* quantity with one or more *contract commitments*.
+* "ContractCommitmentAppliedQuantity" MUST be present in an Elements object within ContractApplied when the service provider associates the *charge's* quantity with one or more *contract commitments*.
 * "ContractCommitmentAppliedQuantity" MUST be of type Decimal.
 * "ContractCommitmentAppliedQuantity" MUST conform to [NumericFormat](#attributes.numericformat) requirements.
 * "ContractCommitmentAppliedQuantity" MUST adhere to the following nullability requirements:
@@ -119,7 +119,7 @@ The Contract Commitment Applied Unit represents a service-provider-specified mea
 
 The "ContractCommitmentAppliedUnit" property adheres to the following requirements:
 
-* "ContractCommitmentAppliedUnit" MUST be present in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) when the service provider associates the *charge's* quantity with one or more *contract commitments*.
+* "ContractCommitmentAppliedUnit" MUST be present in an Elements object within ContractApplied when the service provider associates the *charge's* quantity with one or more *contract commitments*.
 * "ContractCommitmentAppliedUnit" MUST be of type String.
 * "ContractCommitmentAppliedUnit" MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * "ContractCommitmentAppliedUnit" SHOULD conform to [UnitFormat](#attributes.unitformat) requirements.
@@ -143,8 +143,8 @@ The `Elements` array contains one or more objects, each of which contains the fo
 
 | Key                               | Key Type    | Feature Level | Allows Nulls | Data Type |
 | --------------------------------- | ----------- | ------------- | ------------ | --------- |
-| ContractID                        | Dimension   | Conditional   | False        | String    |
-| ContractCommitmentID              | Dimension   | Conditional   | False        | String    |
+| ContractId                        | Dimension   | Conditional   | False        | String    |
+| ContractCommitmentId              | Dimension   | Conditional   | False        | String    |
 | ContractCommitmentAppliedCost     | Dimension   | Conditional   | True         | Numeric   |
 | ContractCommitmentAppliedQuantity | Dimension   | Conditional   | True         | Numeric   |
 | ContractCommitmentAppliedUnit     | Dimension   | Conditional   | True         | String    |
@@ -154,12 +154,12 @@ The `Elements` array contains one or more objects, each of which contains the fo
 ```json
 {
   "Elements" : [ {
-    "ContractID" : "12345",
-    "ContractCommitmentID" : "23456",
+    "ContractId" : "12345",
+    "ContractCommitmentId" : "23456",
     "ContractCommitmentAppliedCost" : 500000.00
   }, {
-    "ContractID" : "12345",
-    "ContractCommitmentID" : "34567",
+    "ContractId" : "12345",
+    "ContractCommitmentId" : "34567",
     "ContractCommitmentAppliedQuantity" : 10000.00,
     "ContractCommitmentAppliedUnit" : "compute_hours"
   } ]
@@ -174,13 +174,13 @@ The `Elements` array contains one or more objects, each of which contains the fo
     "Elements": {
       "elements": {
         "properties": {
-          "ContractID": { "type": "string" },
-          "ContractCommitmentID": { "type": "string" }
+          "ContractId": { "type": "string" },
+          "ContractCommitmentId": { "type": "string" }
         },
         "optionalProperties": {
           "ContractCommitmentAppliedCost": { "type": "float64" },
           "ContractCommitmentAppliedQuantity": { "type": "float64" },
-          "ContractCommitmentAppliedUnit": { "type": "float64" }
+          "ContractCommitmentAppliedUnit": { "type": "string" }
         },
         "additionalProperties": true
       }
@@ -198,7 +198,7 @@ NOTE: The above JSON Type Definition (JTD) is an approximation of the expected c
 
 A single Cost and Usage charge represents the values stated on a contract and its three contract commitments agreed between a service provider and a customer:
 
-1) 12345: Spend $500k overall.  (This is the value of the contract, and thus ContractID = ContractCommitmentID.)
+1) 12345: Spend $500k overall.  (This is the value of the contract, and thus ContractId = ContractCommitmentId.)
 2) 23456: Spend $25k on a particular service.
 3) 34567: Consume 100k compute hours on a particular resource type.
 
@@ -206,23 +206,23 @@ The Charge Category is denoted as Purchase, and the Contract ID, Resource ID, an
 
 ```json
 {
-  "ResourceID": "12345",
+  "ResourceId": "12345",
   "ChargeCategory": "Purchase",
   "BilledCost": 500000.00,
   "EffectiveCost": 0.00,
   "ContractApplied":
     {
       "Elements": [ {
-        "ContractID": "12345",
-        "ContractCommitmentID": "12345",
+        "ContractId": "12345",
+        "ContractCommitmentId": "12345",
         "ContractCommitmentAppliedCost": 500000.00
       }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "23456",
+        "ContractId": "12345",
+        "ContractCommitmentId": "23456",
         "ContractCommitmentAppliedCost": 25000.00
       }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "34567",
+        "ContractId": "12345",
+        "ContractCommitmentId": "34567",
         "ContractCommitmentAppliedQuantity": 100000.00,
         "ContractCommitmentAppliedUnit": "compute_hours"
       } ]
@@ -239,7 +239,7 @@ This applies to the contract commitments in the following manner:
 
 ```json
 {
-  "ResourceID": "myResource1",
+  "ResourceId": "myResource1",
   "ChargeCategory": "Usage",
   "BilledCost": 0.00,
   "EffectiveCost": 30.00,
@@ -247,16 +247,16 @@ This applies to the contract commitments in the following manner:
   "ContractApplied":
     {
       "Elements": [ {
-        "ContractID": "12345",
-        "ContractCommitmentID": "12345",
+        "ContractId": "12345",
+        "ContractCommitmentId": "12345",
         "ContractCommitmentAppliedCost": 15.00
       }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "23456",
+        "ContractId": "12345",
+        "ContractCommitmentId": "23456",
         "ContractCommitmentAppliedCost": 15.00
       }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "34567",
+        "ContractId": "12345",
+        "ContractCommitmentId": "34567",
         "ContractCommitmentAppliedQuantity": 0.50,
         "ContractCommitmentAppliedUnit": "compute_hours"
       } ]
@@ -269,7 +269,7 @@ The same as Scenario 2, except a custom key-value pair `x_ContractCommitmentCost
 
 ```json
 {
-  "ResourceID": "myResource1",
+  "ResourceId": "myResource1",
   "ChargeCategory": "Usage",
   "BilledCost": 0.00,
   "EffectiveCost": 30.00,
@@ -277,18 +277,18 @@ The same as Scenario 2, except a custom key-value pair `x_ContractCommitmentCost
   "ContractApplied":
     {
       "Elements": [ {
-        "ContractID": "12345",
-        "ContractCommitmentID": "12345",
+        "ContractId": "12345",
+        "ContractCommitmentId": "12345",
         "ContractCommitmentAppliedCost": 15.00,
         "x_ContractCommitmentCostBalance": 499985.00
       }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "23456",
+        "ContractId": "12345",
+        "ContractCommitmentId": "23456",
         "ContractCommitmentAppliedCost": 15.00,
         "x_ContractCommitmentCostBalance": 24985.00
       }, {
-        "ContractID": "12345",
-        "ContractCommitmentID": "34567",
+        "ContractId": "12345",
+        "ContractCommitmentId": "34567",
         "ContractCommitmentAppliedQuantity": 0.50,
         "ContractCommitmentAppliedUnit": "compute_hours"
       } ]

--- a/specification/datasets/cost_and_usage/columns/pricingcurrency.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcurrency.md
@@ -30,7 +30,7 @@ The national or virtual currency denomination that a *resource* or *service* was
 | Dataset         | [Cost and Usage](#datasets.costandusage)             |
 | Column type     | Dimension                                            |
 | Feature level   | Conditional                                          |
-| Allows nulls    | True                                                 |
+| Allows nulls    | False                                                |
 | Data type       | String                                               |
 | Value format    | [Currency Format](#attributes.currencyformat)        |
 

--- a/specification/datasets/cost_and_usage/columns/pricingcurrencyeffectivecost.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcurrencyeffectivecost.md
@@ -35,7 +35,7 @@ The cost of the *charge* after applying all reduced rates, discounts, and the ap
 | Dataset         | [Cost and Usage](#datasets.costandusage)             |
 | Column type     | Metric                                               |
 | Feature level   | Conditional                                          |
-| Allows nulls    | True                                                 |
+| Allows nulls    | False                                                |
 | Data type       | Decimal                                              |
 | Value format    | [Numeric Format](#attributes.numericformat)          |
 | Number range    | Any valid decimal value                              |

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -48,9 +48,9 @@ The specification for the Cost and Usage dataset defines a group of columns that
 | [List Cost](#datasets.costandusage.listcost)                                                        | Metric             | Mandatory     | False        | Decimal   |
 | [List Unit Price](#datasets.costandusage.listunitprice)                                             | Metric             | Conditional   | True         | Decimal   |
 | [Pricing Category](#datasets.costandusage.pricingcategory)                                          | Dimension          | Conditional   | True         | String    |
-| [Pricing Currency](#datasets.costandusage.pricingcurrency)                                          | Dimension          | Conditional   | True         | String    |
+| [Pricing Currency](#datasets.costandusage.pricingcurrency)                                          | Dimension          | Conditional   | False        | String    |
 | [Pricing Currency Contracted Unit Price](#datasets.costandusage.pricingcurrencycontractedunitprice) | Metric             | Conditional   | True         | Decimal   |
-| [Pricing Currency Effective Cost](#datasets.costandusage.pricingcurrencyeffectivecost)              | Metric             | Conditional   | True         | Decimal   |
+| [Pricing Currency Effective Cost](#datasets.costandusage.pricingcurrencyeffectivecost)              | Metric             | Conditional   | False        | Decimal   |
 | [Pricing Currency List Unit Price](#datasets.costandusage.pricingcurrencylistunitprice)             | Metric             | Conditional   | True         | Decimal   |
 | [Pricing Quantity](#datasets.costandusage.pricingquantity)                                          | Metric             | Mandatory     | True         | Decimal   |
 | [Pricing Unit](#datasets.costandusage.pricingunit)                                                  | Dimension          | Mandatory     | True         | String    |

--- a/specification/requirements_model/releases/1.3/model_details.json
+++ b/specification/requirements_model/releases/1.3/model_details.json
@@ -1,6 +1,6 @@
 {
   "Details": {
-    "ModelVersion": "1.3",
+    "ModelVersion": "1.3.0.1",
     "FOCUSVersion": "1.3"
   }
 }

--- a/specification/requirements_model/releases/1.3/model_rules/attributes/datageneratorcalculatedsplitcostallocationhandling.json
+++ b/specification/requirements_model/releases/1.3/model_rules/attributes/datageneratorcalculatedsplitcostallocationhandling.json
@@ -96,7 +96,7 @@
     "Type": "Dynamic",
     "Order": 10,
     "ValidationCriteria": {
-      "MustSatisfy": "A FOCUS dataset MUST include the following columns when the data generator supports data generator-calculated split cost allocation: AllocatedMethodId, AllocatedResourceId, AllocatedResourceName, AllocatedResourceTags.",
+      "MustSatisfy": "A FOCUS dataset MUST include the following columns when the data generator supports data generator-calculated split cost allocation: AllocatedMethodId, AllocatedResourceId, AllocatedResourceName, AllocatedTags.",
       "Keyword": "MUST",
       "Requirement": {},
       "Condition": {},

--- a/specification/requirements_model/releases/1.3/model_rules/datasets/cost_and_usage/objects/contractappliedobject.json
+++ b/specification/requirements_model/releases/1.3/model_rules/datasets/cost_and_usage/objects/contractappliedobject.json
@@ -281,7 +281,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"Elements\" objects MUST contain four key-value pairs, representing \"ContractCommitmentID\", \"ContractCommitmentAppliedCost\", \"ContractCommitmentAppliedQuantity\", and \"ContractCommitmentAppliedUnit\".",
+      "MustSatisfy": "\"Elements\" objects MUST contain five key-value pairs, representing \"ContractId\", \"ContractCommitmentId\", \"ContractCommitmentAppliedCost\", \"ContractCommitmentAppliedQuantity\", and \"ContractCommitmentAppliedUnit\".",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "AND",
@@ -289,7 +289,12 @@
           {
             "CheckFunction": "JSONCheckPathKeyExists",
             "ColumnName": "ContractApplied",
-            "Path": "$.Elements[*].ContractCommitmentID"
+            "Path": "$.Elements[*].ContractId"
+          },
+          {
+            "CheckFunction": "JSONCheckPathKeyExists",
+            "ColumnName": "ContractApplied",
+            "Path": "$.Elements[*].ContractCommitmentId"
           },
           {
             "CheckFunction": "JSONCheckPathKeyExists",
@@ -402,7 +407,7 @@
         "Path": "$.Elements[*]",
         "Prefix": "x_",
         "IgnoreKeys": [
-          "ContractCommitmentID",
+          "ContractCommitmentId",
           "ContractCommitmentAppliedCost",
           "ContractCommitmentAppliedQuantity",
           "ContractCommitmentAppliedUnit"
@@ -586,7 +591,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "Contract application property keys MUST begin with the string \"x_\" unless it is a FOCUS-defined allocation property.",
+      "MustSatisfy": "Contract application property keys MUST begin with the string \"x_\" unless it is a FOCUS-defined application property.",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONCheckPathKeyStartsWith",
@@ -594,7 +599,8 @@
         "Path": "$.Elements[*]",
         "Prefix": "x_",
         "IgnoreKeys": [
-          "ContractCommitmentID",
+          "ContractId",
+          "ContractCommitmentId",
           "ContractCommitmentAppliedCost",
           "ContractCommitmentAppliedQuantity",
           "ContractCommitmentAppliedUnit"
@@ -673,7 +679,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractId\" MUST be present in a Cost and Usage *FOCUS Dataset* when the service provider supports *contract commitments*.",
+      "MustSatisfy": "\"ContractId\" MUST be present in an Elements object within ContractApplied when the service provider supports *contract commitments*.",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONCheckPathKeyExists",
@@ -923,7 +929,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "The \"ContractCommitmentID\" property adheres to the following requirements:",
+      "MustSatisfy": "The \"ContractCommitmentId\" property adheres to the following requirements:",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "AND",
@@ -976,12 +982,12 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" MUST be present in a Cost and Usage *FOCUS Dataset* when the service provider supports *contract commitments*.",
+      "MustSatisfy": "\"ContractCommitmentId\" MUST be present in an Elements object within ContractApplied when the service provider supports *contract commitments*.",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONCheckPathKeyExists",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentID"
+        "Path": "$.Elements[*].ContractCommitmentId"
       },
       "Condition": {},
       "Dependencies": []
@@ -1003,12 +1009,12 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" MUST be of type String.",
+      "MustSatisfy": "\"ContractCommitmentId\" MUST be of type String.",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONCheckPathType",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentID",
+        "Path": "$.Elements[*].ContractCommitmentId",
         "ExpectedType": "String"
       },
       "Condition": {},
@@ -1031,12 +1037,12 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" MUST conform to StringHandling requirements.",
+      "MustSatisfy": "\"ContractCommitmentId\" MUST conform to StringHandling requirements.",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONFormatString",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentID"
+        "Path": "$.Elements[*].ContractCommitmentId"
       },
       "Condition": {},
       "Dependencies": []
@@ -1058,7 +1064,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" nullability is defined as follows:",
+      "MustSatisfy": "\"ContractCommitmentId\" nullability is defined as follows:",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "AND",
@@ -1096,7 +1102,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Dynamic",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" MUST be null when a *charge* is not related to a *contract commitment*.",
+      "MustSatisfy": "\"ContractCommitmentId\" MUST be null when a *charge* is not related to a *contract commitment*.",
       "Keyword": "MUST",
       "Requirement": {},
       "Condition": {},
@@ -1119,7 +1125,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Dynamic",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" MUST NOT be null when a *charge* is related to a *contract commitment*.",
+      "MustSatisfy": "\"ContractCommitmentId\" MUST NOT be null when a *charge* is related to a *contract commitment*.",
       "Keyword": "MUST NOT",
       "Requirement": {},
       "Condition": {},
@@ -1142,7 +1148,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "When \"ContractCommitmentID\" is not null, \"ContractCommitmentID\" adheres to the following additional requirements:",
+      "MustSatisfy": "When \"ContractCommitmentId\" is not null, \"ContractCommitmentId\" adheres to the following additional requirements:",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "AND",
@@ -1172,7 +1178,7 @@
       "Condition": {
         "CheckFunction": "JSONCheckPathNotValue",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentID",
+        "Path": "$.Elements[*].ContractCommitmentId",
         "Value": null
       },
       "Dependencies": [
@@ -1200,7 +1206,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Dynamic",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" MUST be a unique identifier within the service provider.",
+      "MustSatisfy": "\"ContractCommitmentId\" MUST be a unique identifier within the service provider.",
       "Keyword": "MUST",
       "Requirement": {},
       "Condition": {},
@@ -1223,7 +1229,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Dynamic",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" SHOULD be a fully-qualified identifier.",
+      "MustSatisfy": "\"ContractCommitmentId\" SHOULD be a fully-qualified identifier.",
       "Keyword": "SHOULD",
       "Requirement": {},
       "Condition": {},
@@ -1246,12 +1252,12 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" MUST have one and only one parent \"ContractID\".",
+      "MustSatisfy": "\"ContractCommitmentId\" MUST have one and only one parent \"ContractId\".",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONCheckPathDistinctParent",
         "ColumnName": "ContractApplied",
-        "ChildPath": "$.Elements[*].ContractCommitmentID",
+        "ChildPath": "$.Elements[*].ContractCommitmentId",
         "ParentPath": "$.Elements[*].ContractId",
         "ExpectedCount": 1
       },
@@ -1275,12 +1281,12 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" MUST be equal to ResourceID when ChargeCategory is \"Purchase\".",
+      "MustSatisfy": "\"ContractCommitmentId\" MUST be equal to ResourceId when ChargeCategory is \"Purchase\".",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONCheckPathSameValue",
         "ColumnAName": "ContractApplied",
-        "PathA": "$.Elements[*].ContractCommitmentID",
+        "PathA": "$.Elements[*].ContractCommitmentId",
         "ColumnBName": "ResourceId",
         "PathB": null
       },
@@ -1308,7 +1314,7 @@
     "DatasetName": "Cost and Usage",
     "Type": "Dynamic",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentID\" MAY be equal to \"ContractID\".",
+      "MustSatisfy": "\"ContractCommitmentId\" MAY be equal to \"ContractId\".",
       "Keyword": "MAY",
       "Requirement": {},
       "Condition": {},
@@ -1389,12 +1395,12 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentAppliedCost\" MUST be present in a Cost and Usage *FOCUS Dataset* when the service provider associates the *charge's* value with one or more *contract commitments*.",
+      "MustSatisfy": "\"ContractCommitmentAppliedCost\" MUST be present in an Elements object within ContractApplied when the service provider associates the *charge's* value with one or more *contract commitments*.",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONCheckPathKeyExists",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentID"
+        "Path": "$.Elements[*].ContractCommitmentId"
       },
       "Condition": {},
       "Dependencies": []
@@ -1674,12 +1680,12 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentAppliedQuantity\" MUST be present in a Cost and Usage *FOCUS Dataset* when the service provider associates the *charge's* quantity with one or more *contract commitments*.",
+      "MustSatisfy": "\"ContractCommitmentAppliedQuantity\" MUST be present in an Elements object within ContractApplied when the service provider associates the *charge's* quantity with one or more *contract commitments*.",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONCheckPathKeyExists",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentID"
+        "Path": "$.Elements[*].ContractCommitmentId"
       },
       "Condition": {},
       "Dependencies": []
@@ -1954,12 +1960,12 @@
     "DatasetName": "Cost and Usage",
     "Type": "Static",
     "ValidationCriteria": {
-      "MustSatisfy": "\"ContractCommitmentAppliedUnit\" MUST be present in a Cost and Usage *FOCUS Dataset* when the service provider associates the *charge's* quantity with one or more *contract commitments*.",
+      "MustSatisfy": "\"ContractCommitmentAppliedUnit\" MUST be present in an Elements object within ContractApplied when the service provider associates the *charge's* quantity with one or more *contract commitments*.",
       "Keyword": "MUST",
       "Requirement": {
         "CheckFunction": "JSONCheckPathKeyExists",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentID"
+        "Path": "$.Elements[*].ContractCommitmentId"
       },
       "Condition": {},
       "Dependencies": []

--- a/specification/requirements_model/releases/1.3/model_rules/datasets/cost_and_usage/objects/contractappliedobject.json
+++ b/specification/requirements_model/releases/1.3/model_rules/datasets/cost_and_usage/objects/contractappliedobject.json
@@ -407,6 +407,7 @@
         "Path": "$.Elements[*]",
         "Prefix": "x_",
         "IgnoreKeys": [
+          "ContractId",
           "ContractCommitmentId",
           "ContractCommitmentAppliedCost",
           "ContractCommitmentAppliedQuantity",
@@ -1400,7 +1401,7 @@
       "Requirement": {
         "CheckFunction": "JSONCheckPathKeyExists",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentId"
+        "Path": "$.Elements[*].ContractCommitmentAppliedCost"
       },
       "Condition": {},
       "Dependencies": []
@@ -1685,7 +1686,7 @@
       "Requirement": {
         "CheckFunction": "JSONCheckPathKeyExists",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentId"
+        "Path": "$.Elements[*].ContractCommitmentAppliedQuantity"
       },
       "Condition": {},
       "Dependencies": []
@@ -1965,7 +1966,7 @@
       "Requirement": {
         "CheckFunction": "JSONCheckPathKeyExists",
         "ColumnName": "ContractApplied",
-        "Path": "$.Elements[*].ContractCommitmentId"
+        "Path": "$.Elements[*].ContractCommitmentAppliedUnit"
       },
       "Condition": {},
       "Dependencies": []


### PR DESCRIPTION
## **Summary**
This PR implements non-material errata and consistency corrections for the FOCUS v1.3 specification. These updates address drafting discrepancies and schema inconsistencies identified during the development of validation tooling, ensuring the specification is structurally sound and mathematically accurate.

**Resolves:** #2048  
**Follows Errata Process:** #2041  
**Requirements Model Version Bump:** Updated to `1.3.0.1`.

---

## **Changes Included**

### 1. Schema & Validation Logic Alignment
* **Scoped Presence Rules:** Updated normative requirements for `ContractId`, `ContractCommitmentId`, and associated `Applied` metrics. These are now correctly scoped to the `Elements` object within `ContractApplied` rather than the top-level dataset.
* **Validation Path Fixes:** Updated JSON path validation logic in the requirements model to ensure keys (like `ContractCommitmentAppliedCost`) are correctly checked within the `Elements` array.
* **JTD Type Correction:** Fixed the JSON Type Definition for `ContractCommitmentAppliedUnit`, changing it from `float64` to `string`.

### 2. Standardized Naming & Terminology
* **PascalCase Consistency:** Standardized the casing of identifiers to use `Id` instead of `ID` (e.g., `ContractId`, `ContractCommitmentId`, `ResourceId`) across all markdown documentation, JSON examples, and validation rules.
* **Column Reference Fix:** In the split cost allocation handling specification, corrected the column reference from `AllocatedResourceTags` to the correct FOCUS term: `AllocatedTags`.
* **Contextual Correction:** Changed "allocation property" to "application property" within the `ContractApplied` documentation to better reflect the domain context.

### 3. Structural & Typographical Fixes
* **Key Count Accuracy:** Updated the required key-value pair count for the `Elements` object from **four** to **five** to correctly account for the inclusion of `ContractId`.
* **Model Versioning:** Incremented the `ModelVersion` in `model_details.json` to `1.3.0.1` to reflect these technical errata.

---

## **Motivation**
These changes are strictly editorial and intended to eliminate "bugs" in the specification text. By aligning the markdown documentation with the underlying requirements model and JSON schemas, we provide data generators and validator maintainers with a consistent, unambiguous target for FOCUS v1.3 compliance.