### PR TITLE
AI #1940: Order datasets by feature level, then alphabetically

### DIFF
--- a/specification/datasets/data_model.md
+++ b/specification/datasets/data_model.md
@@ -4,9 +4,11 @@ FOCUS defines many individual datasets made up of a selected set of columns whic
 
 ## Dataset List<!--SkipTOC-->
 
+Datasets are sorted first by Feature Level (i.e., Mandatory, then Conditional), then alphabetically by name.
+
 | Dataset                                             | Dataset Type | Feature Level | Description                                                                                                   |
 | --------------------------------------------------- | ------------ | ------------- | ------------------------------------------------------------------------------------------------------------- |
+| [Cost and Usage](#datasets.costandusage)            | Transaction  | Mandatory     | Describes the cost and usage incurred through using or purchasing a service provider's resources or services. |
 | [Billing Period](#datasets.billingperiod)           | Reference    | Conditional   | Describes the billing periods by which cost and usage is invoiced.                                            |
 | [Contract Commitment](#datasets.contractcommitment) | Reference    | Conditional   | Describes the terms of contracts agreed between a service provider and a customer.                            |
-| [Cost and Usage](#datasets.costandusage)            | Transaction  | Mandatory     | Describes the cost and usage incurred through using or purchasing a service provider's resources or services. |
 | [Invoice Detail](#datasets.invoicedetail)           | Transaction  | Conditional   | Describes the cost and usage issued on invoices.                                                              |

--- a/specification/datasets/datasets.mdpp
+++ b/specification/datasets/datasets.mdpp
@@ -1,5 +1,5 @@
 !INCLUDE "data_model.md",0
 !INCLUDE "cost_and_usage/cost_and_usage.mdpp",1
+!INCLUDE "billing_period/billing_period.mdpp",1
 !INCLUDE "contract_commitment/contract_commitment.mdpp",1
 !INCLUDE "invoice_detail/invoice_detail.mdpp",1
-!INCLUDE "billing_period/billing_period.mdpp",1


### PR DESCRIPTION
## Summary

This PR establishes a clear sorting convention for the Dataset List in the specification and updates the documentation and include files to reflect this new order.

* **`specification/datasets/data_model.md`**: 
    * Added a clarification note stating that datasets are now sorted first by Feature Level (Mandatory, then Conditional), followed by alphabetical order.
    * Reordered the Dataset List table to comply with this rule, moving the mandatory `Cost and Usage` dataset to the top of the list.
* **`specification/datasets/datasets.mdpp`**: 
    * Reordered the `!INCLUDE` statements to match the new sorting order.

### Type of Change
- [ ] Bug fix
- [ ] New feature / Specification update
- [x] Editorial / Formatting

### Author Checklist
- [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
- [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
- [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
