### PR TITLE
FR #1124: TagDetails JSON restructure to PR #1904 (Version 2)

### DIFF
--- a/specification/appendix/json_object_examples/json_object_examples.mdpp
+++ b/specification/appendix/json_object_examples/json_object_examples.mdpp
@@ -2,3 +2,4 @@
 !INCLUDE "allocated_method_details_examples.md",1
 !INCLUDE "contract_applied_examples.md",1
 !INCLUDE "contract_commitment_applicability_examples.md",1
+!INCLUDE "tag_details_examples.md",1

--- a/specification/appendix/json_object_examples/tag_details_examples.md
+++ b/specification/appendix/json_object_examples/tag_details_examples.md
@@ -1,10 +1,16 @@
 # Examples: Tag Details
 
-The JSON samples in the scenarios below each represent the `TagDetails` object for a single charge. They detail the provenance and eligibility of tags across various tag sources and schemes, illustrating how the finalized tags were derived.
+The scenarios below illustrate the relationship between the [TagDetails](#datasets.costandusage.tagdetails) and [Tags](#datasets.costandusage.tags) columns for a single charge. 
+
+For each scenario, two JSON samples are provided:
+1. **`TagDetails`:** Details the provenance and eligibility of tags across various tag sources and schemes, showing how the finalized tags were derived.
+2. **`Tags`:** The resulting finalized key-value pairs as they would appear in the `Tags` column for that exact same charge.
 
 ## Scenario 1: Standard resource and ancestor tags
 
 A common scenario where tags are applied directly to the resource but are also inherited from ancestor sources. In this case, the tag `env` is finalized from the resource, but was also present on an ancestor. The tag `owner` is only finalized from an ancestor source.
+
+### `TagDetails` Column
 
 ```json
 {
@@ -33,9 +39,20 @@ A common scenario where tags are applied directly to the resource but are also i
 }
 ```
 
+### `Tags` Column
+
+```json
+{
+  "env": "prod",
+  "owner": "team-alpha"
+}
+```
+
 ## Scenario 2: Ancestor tags only
 
 The charge has no tags finalized directly at the primary source level (e.g., an API request or a resource that wasn't directly tagged), but tags are inherited from an ancestor level. The finalized `TagSource`, `TagSourceId`, and `TagValue` are null, and the value is only found within the `AncestorTaggedSources` object.
+
+### `TagDetails` Column
 
 ```json
 {
@@ -60,9 +77,19 @@ The charge has no tags finalized directly at the primary source level (e.g., an 
 }
 ```
 
+### `Tags` Column
+
+*(The column would be null or contain an empty object, as no tags were finalized)*
+
+```json
+{}
+```
+
 ## Scenario 3: Eligible sources with no tags applied
 
 The charge originates from sources that support tagging for the specified scheme, but no tags were applied. This is critical for calculating accurate tag coverage. The `Tags` object is empty, and the eligible sources are listed in `UntaggedSources`.
+
+### `TagDetails` Column
 
 ```json
 {
@@ -77,9 +104,17 @@ The charge originates from sources that support tagging for the specified scheme
 }
 ```
 
+### `Tags` Column
+
+```json
+{}
+```
+
 ## Scenario 4: Multiple schemes with valueless and provider-defined tags
 
 The data generator supports multiple tag schemes. One scheme uses a valueless label (represented as a boolean `true`), while a provider-defined scheme includes non-string values like numbers and booleans.
+
+### `TagDetails` Column
 
 ```json
 {
@@ -127,9 +162,22 @@ The data generator supports multiple tag schemes. One scheme uses a valueless la
 }
 ```
 
+### `Tags` Column
+
+```json
+{
+  "department": "finance",
+  "userDefinedValuelessLabelScheme/project_foci": true,
+  "providerDefinedTagScheme/is_spot_instance": false,
+  "providerDefinedTagScheme/k8s_version": 1.29
+}
+```
+
 ## Scenario 5: Additional non-FOCUS specified properties
 
 A data generator can add custom properties if they feel more context is helpful or necessary to the practitioner. Custom keys must be prefixed with `x_` followed by PascalCase. In this scenario, the data generator is supplying an internal metadata ID and a policy enforcement status alongside the standard tag data.
+
+### `TagDetails` Column
 
 ```json
 {
@@ -147,5 +195,13 @@ A data generator can add custom properties if they feel more context is helpful 
     },
     "UntaggedSources": null
   }
+}
+```
+
+### `Tags` Column
+
+```json
+{
+  "costcenter": "cc-404"
 }
 ```

--- a/specification/appendix/json_object_examples/tag_details_examples.md
+++ b/specification/appendix/json_object_examples/tag_details_examples.md
@@ -1,6 +1,6 @@
 # Examples: Tag Details
 
-The scenarios below illustrate the relationship between the [TagDetails](#datasets.costandusage.tagdetails) and [Tags](#datasets.costandusage.tags) columns for a single charge. 
+The scenarios below illustrate the relationship between the [TagDetails](#datasets.costandusage.tagdetails) and [Tags](#datasets.costandusage.tags) columns for a single charge.
 
 For each scenario, two JSON samples are provided:
 1. **`TagDetails`:** Details the provenance and eligibility of tags across various tag sources and schemes, showing how the finalized tags were derived.
@@ -79,7 +79,7 @@ The charge has no tags finalized directly at the primary source level (e.g., an 
 
 ### `Tags` Column
 
-*(The column would be null or contain an empty object, as no tags were finalized)*
+(The column would be null or contain an empty object, as no tags were finalized.)
 
 ```json
 {}

--- a/specification/appendix/json_object_examples/tag_details_examples.md
+++ b/specification/appendix/json_object_examples/tag_details_examples.md
@@ -1,0 +1,151 @@
+# Examples: Tag Details
+
+The JSON samples in the scenarios below each represent the `TagDetails` object for a single charge. They detail the provenance and eligibility of tags across various tag sources and schemes, illustrating how the finalized tags were derived.
+
+## Scenario 1: Standard resource and ancestor tags
+
+A common scenario where tags are applied directly to the resource but are also inherited from ancestor sources. In this case, the tag `env` is finalized from the resource, but was also present on an ancestor. The tag `owner` is only finalized from an ancestor source.
+
+```json
+{
+  "Default": {
+    "Tags": {
+      "env": {
+        "TagSource": "Resource",
+        "TagSourceId": "i-1234567890abcdef0",
+        "TagValue": "prod",
+        "AncestorTaggedSources": {
+          "Resource Group": {
+            "TagSourceId": "rg-frontend-01",
+            "TagValue": "dev"
+          }
+        }
+      },
+      "owner": {
+        "TagSource": "Subscription",
+        "TagSourceId": "sub-987654321",
+        "TagValue": "team-alpha",
+        "AncestorTaggedSources": null
+      }
+    },
+    "UntaggedSources": null
+  }
+}
+```
+
+## Scenario 2: Ancestor tags only
+
+The charge has no tags finalized directly at the primary source level (e.g., an API request or a resource that wasn't directly tagged), but tags are inherited from an ancestor level. The finalized `TagSource`, `TagSourceId`, and `TagValue` are null, and the value is only found within the `AncestorTaggedSources` object.
+
+```json
+{
+  "Default": {
+    "Tags": {
+      "project": {
+        "TagSource": null,
+        "TagSourceId": null,
+        "TagValue": null,
+        "AncestorTaggedSources": {
+          "Project": {
+            "TagSourceId": "gcp-project-8675309",
+            "TagValue": "backend-api"
+          }
+        }
+      }
+    },
+    "UntaggedSources": [
+      "Resource"
+    ]
+  }
+}
+```
+
+## Scenario 3: Eligible sources with no tags applied
+
+The charge originates from sources that support tagging for the specified scheme, but no tags were applied. This is critical for calculating accurate tag coverage. The `Tags` object is empty, and the eligible sources are listed in `UntaggedSources`.
+
+```json
+{
+  "Default": {
+    "Tags": {},
+    "UntaggedSources": [
+      "Resource",
+      "Resource Group",
+      "Subscription"
+    ]
+  }
+}
+```
+
+## Scenario 4: Multiple schemes with valueless and provider-defined tags
+
+The data generator supports multiple tag schemes. One scheme uses a valueless label (represented as a boolean `true`), while a provider-defined scheme includes non-string values like numbers and booleans.
+
+```json
+{
+  "Default": {
+    "Tags": {
+      "department": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": "finance",
+        "AncestorTaggedSources": null
+      }
+    },
+    "UntaggedSources": null
+  },
+  "userDefinedValuelessLabelScheme": {
+    "Tags": {
+      "project_foci": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": true,
+        "AncestorTaggedSources": null
+      }
+    },
+    "UntaggedSources": [
+      "Resource Group"
+    ]
+  },
+  "providerDefinedTagScheme": {
+    "Tags": {
+      "is_spot_instance": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": false,
+        "AncestorTaggedSources": null
+      },
+      "k8s_version": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": 1.29,
+        "AncestorTaggedSources": null
+      }
+    },
+    "UntaggedSources": null
+  }
+}
+```
+
+## Scenario 5: Additional non-FOCUS specified properties
+
+A data generator can add custom properties if they feel more context is helpful or necessary to the practitioner. Custom keys must be prefixed with `x_` followed by PascalCase. In this scenario, the data generator is supplying an internal metadata ID and a policy enforcement status alongside the standard tag data.
+
+```json
+{
+  "Default": {
+    "x_InternalTaggingSystemId": "sys-998877",
+    "Tags": {
+      "costcenter": {
+        "TagSource": "Resource",
+        "TagSourceId": "i-1234567890abcdef0",
+        "TagValue": "cc-404",
+        "AncestorTaggedSources": null,
+        "x_EnforcementPolicy": "Strict",
+        "x_AppliedBy": "terraform-svc-account"
+      }
+    },
+    "UntaggedSources": null
+  }
+}
+```

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -62,7 +62,7 @@ Each tag scheme object (including `Default`) contains the following entries:
 | `Tags` | Object | True | An object containing all tag keys present in the Tags column for this scheme. |
 | `UntaggedSources` | Array | True | A list of sources which support this tag scheme (i.e. are taggable) that had no tags applied. |
 
-### Tags Object (Tag Key)
+### Tag Key Object
 
 The tag key object contains the properties of the *finalized tag* as well as other *tag sources* where this key was present:
 

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -60,7 +60,7 @@ Each tag scheme object (including `Default`) contains the following entries:
 | Key | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `Tags` | Object | True | An object containing all tag keys present in the Tags column for this scheme. |
-| `UntaggedSources` | Array | True | A list of sources which support this tag scheme (i.e. are taggable) that had no tags applied. |
+| `UntaggedSources` | Array or Null | True | A list of sources which support this tag scheme (i.e. are taggable) that had no tags applied. |
 
 ### Tag Key Object
 

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -99,65 +99,68 @@ Here is a basic example of the object format containing multiple tag schemes and
 
 ```json
 {
-  "Default": {
-    "Tags": {
-      "foo": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": "baz",
-        "AncestorTaggedSources": {
-          "Subscription": {
-            "TagSourceId": "1234-abcd-5678",
-            "TagValue": "bar"
-          },
-          "Resource Group": {
-            "TagSourceId": "/subscriptions/1234-abcd-5678/resourceGroups/myresourcegroup",
-            "TagValue": "bang"
-          }
-        }
-      },
-      "lorem": {
-        "TagSource": "Resource Group",
-        "TagSourceId": "/subscriptions/1234-abcd-5678/resourceGroups/myresourcegroup",
-        "TagValue": "ipsum",
-        "AncestorTaggedSources": {
-          "Subscription": {
-            "TagSourceId": "1234-abcd-5678",
-            "TagValue": "adest"
-          }
-        }
-      }
-    },
-    "UntaggedSources": null
-  },
-  "userDefinedValuelessLabelScheme": {
-    "Tags": {
-      "project_foci": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": true,
-        "AncestorTaggedSources": null
-      }
-    },
-    "UntaggedSources": ["Resource Group", "Subscription"]
-  },
-  "providerDefinedTagScheme": {
-    "Tags": {
-      "isfeatureenabled": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": false,
-        "AncestorTaggedSources": null
-      },
-      "versionnumber": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": 12.2,
-        "AncestorTaggedSources": null
-      }
-    },
-    "UntaggedSources": null
-  }
+  "Default": {
+    "Tags": {
+      "foo": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": "baz",
+        "AncestorTaggedSources": {
+          "Subscription": {
+            "TagSourceId": "1234-abcd-5678",
+            "TagValue": "bar"
+          },
+          "Resource Group": {
+            "TagSourceId": "/subscriptions/1234-abcd-5678/resourceGroups/myresourcegroup",
+            "TagValue": "bang"
+          }
+        }
+      },
+      "lorem": {
+        "TagSource": "Resource Group",
+        "TagSourceId": "/subscriptions/1234-abcd-5678/resourceGroups/myresourcegroup",
+        "TagValue": "ipsum",
+        "AncestorTaggedSources": {
+          "Subscription": {
+            "TagSourceId": "1234-abcd-5678",
+            "TagValue": "adest"
+          }
+        }
+      }
+    },
+    "UntaggedSources": null
+  },
+  "userDefinedValuelessLabelScheme": {
+    "Tags": {
+      "project_foci": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": true,
+        "AncestorTaggedSources": null
+      }
+    },
+    "UntaggedSources": [
+      "Resource Group",
+      "Subscription"
+    ]
+  },
+  "providerDefinedTagScheme": {
+    "Tags": {
+      "isfeatureenabled": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": false,
+        "AncestorTaggedSources": null
+      },
+      "versionnumber": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": 12.2,
+        "AncestorTaggedSources": null
+      }
+    },
+    "UntaggedSources": null
+  }
 }
 ```
 

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -73,7 +73,7 @@ The tag key object contains the properties of the *finalized tag* as well as oth
 | `TagValue` | String, Boolean, Number, or Null | True |  The value associated with the tag key. |
 | `AncestorTaggedSources` | Object or Null | True | An object containing all *tag sources* where the corresponding tag key was present which did not result in the *finalized tag*. |
 
-### Ancestor Tagged Sources Object
+### Ancestor Tagged Source Object
 
 The ancestor tag source object contains the properties of the tag present in the *tag source*:
 

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -6,455 +6,174 @@ The Tag Details column is a superset of [Tags](#tags) which includes additional 
 
 ### Column Requirements
 
-The TagDetails column adheres to the following requirements:
+TagDetails MUST adhere to the following requirements:
 
-* TagDetails MUST be of type String.
+* TagDetails MUST be of type JSON Object (serialized as a String where necessary).
 * TagDetails MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * TagDetails MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
-* TagDetails nullability is defined as follows:
+* TagDetails MUST adhere to the following nullability requirements:
   * TagDetails MUST NOT be null unless all of the following are true:
     * Tags column is null.
     * Tags are not present in any other *tag sources*.
-    * No *tag sources* are supported for any user-defined [*tag scheme*](glossary:tag-scheme).
+    * No *tag sources* are supported for any user-defined [*tag scheme*](#glossary:tag-scheme).
+* TagDetails MUST conform to [TagDetailsObject](#datasets.costandusage.tagdetails.tagdetailsobject) requirements when TagDetails is not null.
 
-### Object Schema Requirements
+## Tag Details Object
 
-Tag Details consists of a valid JSON object which contains objects for one or more *tag schemes* which each contain an object describing the tags as well as an array of eligible *tag sources* which do not contain tags.
+Tag Details consists of a valid JSON object which contains objects for one or more *tag schemes*, each of which contains an object describing the tags as well as an array of eligible *tag sources* which do not contain tags.
 
-When TagDetails is not null, the JsonObjectFormat for TagDetails adheres to the following requirements:
+The following section details the normative requirements for the TagDetailsObject and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datasets.costandusage.tagdetails.schemastructure) and [Object Example](#datasets.costandusage.tagdetails.objectexample) sections.
 
-* TagDetails root object MUST contain an object for each tag scheme present in Tags.
-  * The key for each tag scheme object MUST align to the tag prefix (up to but not including the forward slash) used to define the tag scheme in Tags.
-  * The key for the unprefixed user-defined tag scheme in Tags MUST be "Default".
-* Each tag scheme object MUST contain an object for each tag key applied to any tag source in that tag scheme.
-  * Each tag key object MUST contain FOCUS-defined tag properties.
-  * FOCUS-defined tag properties are subject to the additional requirements:
-    * Tag property key MUST match the spelling and casing specified for the FOCUS-defined property.
-    * Tag property value MUST be of the type specified for that property.
-    * Tag properties MUST adhere to additional normative requirements specific to that property.
-  * Each tag key object MUST contain an object with the key "AncestorTaggedSources".
-    * The value of AncestorTaggedSources MUST be null when the tag key from the corresponding tag key object within the tag scheme is not present in any *tag source* other than the *tag source* which results in the *finalized tag*.
-    * When the value of AncestorTaggedSources is not null, each object in AncestorTaggedSources MUST have a key denoting the *tag source*.
-      * Each tag source object MUST contain FOCUS-defined tag properties.
-    * AncestorTaggedSources SHOULD contain objects for *tag sources* which did not result in the *finalized tag*.
-* Each tag scheme object MUST contain an array with the key "UntaggedSources".
-  * UntaggedSources array MUST contain all *tag sources* for the corresponding tag scheme which are eligible to be tagged for the *charge* but have no tags applied.
-  * The value of UntaggedSources MUST be null when there are no eligible *tag sources* which contain no tags.
+### Object Requirements
 
-### Content Requirements
+The TagDetailsObject MUST adhere to the following requirements:
 
-The following keys are used for tag properties to facilitate standardized extraction of data across providers. FOCUS-defined keys will appear in the list below and data generator-defined keys will be prefixed with "x_" to make them easy to identify as well as prevent collisions.
+* TagDetailsObject MUST conform to the [TagDetailsObjectSchema](#schemas.datasets.costandusage.tagdetailsobjectschema) JSON Schema.
+* TagDetailsObject root object MUST contain an object for each tag scheme present in Tags.
+  * TagDetailsObject.{\*} keys MUST align to the tag prefix (up to but not including the forward slash) used to define the tag scheme in Tags.
+  * TagDetailsObject.Default MUST be used to represent the unprefixed user-defined tag scheme in Tags.
+* TagDetailsObject.{TagScheme} MUST contain an array with the key "UntaggedSources".
+  * TagDetailsObject.{TagScheme}.UntaggedSources[\*] MUST contain all *tag sources* for the corresponding tag scheme which are eligible to be tagged for the *charge* but have no tags applied.
+  * TagDetailsObject.{TagScheme}.UntaggedSources[\*] MUST be null when there are no eligible *tag sources* which contain no tags.
+* TagDetailsObject.{TagScheme} MUST contain an object for each tag key applied to any tag source in that tag scheme under the key "Tags".
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey} MUST contain FOCUS-defined tag properties.
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagSource MUST be present in each tag key object in the Tags object and MUST contain the type of *tag source* where the tag key is present.
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagSourceId MUST be present and MUST contain the identifier of the TagSource.
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagValue MUST be present and MUST represent the *finalized tag*.
+    * TagValue MUST have the value of true (boolean) when the TagScheme does not support values.
+    * Data generator MUST NOT alter tag values unless applying true (boolean) to valueless tags.
+    * TagValue MAY be null when the data generator supports setting a null value for a key-value pair type tag.
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey} MUST contain an object with the key "AncestorTaggedSources".
+    * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources MUST be null when the tag key from the corresponding tag key object within the tag scheme is not present in any *tag source* other than the *tag source* which results in the *finalized tag*.
+    * When TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources is not null, each object in AncestorTaggedSources MUST have a key denoting the *tag source*.
+      * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources.{TagSource} MUST contain FOCUS-defined tag properties.
+      * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources.{TagSource}.TagSourceId MUST be present and MUST contain the identifier of the TagSource.
+      * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources.{TagSource}.TagValue MUST be present and MUST adhere to the same boolean/null conditional logic as the finalized TagValue.
+    * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources SHOULD contain objects for *tag sources* which did not result in the *finalized tag*.
 
-<b>TagValue</b>
+## Schema Structure
 
-"TagValue" represents the tag value associated with the tag key for the corresponding tag scheme and *tag source*.
+TagDetails contains a structured JSON object defining tag eligibility and provenance from all tag sources.
 
-The "TagValue" property adheres to the following requirements:
+### Top-Level Properties
 
-* TagValue MUST be present in each tag key object in the Tags object.
-* When TagValue is directly contained in the tag key object, TagValue MUST represent the *finalized tag*.
-* TagValue MUST be present in each tag source object in the AncestorTaggedSources object.
-* TagValue MUST have the value of true (boolean) when the TagScheme does not support values.
-* Data generator MUST NOT alter tag values unless applying true (boolean) to valueless tags.
-* TagValue MAY be null when the data generator supports setting a null value for a key-value pair type tag.
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `Default` | Object | True | The object containing information about the unprefixed tag scheme in the Tags column. |
+| `*{TagScheme}*` | Object | True | One or more objects containing information about a prefixed tag scheme in the Tags column. |
 
-<b>TagSource</b>
+### Tag Scheme Object
 
-"TagSource" denotes the type of *tag source* where the tag key is present.
+Each tag scheme object (including `Default`) contains the following entries:
 
-The "TagSource" property adheres to the following requirements:
+| Key | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `Tags` | Object | True | An object containing all tag keys present in the Tags column for this scheme. |
+| `UntaggedSources` | Array | True | A list of sources which support this tag scheme (i.e. are taggable) that had no tags applied. |
 
-* TagSource MUST be present in each tag key object in the Tags object.
-* TagSource MUST NOT be present in each tag source object in the AncestorTaggedSources object.
-* TagSource MUST contain the type of *tag source* where the tag key is present.
+### Tags Object (Tag Key)
 
-<b>TagSourceId</b>
+The tag key object contains the properties of the *finalized tag* as well as other *tag sources* where this key was present:
 
-"TagSourceId" denotes the identifier of the specific *tag source* where the tag key is present.
+| Key | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `TagSource` | String | True | The type of *tag source* where the tag key is present. |
+| `TagSourceId` | String | True | The identifier of the *tag source* where the tag key is present. |
+| `TagValue` | String, Boolean, or Number | True |  The value associated with the tag key. |
+| `AncestorTaggedSources` | Object | True | An object containing all *tag sources* where the corresponding tag key was present which did not result in the *finalized tag*. |
 
-The "TagSourceId" property adheres to the following requirements:
+### Ancestor Tagged Sources Object
 
-* TagSourceId MUST be present in each tag key object in the Tags object.
-* TagSourceId MUST be present in each tag source object in the AncestorTaggedSources object.
-* TagSourceId MUST contain the identifier of the TagSource.
+The ancestor tag source object contains the properties of the tag present in the *tag source*:
 
-## Overview
+| Key | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `TagSourceId` | String | True | The identifier of the *tag source* where the tag key is present. |
+| `TagValue` | String, Boolean, or Number | True |  The value associated with the tag key. |
 
-### Object Schema
+## Object Example
 
-The object contains an object for each tag scheme present in the Tags column.
+Here is a basic example of the object format containing multiple tag schemes and sources.
 
-| Key | Parent | ValueType | Required | Description |
-| ----- | ---- | ---- | ---------- | ----------- |
-| Default | _root object_ | Object | TRUE | The object containing information about the unprefixed tag scheme in the Tags column. |
-| _TagScheme_ | _root object_ | Object | TRUE | One or more objects containing information about a prefixed tag scheme in the Tags column. |
-| Tags | _tag scheme object_ | Object | TRUE | An object containing all tag keys present in the Tags column. |
-| UntaggedSources | _tag scheme object_ | Array | TRUE | A list of sources which support this tag scheme (i.e. are taggable) that had no tags applied. |
-| _TagKey_ | Tags | Object | TRUE | An object containing the properties of the *finalized tag* as well as other *tag sources* where this key was present. |
-| AncestorTaggedSources | _TagKey_ | Object | TRUE | An object containing all *tag sources* where the corresponding tag key was present which did not result in the *finalized tag*. |
-| _AncestorTaggedSource_ | AncestorTaggedSources | Object | Conditional | An object containing the properties of the tag present in the *tag source*. |
-
-### Object Entries
-
-The tag key object contains the following properties:
-
-| Key | ValueType | Required | Description |
-| ----- | ---- | ---------- | ----------- |
-| TagSource | String | TRUE | The type of *tag source* where the tag key is present. |
-| TagSourceId | String | TRUE | The identifier of the *tag source* where the tag key is present. |
-| TagValue | String, Boolean, or Number | TRUE |  The value associated with the tag key. |
-
-The ancestor tag source object contains the following properties:
-
-| Key | ValueType | Required | Description |
-| ----- | ---- | ---------- | ----------- |
-| TagSourceId | String | TRUE | The identifier of the *tag source* where the tag key is present. |
-| TagValue | String, Boolean, or Number | TRUE |  The value associated with the tag key. |
-
-### Example
+* For the JSON schema, please see [Tag Details Object Schema](#schemas.datasets.costandusage.tagdetailsobjectschema).
 
 ```json
 {
-  "Default": {
-    "Tags": {
-      "foo": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": "baz",
-        "AncestorTaggedSources": {
-          "Subscription": {
-            "TagSourceId": "/subs/#",
-            "TagValue": "foo"
-          },
-          "Resource Group": {
-            "TagSourceId": "/subs/#/rgs/x",
-            "TagValue": "bar"
-          }
-        }
-      }
-    },
-    "UntaggedSources": ["CustomSourceOne"]
-  },
-  "userDefinedTagScheme2": {
-    "Tags": {
-      "foo": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": "bar",
-        "AncestorTaggedSources": null
-      }
-    },
-    "UntaggedSources": null
-  },
-  "userDefinedTagScheme3": {
-    "Tags": {
-      "foo": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": "bar",
-        "AncestorTaggedSources": null
-      }
-    },
-    "UntaggedSources": null
-  },
-  "providerDefinedTagScheme1": {
-    "Tags": {
-      "foo": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": "bar",
-        "AncestorTaggedSources": null
-      }
-    },
-    "UntaggedSources": null
-  },
-  "providerDefinedTagScheme2": {
-    "Tags": {
-      "foo": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": "bar",
-        "AncestorTaggedSources": null
-      }
-    },
-    "UntaggedSources": null
-  }
+  "Default": {
+    "Tags": {
+      "foo": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": "baz",
+        "AncestorTaggedSources": {
+          "Subscription": {
+            "TagSourceId": "1234-abcd-5678",
+            "TagValue": "bar"
+          },
+          "Resource Group": {
+            "TagSourceId": "/subscriptions/1234-abcd-5678/resourceGroups/myresourcegroup",
+            "TagValue": "bang"
+          }
+        }
+      },
+      "lorem": {
+        "TagSource": "Resource Group",
+        "TagSourceId": "/subscriptions/1234-abcd-5678/resourceGroups/myresourcegroup",
+        "TagValue": "ipsum",
+        "AncestorTaggedSources": {
+          "Subscription": {
+            "TagSourceId": "1234-abcd-5678",
+            "TagValue": "adest"
+          }
+        }
+      }
+    },
+    "UntaggedSources": null
+  },
+  "userDefinedValuelessLabelScheme": {
+    "Tags": {
+      "project_foci": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": true,
+        "AncestorTaggedSources": null
+      }
+    },
+    "UntaggedSources": ["Resource Group", "Subscription"]
+  },
+  "providerDefinedTagScheme": {
+    "Tags": {
+      "isfeatureenabled": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": false,
+        "AncestorTaggedSources": null
+      },
+      "versionnumber": {
+        "TagSource": "Resource",
+        "TagSourceId": "my-resource-11",
+        "TagValue": 12.2,
+        "AncestorTaggedSources": null
+      }
+    },
+    "UntaggedSources": null
+  }
 }
 ```
 
-The corresponding Tags column would be:
+## Implementation Guidance
 
-```json
-{
-  "foo":"baz",
-  "userDefinedTagScheme2/foo":"bar",
-  "userDefinedTagScheme3/foo":"bar",
-  "providerDefinedTagScheme1/foo":"bar",
-  "providerDefinedTagScheme2/foo":"bar"
-}
-```
+### Custom Properties
 
-### JSON Schema Definition
+To facilitate querying data across tagging systems and data generators, a data generator may include one or more custom properties nested within the individual schema or element objects. Custom keys must be prefixed with "x_" followed by PascalCase format (e.g., `x_MyCustomKey`) to make them easy to identify as well as prevent collisions with FOCUS-defined keys.
 
-```json
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://focus.finops.org/schemas/tagdetails.json",
-  "title": "TagDetails",
-  "description": "A superset of Tags which includes additional properties describing tag eligibility and tag provenance from all tag sources.",
-  "type": "object",
-  "patternProperties": {
-    "^[a-zA-Z0-9_]+$": {
-      "$ref": "#/$defs/tagScheme"
-    }
-  },
-  "additionalProperties": false,
-  "$defs": {
-    "tagScheme": {
-      "type": "object",
-      "properties": {
-        "Tags": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9_]+$": {
-              "$ref": "#/$defs/tagKeyObject"
-            }
-          },
-          "additionalProperties": false
-        },
-        "UntaggedSources": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": [
-        "Tags",
-        "UntaggedSources"
-      ]
-    },
-    "tagKeyObject": {
-      "type": "object",
-      "properties": {
-        "TagSource": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "The source of the finalized tag. Can be null if the tag is only present on an ancestor."
-        },
-        "TagSourceId": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "The ID of the finalized tag's source. Can be null if the tag is only present on an ancestor."
-        },
-        "TagValue": {
-          "description": "The finalized tag value. Can be null, indicating it doesn't appear in the Tags column.",
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "AncestorTaggedSources": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "patternProperties": {
-            "^[a-zA-Z0-9_ ]+$": {
-              "$ref": "#/$defs/ancestorTag"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "required": [
-        "TagSource",
-        "TagSourceId",
-        "TagValue",
-        "AncestorTaggedSources"
-      ]
-    },
-    "ancestorTag": {
-      "type": "object",
-      "properties": {
-        "TagSourceId": {
-          "type": "string"
-        },
-        "TagValue": {
-          "description": "The tag value from an ancestor source.",
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "required": [
-        "TagSourceId",
-        "TagValue"
-      ]
-    }
-  }
-}
-```
+### Object ID
 
-## Example Scenarios
+TagDetailsObject
 
-### Ancestor tags only
+### Object Display Name
 
-Details:
-* One Tag Scheme supported (default).
-* Charge is for API usage which has no resource to tag, but this charge does support job tagging in the API request payload.
-  * No tags were applied in the API request payload.
-* One tag was applied at the ancestor level.
-
-```json
-{
-  "Default": {
-    "Tags": {
-      "foo": {
-        "TagSource": null,
-        "TagSourceId": null,
-        "TagValue": null,
-        "AncestorTaggedSources": {
-          "Project": {
-            "TagSourceId": "gcp-project-8675309",
-            "TagValue": "bar"
-          }
-        }
-      }
-    },
-    "UntaggedSources": ["api-job-label"]
-  }
-}
-```
-
-The corresponding Tags column would either be null or contain an empty object:
-
-```json
-{}
-```
-
-### Tags from multiple sources and schemes with different value types
-
-Details:
-* 3 tag schemes are used:
-  * User defined tags (default)
-    * Provider supports tag finalization via inheritance.
-    * First tag (foo) is set at the resource level as well as ancestor levels.
-    * Second tag (lorem) is applied at ancestor levels.
-      * One of the values from an ancestor is included in Tags column due to tag finalization process.
-    * There are no other supported sources for tags to be applied for this charge.
-  * userDefinedValuelessLabelScheme
-    * Label scheme is valueless so boolean `true` is provided as value to represent the presence of the label.
-    * User has set the label (project_foci) on the resource.
-    * Label scheme is supported on ancestor levels, but no labels have been set on either.
-  * providerDefinedTagScheme
-    * Provider has tag scheme which is only applicable at the resource level.
-    * First tag (isfeatureenabled) is boolean.
-    * Second tag (versionnumber) is numeric.
-
-```json
-{
-  "Default": {
-    "Tags": {
-      "foo": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": "baz",
-        "AncestorTaggedSources": {
-          "Subscription": {
-            "TagSourceId": "1234-abcd-5678",
-            "TagValue": "bar"
-          },
-          "Resource Group": {
-            "TagSourceId": "/subscriptions/1234-abcd-5678/resourceGroups/myresourcegroup",
-            "TagValue": "bang"
-          }
-        }
-      },
-      "lorem": {
-        "TagSource": "Resource Group",
-        "TagSourceId": "/subscriptions/1234-abcd-5678/resourceGroups/myresourcegroup",
-        "TagValue": "ipsum",
-        "AncestorTaggedSources": {
-          "Subscription": {
-            "TagSourceId": "1234-abcd-5678",
-            "TagValue": "adest"
-          }
-        }
-      }
-    },
-    "UntaggedSources": null
-  },
-  "userDefinedValuelessLabelScheme": {
-    "Tags": {
-      "project_foci": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": true,
-        "AncestorTaggedSources": null
-      }
-    },
-    "UntaggedSources": ["Resource Group", "Subscription"]
-  },
-  "providerDefinedTagScheme": {
-    "Tags": {
-      "isfeatureenabled": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": false,
-        "AncestorTaggedSources": null
-      },
-      "versionnumber": {
-        "TagSource": "Resource",
-        "TagSourceId": "my-resource-11",
-        "TagValue": 12.2,
-        "AncestorTaggedSources": null
-      }
-    },
-    "UntaggedSources": null
-  }
-}
-```
-
-The corresponding Tags column would contain:
-
-```json
-{
-"foo": "baz",
-"lorem": "ipsum",
-"userDefinedValuelessLabelScheme/project_foci": true,
-"providerDefinedTagScheme/isfeatureenabled": false,
-"providerDefinedTagScheme/versionnumber": 12.2
-}
-```
+Tag Details Object
 
 ## Column ID
 
@@ -466,17 +185,19 @@ Tag Details
 
 ## Description
 
-The superset of Tags which includes additional properties describing tag eligibility and tag provenance from all *tag sources,* both provider-defined and user-defined.
+The superset of Tags which includes additional properties describing tag eligibility and tag provenance from all *tag sources*, both provider-defined and user-defined.
 
 ## Content Constraints
 
-| Constraint      | Value           |
-|:----------------|:----------------|
-| Column type     | Dimension       |
-| Feature level   | Recommended     |
-| Allows nulls    | True            |
-| Data type       | JSON            |
-| Value format    | [JSON Object Format](#attributes.jsonobjectformat) |
+| Constraint | Value |
+| :--- | :--- |
+| Dataset | [Cost and Usage](#datasets.costandusage) |
+| Column type | Dimension |
+| Feature level | Recommended |
+| Allows nulls | True |
+| Data type | JSON |
+| Value format | [JSON Object Format](#attributes.jsonobjectformat) |
+| Object | [TagDetailsObject](#datasets.costandusage.tagdetails.tagdetailsobject) |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -77,10 +77,10 @@ The tag key object contains the properties of the *finalized tag* as well as oth
 
 | Key | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| `TagSource` | String | True | The type of *tag source* where the tag key is present. |
-| `TagSourceId` | String | True | The identifier of the *tag source* where the tag key is present. |
-| `TagValue` | String, Boolean, or Number | True |  The value associated with the tag key. |
-| `AncestorTaggedSources` | Object | True | An object containing all *tag sources* where the corresponding tag key was present which did not result in the *finalized tag*. |
+| `TagSource` | String or Null | True | The type of *tag source* where the tag key is present. |
+| `TagSourceId` | String or Null | True | The identifier of the *tag source* where the tag key is present. |
+| `TagValue` | String, Boolean, Number, or Null | True |  The value associated with the tag key. |
+| `AncestorTaggedSources` | Object or Null | True | An object containing all *tag sources* where the corresponding tag key was present which did not result in the *finalized tag*. |
 
 ### Ancestor Tagged Sources Object
 
@@ -89,7 +89,7 @@ The ancestor tag source object contains the properties of the tag present in the
 | Key | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `TagSourceId` | String | True | The identifier of the *tag source* where the tag key is present. |
-| `TagValue` | String, Boolean, or Number | True |  The value associated with the tag key. |
+| `TagValue` | String, Boolean, Number, or Null | True |  The value associated with the tag key. |
 
 ## Object Example
 

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -86,6 +86,7 @@ The ancestor tag source object contains the properties of the tag present in the
 
 Here is a basic example of the object format containing multiple tag schemes and sources.
 
+* For more detailed scenarios, including side-by-side comparisons with the corresponding `Tags` column, please see the [Tag Details Examples](#appendix.examples:jsonobject.examples:tagdetails) appendix.
 * For the JSON schema, please see [Tag Details Object Schema](#schemas.datasets.costandusage.tagdetailsobjectschema).
 
 ```json

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -11,12 +11,8 @@ TagDetails MUST adhere to the following requirements:
 * TagDetails MUST be of type JSON Object (serialized as a String where necessary).
 * TagDetails MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * TagDetails MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
