### PR TITLE
AI #2068: Add MD004 asterisk to linter

### DIFF
--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -152,6 +152,8 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Non-Normative Use of “recommended”:** The lowercase word “recommended” may still be used in non-normative, descriptive text (e.g., “Feature level: Recommended”) provided it does not express a normative requirement on implementers.
 
+* **Unordered List Style:** All unordered lists in Markdown MUST use asterisks (`*`) rather than dashes (`-`) or plus signs (`+`). This maintains visual consistency across the specification and aligns with our automated linting standards.
+
 ### Example
 
 > **2.28. Pricing Quantity**

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -40,6 +40,7 @@ Grouping and ordering of dataset-level normative requirements ensures clarity, c
 ### Structuring Individual Dataset Requirements
 
 * **Start with the DatasetId**: Whenever possible, begin each requirement with the DatasetId to make the requirement clear and focused.
+* **Use Asterisks for Lists**: All unordered lists representing normative requirements must use an asterisk (`*`) for the bullet character. Do not use dashes (`-`) or plus signs (`+`). This ensures visual consistency across the specification and aligns with our automated linting standards.
 
   **Example Pattern 1**
 
@@ -161,6 +162,7 @@ Grouping and ordering of requirements ensure clarity, logical flow, and consiste
 ### Structuring Individual Column Requirements
 
 * **Start with the ColumnId**: Whenever possible, begin each requirement with the ColumnId to make the requirement clear and focused.
+* **Use Asterisks for Lists**: All unordered lists representing normative requirements MUST use an asterisk (`*`) for the bullet character. Do not use dashes (`-`) or plus signs (`+`). This ensures visual consistency across the specification and aligns with our automated linting standards.
 
   **Example Pattern 1**
 

--- a/specification/markdownlnt.cfg
+++ b/specification/markdownlnt.cfg
@@ -1,5 +1,6 @@
 {
   "plugins" : {
+    "MD004" : { "style": "asterisk" },
     "MD033" : { "enabled" : false },
     "MD013" : { "enabled" : false },
     "MD031" : { "enabled" : false },


### PR DESCRIPTION
## Background

FOCUS spec markdown files use `*` for unordered list markers. The default pymarkdownlnt MD004 rule is `consistent` (follows first list marker in each file). A change to enforce `asterisk` globally was proposed in PR #1877 but deferred.

## Problem

- formatters in VSCode convert `*` list markers to `-`, breaking MD004 when the existing file uses `*`
- Without `asterisk` enforcement, contributors using prettier will introduce lint failures
- Current `consistent` mode works only because existing files all start with `*`

## Proposed Change

In `specification/markdownlnt.cfg`, add:

```json
"MD004": { "style": "asterisk" }
```

## Discussion

- **@mike-finopsorg** ([comment](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/1877#discussion_r2920981862)): Wants justification — "what errors are you fighting without changing this to asterisk?"
- **@ljadvey** ([reply](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/1877)): prettier converts `*` to `-`, can't use prettier for FOCUS markdown without this
- **@shawnalpay** ([comment](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/1877#discussion_r2937375576)): Deferred to @mike-finopsorg given his experience with the linter

## Alternatives

1. **Enforce `asterisk`** — aligns with all existing FOCUS files, prevents prettier conflicts
2. **Keep `consistent`** — less opinionated, works today since all files already start with `*`