### PR TITLE
AI #2088: Add bug classification to feedback template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -6,14 +6,14 @@ Recommended Labels: feedback, needs triage
 Suggested Assignee: @matt-cowsert
 ```
 
-_Use this template to report small corrections or suggestions that improve clarity, accuracy, or consistency in the FOCUS Specification._
+_Use this template to report corrections, clarity improvements, or bugs in the FOCUS Specification._
 
-> ⚠️ **Not sure which template to use?**
+> **Not sure which template to use?**
 > If your suggestion involves **adding, changing, or removing a data field, label, or structure**, please submit a [Feature Request](../feature_request_template.md) instead.
 
 ---
 
-### 🏢 Submitting Organization (Optional)
+### Submitting Organization (Optional)
 If you're submitting on behalf of an organization, list it here.
 
 ```
@@ -22,7 +22,7 @@ e.g., BigCloud Inc.
 
 ---
 
-### ✏️ Feedback Summary
+### Feedback Summary
 Describe the issue or suggestion. Be specific and actionable.
 
 ```
@@ -31,24 +31,25 @@ e.g., Typo in field `skuDescription` definition — should say "metered" instead
 
 ---
 
-### 📂 Type of Feedback
+### Type of Feedback
 Select the category that best describes your suggestion:
 
-- [ ] Typo or grammar  
+- [ ] Bug — incorrect or contradictory behavior in the current spec
+- [ ] Typo or grammar
   _e.g., spelling, punctuation, or wording errors_
-- [ ] Clarity improvement  
+- [ ] Clarity improvement
   _e.g., a confusing explanation, unclear table header, ambiguous instruction_
-- [ ] Field naming or label inconsistency  
+- [ ] Field naming or label inconsistency
   _e.g., same concept referred to as `region` in one section and `location` in another_
-- [ ] Definition or behavior inconsistency  
+- [ ] Definition or behavior inconsistency
   _e.g., a metric described differently across two pages or files_
-- [ ] Minor correction (non-breaking)  
+- [ ] Minor correction (non-breaking)
   _e.g., formatting tweaks, broken links, outdated references_
 - [ ] Other (please explain)
 
 ---
 
-### 📍 Affected Section or Field (Optional)
+### Affected Section or Field (Optional)
 If known, indicate where the issue appears (file path, section, or data field name).
 
 ```
@@ -57,7 +58,7 @@ e.g., /definitions/UsageRecord or spec.md#sku-capacity
 
 ---
 
-### 💬 Additional Notes (Optional)
+### Additional Notes (Optional)
 Include any extra context, examples, or links that may help maintainers understand the issue.
 
 ```

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -35,6 +35,7 @@ e.g., Typo in field `skuDescription` definition — should say "metered" instead
 Select the category that best describes your suggestion:
 
 - [ ] Bug — incorrect or contradictory behavior in the current spec
+  _e.g., a column definition that contradicts its own validation rules_
 - [ ] Typo or grammar
   _e.g., spelling, punctuation, or wording errors_
 - [ ] Clarity improvement

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -9,7 +9,7 @@ Suggested Assignee: @matt-cowsert
 _Use this template to report corrections, clarity improvements, or bugs in the FOCUS Specification._
 
 > **Not sure which template to use?**
-> If your suggestion involves **adding, changing, or removing a data field, label, or structure**, please submit a [Feature Request](../feature_request_template.md) instead.
+> If your suggestion involves **adding, changing, or removing a data field, label, or structure**, please submit a [Feature Request](feature_request_template.md) instead.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,5 +1,5 @@
 name: "General Feedback"
-description: Suggest minor corrections, clarity improvements, or report bugs in the FOCUS Specification.
+description: Report corrections, clarity improvements, or bugs in the FOCUS Specification.
 title: "[Feedback] <Brief description of issue>"
 labels: ["feedback", "needs triage"]
 assignees: ["matt-cowsert"]
@@ -35,13 +35,13 @@ body:
       label: Type of Feedback
       description: Select the option that best describes your suggestion.
       options:
-        - label: "Bug — incorrect or contradictory behavior in the current spec"
+        - label: Bug — incorrect or contradictory behavior in the current spec
         - label: Typo or grammar
         - label: Clarity improvement
         - label: Field naming or label inconsistency
         - label: Definition or behavior inconsistency
-        - label: "Minor correction (non-breaking)"
-        - label: Other
+        - label: Minor correction (non-breaking)
+        - label: Other (please explain)
 
   - type: input
     id: affected_section

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,5 +1,5 @@
 name: "General Feedback"
-description: Suggest minor corrections, clarity improvements, or inconsistencies in the FOCUS Specification.
+description: Suggest minor corrections, clarity improvements, or report bugs in the FOCUS Specification.
 title: "[Feedback] <Brief description of issue>"
 labels: ["feedback", "needs triage"]
 assignees: ["matt-cowsert"]
@@ -7,9 +7,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        _Use this form to report small corrections or suggestions that improve clarity, accuracy, or consistency._
+        _Use this form to report corrections, clarity improvements, or bugs in the FOCUS Specification._
 
-        ⚠️ **Feature-related suggestions should be submitted via the Feature Request template instead.**
+        **Feature-related suggestions should be submitted via the Feature Request template instead.**
 
   - type: input
     id: organization
@@ -35,11 +35,12 @@ body:
       label: Type of Feedback
       description: Select the option that best describes your suggestion.
       options:
+        - label: "Bug — incorrect or contradictory behavior in the current spec"
         - label: Typo or grammar
         - label: Clarity improvement
         - label: Field naming or label inconsistency
         - label: Definition or behavior inconsistency
-        - label: Minor correction (non-breaking)
+        - label: "Minor correction (non-breaking)"
         - label: Other
 
   - type: input


### PR DESCRIPTION
## Summary
- Adds "Bug — incorrect or contradictory behavior in the current spec" as the first option in the Type of Feedback checklist (both `.yml` and `.md` templates)
- Simplifies intro text to mention bugs naturally alongside corrections and clarity improvements
- Removes emojis from markdown template section headers
- Aligns "Other (please explain)" label across both templates
- Adds example description for bug option in markdown template

## Context
During the errata process discussion (re: PR #2041) in the March 9 maintainers meeting, the group agreed errata/bugs should route through the feedback template. This adds an explicit bug option to support that workflow.

Issues like #2036 could have been routed differently with a bug option available.

Tested in the [test repo](https://github.com/FinOps-Open-Cost-and-Usage-Spec/test/pull/34) first.

## Test plan
- [x] Create a test issue using the feedback template and verify the bug checkbox renders
- [x] Confirm all other feedback type options display correctly
- [x] Verify the markdown template matches the form template

🤖 Generated with [Claude Code](https://claude.com/claude-code)