-* TagDetails MUST adhere to the following nullability requirements:
-  * TagDetails MUST NOT be null unless all of the following are true:
-    * Tags column is null.
-    * Tags are not present in any other *tag sources*.
-    * No *tag sources* are supported for any user-defined [*tag scheme*](#glossary:tag-scheme).
-* TagDetails MUST conform to [TagDetailsObject](#datasets.costandusage.tagdetails.tagdetailsobject) requirements when TagDetails is not null.
+* TagDetails MUST be null when [Tags](#datasets.costandusage.tags) is null, tags are not present in any other *tag sources*, and no *tag sources* are supported for any user-defined [*tag scheme*](#glossary:tag-scheme).
+* TagDetails MUST conform to the [TagDetailsObjectSchema](#schemas.datasets.costandusage.tagdetailsobjectschema) JSON Schema.
 
 ## Tag Details Object
 
@@ -28,28 +24,23 @@ The following section details the normative requirements for the TagDetailsObjec
 
 The TagDetailsObject MUST adhere to the following requirements:
 
-* TagDetailsObject MUST conform to the [TagDetailsObjectSchema](#schemas.datasets.costandusage.tagdetailsobjectschema) JSON Schema.
-* TagDetailsObject root object MUST contain an object for each tag scheme present in Tags.
-  * TagDetailsObject.{\*} keys MUST align to the tag prefix (up to but not including the forward slash) used to define the tag scheme in Tags.
-  * TagDetailsObject.Default MUST be used to represent the unprefixed user-defined tag scheme in Tags.
-* TagDetailsObject.{TagScheme} MUST contain an array with the key "UntaggedSources".
-  * TagDetailsObject.{TagScheme}.UntaggedSources[\*] MUST contain all *tag sources* for the corresponding tag scheme which are eligible to be tagged for the *charge* but have no tags applied.
-  * TagDetailsObject.{TagScheme}.UntaggedSources[\*] MUST be null when there are no eligible *tag sources* which contain no tags.
-* TagDetailsObject.{TagScheme} MUST contain an object for each tag key applied to any tag source in that tag scheme under the key "Tags".
-  * TagDetailsObject.{TagScheme}.Tags.{TagKey} MUST contain FOCUS-defined tag properties.
-  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagSource MUST be present in each tag key object in the Tags object and MUST contain the type of *tag source* where the tag key is present.
-  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagSourceId MUST be present and MUST contain the identifier of the TagSource.
-  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagValue MUST be present and MUST represent the *finalized tag*.
-    * TagValue MUST have the value of true (boolean) when the TagScheme does not support values.
-    * Data generator MUST NOT alter tag values unless applying true (boolean) to valueless tags.
-    * TagValue MAY be null when the data generator supports setting a null value for a key-value pair type tag.
-  * TagDetailsObject.{TagScheme}.Tags.{TagKey} MUST contain an object with the key "AncestorTaggedSources".
-    * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources MUST be null when the tag key from the corresponding tag key object within the tag scheme is not present in any *tag source* other than the *tag source* which results in the *finalized tag*.
-    * When TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources is not null, each object in AncestorTaggedSources MUST have a key denoting the *tag source*.
-      * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources.{TagSource} MUST contain FOCUS-defined tag properties.
-      * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources.{TagSource}.TagSourceId MUST be present and MUST contain the identifier of the TagSource.
-      * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources.{TagSource}.TagValue MUST be present and MUST adhere to the same boolean/null conditional logic as the finalized TagValue.
-    * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources SHOULD contain objects for *tag sources* which did not result in the *finalized tag*.
+* TagDetailsObject.{\*} keys MUST align to the tag prefix (up to but not including the forward slash) used to define the tag scheme in Tags.
+* TagDetailsObject.Default MUST be used to represent the unprefixed user-defined tag scheme in Tags.
+* TagDetailsObject.{TagScheme}.UntaggedSources[\*] MUST contain all *tag sources* for the corresponding tag scheme which are eligible to be tagged for the *charge* but have no tags applied.
+* TagDetailsObject.{TagScheme}.UntaggedSources MUST be null when there are no eligible *tag sources* which contain no tags.
+* TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagSource MUST contain the type of *tag source* where the tag key is present.
+* TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagSourceId MUST contain the identifier of the TagSource.
+* TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagValue MUST represent the *finalized tag*.
+* When TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagValue is not null, TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagValue adheres to the following additional requirements:
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagValue MUST have the value of true (boolean) when the tag scheme does not support values.
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagValue MUST NOT be altered from the original tag value unless applying true (boolean) to valueless tags.
+* TagDetailsObject.{TagScheme}.Tags.{TagKey}.TagValue MAY be null when setting a null value is supported for a key-value pair type tag.
+* TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources MUST be null when the tag key from the corresponding tag key object within the tag scheme is not present in any *tag source* other than the *tag source* which results in the *finalized tag*.
+* When TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources is not null, TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources adheres to the following additional requirements:
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources.{TagSource} key MUST denote the *tag source*.
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources.{TagSource}.TagSourceId MUST contain the identifier of the TagSource.
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources.{TagSource}.TagValue MUST adhere to the same boolean/null conditional logic as the finalized TagValue.
+  * TagDetailsObject.{TagScheme}.Tags.{TagKey}.AncestorTaggedSources SHOULD contain objects for *tag sources* which did not result in the *finalized tag*.
 
 ## Schema Structure
 

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -53,7 +53,7 @@ TagDetails contains a structured JSON object defining tag eligibility and proven
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| `Default` | Object | True | The object containing information about the unprefixed tag scheme in the Tags column. |
+| `Default` | Object | Conditional | The object containing information about the unprefixed tag scheme in the Tags column. |
 | `*{TagScheme}*` | Object | True | One or more objects containing information about a prefixed tag scheme in the Tags column. |
 
 ### Tag Scheme Object

--- a/specification/datasets/cost_and_usage/columns/tagdetails.md
+++ b/specification/datasets/cost_and_usage/columns/tagdetails.md
@@ -11,7 +11,10 @@ TagDetails MUST adhere to the following requirements:
 * TagDetails MUST be of type JSON Object (serialized as a String where necessary).
 * TagDetails MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * TagDetails MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
-* TagDetails MUST be null when [Tags](#datasets.costandusage.tags) is null, tags are not present in any other *tag sources*, and no *tag sources* are supported for any user-defined [*tag scheme*](#glossary:tag-scheme).
+* TagDetails MUST adhere to the following nullability requirements:
+  * TagDetails MUST NOT be null when [Tags](#datasets.costandusage.tags) is not null.
+  * TagDetails MUST NOT be null when tags are present in any *tag sources* which did not result in *finalized* tags.
+  * TagDetails MUST NOT be null when *tag sources* are supported for any user-defined [*tag scheme*](#glossary:tag-scheme) which could have contained tags.
 * TagDetails MUST conform to the [TagDetailsObjectSchema](#schemas.datasets.costandusage.tagdetailsobjectschema) JSON Schema.
 
 ## Tag Details Object

--- a/specification/schemas/datasets/cost_and_usage/tagdetailsobjectschema.json
+++ b/specification/schemas/datasets/cost_and_usage/tagdetailsobjectschema.json
@@ -9,7 +9,7 @@
         "^x_[A-Z][a-zA-Z0-9]*$": {
             "description": "Custom data generator-defined top-level properties prefixed with x_ in PascalCase format"
         },
-        "^(?!x_[A-Z])[a-zA-Z0-9_]+$": {
+        "^(?!x_[A-Z]).+$": {
             "description": "Objects containing information about a tag scheme (including 'Default') in the Tags column",
             "$ref": "#/$defs/tagScheme"
         }
@@ -29,7 +29,7 @@
                         "^x_[A-Z][a-zA-Z0-9]*$": {
                             "description": "Custom data generator-defined properties prefixed with x_ in PascalCase format"
                         },
-                        "^(?!x_[A-Z])[a-zA-Z0-9_]+$": {
+                        "^(?!x_[A-Z]).+$": {
                             "$ref": "#/$defs/tagKeyObject"
                         }
                     },
@@ -95,7 +95,7 @@
                         "^x_[A-Z][a-zA-Z0-9]*$": {
                             "description": "Custom data generator-defined properties prefixed with x_ in PascalCase format"
                         },
-                        "^(?!x_[A-Z])[a-zA-Z0-9_ ]+$": {
+                        "^(?!x_[A-Z]).+$": {
                             "$ref": "#/$defs/ancestorTag"
                         }
                     },

--- a/specification/schemas/datasets/cost_and_usage/tagdetailsobjectschema.json
+++ b/specification/schemas/datasets/cost_and_usage/tagdetailsobjectschema.json
@@ -18,6 +18,7 @@
     "$defs": {
         "tagScheme": {
             "type": "object",
+            "description": "An object containing information about a specific tag scheme, including its tags and eligible untagged sources.",
             "required": [
                 "Tags",
                 "UntaggedSources"
@@ -55,6 +56,7 @@
         },
         "tagKeyObject": {
             "type": "object",
+            "description": "An object containing the properties of a finalized tag as well as other tag sources where this key was present.",
             "required": [
                 "TagSource",
                 "TagSourceId",
@@ -111,6 +113,7 @@
         },
         "ancestorTag": {
             "type": "object",
+            "description": "An object containing the properties of a tag present in an ancestor tag source.",
             "required": [
                 "TagSourceId",
                 "TagValue"

--- a/specification/schemas/datasets/cost_and_usage/tagdetailsobjectschema.json
+++ b/specification/schemas/datasets/cost_and_usage/tagdetailsobjectschema.json
@@ -1,0 +1,149 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://focus.finops.org/schemas/tagdetailsobject.json",
+    "title": "Tag Details Object",
+    "description": "Schema for validating the Tag Details column JSON object structure in FOCUS datasets",
+    "type": "object",
+    "required": [
+        "Default"
+    ],
+    "properties": {
+        "Default": {
+            "description": "The object containing information about the unprefixed tag scheme in the Tags column",
+            "$ref": "#/$defs/tagScheme"
+        }
+    },
+    "patternProperties": {
+        "^x_[A-Z][a-zA-Z0-9]*$": {
+            "description": "Custom data generator-defined top-level properties prefixed with x_ in PascalCase format"
+        },
+        "^(?!x_[A-Z])[a-zA-Z0-9_]+$": {
+            "description": "Objects containing information about a prefixed tag scheme in the Tags column",
+            "$ref": "#/$defs/tagScheme"
+        }
+    },
+    "additionalProperties": false,
+    "$defs": {
+        "tagScheme": {
+            "type": "object",
+            "required": [
+                "Tags",
+                "UntaggedSources"
+            ],
+            "properties": {
+                "Tags": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x_[A-Z][a-zA-Z0-9]*$": {
+                            "description": "Custom data generator-defined properties prefixed with x_ in PascalCase format"
+                        },
+                        "^(?!x_[A-Z])[a-zA-Z0-9_]+$": {
+                            "$ref": "#/$defs/tagKeyObject"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UntaggedSources": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "description": "A list of sources which support this tag scheme that had no tags applied",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x_[A-Z][a-zA-Z0-9]*$": {
+                    "description": "Custom data generator-defined properties prefixed with x_ in PascalCase format"
+                }
+            },
+            "additionalProperties": false
+        },
+        "tagKeyObject": {
+            "type": "object",
+            "required": [
+                "TagSource",
+                "TagSourceId",
+                "TagValue",
+                "AncestorTaggedSources"
+            ],
+            "properties": {
+                "TagSource": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The type of tag source where the tag key is present. Can be null if only present on an ancestor."
+                },
+                "TagSourceId": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The identifier of the tag source where the tag key is present. Can be null if only present on an ancestor."
+                },
+                "TagValue": {
+                    "type": [
+                        "string",
+                        "boolean",
+                        "number",
+                        "null"
+                    ],
+                    "description": "The finalized tag value. Can be null, indicating it doesn't appear in the Tags column."
+                },
+                "AncestorTaggedSources": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "description": "An object containing all tag sources where the tag key was present which did not result in the finalized tag.",
+                    "patternProperties": {
+                        "^x_[A-Z][a-zA-Z0-9]*$": {
+                            "description": "Custom data generator-defined properties prefixed with x_ in PascalCase format"
+                        },
+                        "^(?!x_[A-Z])[a-zA-Z0-9_ ]+$": {
+                            "$ref": "#/$defs/ancestorTag"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "patternProperties": {
+                "^x_[A-Z][a-zA-Z0-9]*$": {
+                    "description": "Custom data generator-defined properties prefixed with x_ in PascalCase format"
+                }
+            },
+            "additionalProperties": false
+        },
+        "ancestorTag": {
+            "type": "object",
+            "required": [
+                "TagSourceId",
+                "TagValue"
+            ],
+            "properties": {
+                "TagSourceId": {
+                    "type": "string",
+                    "description": "The identifier of the tag source where the tag key is present."
+                },
+                "TagValue": {
+                    "type": [
+                        "string",
+                        "boolean",
+                        "number",
+                        "null"
+                    ],
+                    "description": "The tag value from an ancestor source."
+                }
+            },
+            "patternProperties": {
+                "^x_[A-Z][a-zA-Z0-9]*$": {
+                    "description": "Custom data generator-defined properties prefixed with x_ in PascalCase format"
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/specification/schemas/datasets/cost_and_usage/tagdetailsobjectschema.json
+++ b/specification/schemas/datasets/cost_and_usage/tagdetailsobjectschema.json
@@ -4,21 +4,13 @@
     "title": "Tag Details Object",
     "description": "Schema for validating the Tag Details column JSON object structure in FOCUS datasets",
     "type": "object",
-    "required": [
-        "Default"
-    ],
-    "properties": {
-        "Default": {
-            "description": "The object containing information about the unprefixed tag scheme in the Tags column",
-            "$ref": "#/$defs/tagScheme"
-        }
-    },
+    "minProperties": 1,
     "patternProperties": {
         "^x_[A-Z][a-zA-Z0-9]*$": {
             "description": "Custom data generator-defined top-level properties prefixed with x_ in PascalCase format"
         },
         "^(?!x_[A-Z])[a-zA-Z0-9_]+$": {
-            "description": "Objects containing information about a prefixed tag scheme in the Tags column",
+            "description": "Objects containing information about a tag scheme (including 'Default') in the Tags column",
             "$ref": "#/$defs/tagScheme"
         }
     },

--- a/specification/schemas/schemas.mdpp
+++ b/specification/schemas/schemas.mdpp
@@ -29,3 +29,11 @@ The Contract Applied Object Schema defines the structure for the [Contract Appli
 [Download from GitHub](/specification/schemas/datasets/cost_and_usage/contractappliedobjectschema.json)
 
 !INCLUDECODE "schemas/datasets/cost_and_usage/contractappliedobjectschema.json" (json)
+
+### Tag Details Object Schema
+
+The Tag Details Object Schema defines the structure for the [Tag Details](#datasets.costandusage.tagdetails) column.
+
+[Download from GitHub](/specification/schemas/datasets/cost_and_usage/tagdetailsobjectschema.json)
+
+!INCLUDECODE "schemas/datasets/cost_and_usage/tagdetailsobjectschema.json" (json)


### PR DESCRIPTION
(Proposed replacement for PR #2078)

### 📖 Summary
This PR significantly refactors the `TagDetails` column documentation to match the newly established structural conventions used by `AllocatedMethodDetails`. It introduces a formal, robust JSON Schema for `TagDetails` validation, adds comprehensive real-world examples to the appendix, and resolves several underlying formatting and linting issues.

### 🛠️ Key Changes
* **Structural Alignment:** Reorganized `tagdetails.md` to cleanly separate *Column Requirements*, *Object Requirements*, *Schema Structure*, and *Implementation Guidance*, mirroring the `AllocatedMethodDetails` layout.
* **JSON Schema Introduction (`tagdetailsobjectschema.json`):** * Created a formal JSON Schema to validate `TagDetails` objects.
  * **Smart Regex:** Implemented a negative lookahead regex (`^(?!x_[A-Z]).+$`) for Tag Schemes and Tag Keys. This safely allows all real-world cloud tag characters (hyphens, periods, colons, etc.) while strictly protecting the `x_PascalCase` custom property namespace.
  * **Dynamic Validation:** Dropped the hardcoded requirement for the `Default` object in favor of `minProperties: 1`, correctly allowing charges that *only* have provider-defined tags to validate successfully.
* **Markdown Table & Nullability Fixes:** Updated the *Schema Structure* tables to accurately reflect nullability (e.g., `String or Null`, `String, Boolean, Number, or Null`), synchronizing the text with the JSON Schema and the "Ancestor tags only" use cases.
* **Comprehensive Examples (`tag_details_examples.md`):** Added 5 distinct, standard-space indented JSON scenarios to the appendix covering standard inheritance, ancestor-only tags, untagged sources, valueless labels, and custom `x_` properties. Hooked them up via `json_object_examples.mdpp`.
* **Markdown Linter Fixes:** Scrubbed invisible Non-Breaking Spaces (NBSPs) from the documentation and JSON code blocks that were previously causing `MD037` markdown linter errors.

### ✅ Verification
* Verified that dot-notation object paths (`TagDetailsObject.{TagScheme}.Tags.{TagKey}`) and array paths (`UntaggedSources[*]`) are used correctly in the normative text.
* Verified that the JSON schema safely validates edge cases (e.g., when a tag only exists on an ancestor source and primary fields are `null`).
* Hooked the new schema into `schemas.mdpp` for proper documentation generation.