### PR TITLE
FR #1389: Complete move of column presence requirements to dataset level

### DIFF
--- a/specification/datasets/contract_commitment/columns/contractcommitmentdiscountpercentage.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentdiscountpercentage.md
@@ -35,13 +35,14 @@ ContractCommitmentDiscountPercentage MUST adhere to the following requirements:
 
 * ContractCommitmentDiscountPercentage MUST be of type Decimal.
 * ContractCommitmentDiscountPercentage MUST conform to [NumericFormat](#attributes.numericformat) requirements.
-* ContractCommitmentDiscountPercentage MUST NOT be null if [ContractCommitmentBenefitCategory](#datasets.contractcommitment.contractcommitmentbenefitcategory) is "Discount".
-* ContractCommitmentDiscountPercentage MUST be null if ContractCommitmentBenefitCategory is "Availability".
+* ContractCommitmentDiscountPercentage MUST adhere to the following nullability requirements:
+  * ContractCommitmentDiscountPercentage MUST NOT be null when [ContractCommitmentBenefitCategory](#datasets.contractcommitment.contractcommitmentbenefitcategory) is "Discount".
+  * ContractCommitmentDiscountPercentage MUST be null when ContractCommitmentBenefitCategory is "Availability".
 * ContractCommitmentDiscountPercentage MUST be a value between 0.0 and 1.0, inclusive.
 * For contracts with multiple tiers (e.g., 5% discount up to 1M, 10% above 1M), ContractCommitmentDiscountPercentage MUST adhere to the following additional requirements:
   * ContractCommitmentDiscountPercentage MUST reflect the discount percentage defined for the specific pricing tier represented by the Contract Commitment row.
   * ContractCommitmentDiscountPercentage MUST correspond to only one pricing tier per Contract Commitment row.
-* ContractCommitmentDiscountPercentage SHOULD represent the net effective discount if multiple contractual layers are applicable (e.g., a negotiated discount on top of a standard commitment).
+* ContractCommitmentDiscountPercentage SHOULD represent the net effective discount when multiple contractual layers are applicable (e.g., a negotiated discount on top of a standard commitment).
 
 ## Column ID
 

--- a/specification/datasets/cost_and_usage/columns/pricingcurrencycontractedunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcurrencycontractedunitprice.md
@@ -6,9 +6,6 @@ The Pricing Currency Contracted Unit Price represents the agreed-upon unit price
 
 PricingCurrencyContractedUnitPrice MUST adhere to the following requirements:
 
-* PricingCurrencyContractedUnitPrice presence in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) MUST adhere to the following presence requirements:
-  * PricingCurrencyContractedUnitPrice SHOULD be present in a Cost and Usage *FOCUS dataset* when the service provider supports pricing and billing in different currencies and publishes unit prices exclusive of discounts.
-  * PricingCurrencyContractedUnitPrice MAY be present in a Cost and Usage *FOCUS dataset* in all other cases.
 * PricingCurrencyContractedUnitPrice MUST be of type Decimal.
 * PricingCurrencyContractedUnitPrice MUST conform to [NumericFormat](#attributes.numericformat) requirements.
 * PricingCurrencyContractedUnitPrice MUST adhere to the following nullability requirements:

--- a/specification/datasets/cost_and_usage/columns/pricingcurrencyeffectivecost.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcurrencyeffectivecost.md
@@ -6,9 +6,6 @@ The Pricing Currency Effective Cost represents the cost of the [*charge*](#gloss
 
 PricingCurrencyEffectiveCost MUST adhere to the following requirements:
 
-* PricingCurrencyEffectiveCost presence in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) MUST adhere to the following presence requirements:
-  * PricingCurrencyEffectiveCost SHOULD be present in a Cost and Usage *FOCUS dataset* when the service provider supports pricing and billing in different currencies and publishes unit prices exclusive of discounts.
-  * PricingCurrencyEffectiveCost MAY be present in a Cost and Usage *FOCUS dataset* in all other cases.
 * PricingCurrencyEffectiveCost MUST be of type Decimal.
 * PricingCurrencyEffectiveCost MUST conform to [NumericFormat](#attributes.numericformat) requirements.
 * PricingCurrencyEffectiveCost MUST NOT be null.

--- a/specification/datasets/cost_and_usage/columns/pricingcurrencylistunitprice.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcurrencylistunitprice.md
@@ -6,9 +6,6 @@ The Pricing Currency List Unit Price represents the suggested service-provider-p
 
 PricingCurrencyListUnitPrice MUST adhere to the following requirements:
 
-* PricingCurrencyListUnitPrice presence in a Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) MUST adhere to the following presence requirements:
-  * PricingCurrencyListUnitPrice SHOULD be present in a Cost and Usage *FOCUS dataset* when the service provider supports pricing and billing in different currencies and publishes unit prices exclusive of discounts.
-  * PricingCurrencyListUnitPrice MAY be present in a Cost and Usage *FOCUS dataset* in all other cases.
 * PricingCurrencyListUnitPrice MUST be of type Decimal.
 * PricingCurrencyListUnitPrice MUST conform to [NumericFormat](#attributes.numericformat) requirements.
 * PricingCurrencyListUnitPrice MUST adhere to the following nullability requirements:

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -132,9 +132,18 @@ CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MUST include [ListUnitPrice](#datasets.costandusage.listunitprice) when the service provider publishes unit prices exclusive of discounts.
   * CostAndUsage MUST include [PricingCategory](#datasets.costandusage.pricingcategory) when the service provider supports more than one pricing category across all [*SKUs*](#glossary:sku).
   * CostAndUsage MUST include [PricingCurrency](#datasets.costandusage.pricingcurrency) when the service provider supports pricing and billing in different currencies.
-  * CostAndUsage MUST include [PricingCurrencyContractedUnitPrice](#datasets.costandusage.pricingcurrencycontractedunitprice) when the service provider supports prices in virtual currency and publishes unit prices exclusive of discounts.
-  * CostAndUsage MUST include [PricingCurrencyEffectiveCost](#datasets.costandusage.pricingcurrencyeffectivecost) when the service provider supports prices in virtual currency and publishes unit prices exclusive of discounts.
-  * CostAndUsage MUST include [PricingCurrencyListUnitPrice](#datasets.costandusage.pricingcurrencylistunitprice) when the service provider supports prices in virtual currency and publishes unit prices exclusive of discounts.
+  * CostAndUsage MUST adhere to the following [PricingCurrencyContractedUnitPrice](#datasets.costandusage.pricingcurrencycontractedunitprice) presence requirements:
+    * CostAndUsage MUST include PricingCurrencyContractedUnitPrice when the service provider supports prices in virtual currency and publishes unit prices exclusive of discounts.
+    * CostAndUsage SHOULD include PricingCurrencyContractedUnitPrice when the service provider supports pricing and billing in different currencies and publishes unit prices exclusive of discounts.
+    * CostAndUsage MAY include PricingCurrencyContractedUnitPrice in all other cases.
+  * CostAndUsage MUST adhere to the following [PricingCurrencyEffectiveCost](#datasets.costandusage.pricingcurrencyeffectivecost) presence requirements:
+    * CostAndUsage MUST include PricingCurrencyEffectiveCost when the service provider supports prices in virtual currency and publishes unit prices exclusive of discounts.
+    * CostAndUsage SHOULD include PricingCurrencyEffectiveCost when the service provider supports pricing and billing in different currencies and publishes unit prices exclusive of discounts.
+    * CostAndUsage MAY include PricingCurrencyEffectiveCost in all other cases.
+  * CostAndUsage MUST adhere to the following [PricingCurrencyListUnitPrice](#datasets.costandusage.pricingcurrencyeffectivecost) presence requirements:
+    * CostAndUsage MUST include PricingCurrencyListUnitPrice when the service provider supports prices in virtual currency and publishes unit prices exclusive of discounts.
+    * CostAndUsage SHOULD include PricingCurrencyListUnitPrice when the service provider supports pricing and billing in different currencies and publishes unit prices exclusive of discounts.
+    * CostAndUsage MAY include PricingCurrencyListUnitPrice in all other cases.
   * CostAndUsage MUST include [PricingQuantity](#datasets.costandusage.pricingquantity).
   * CostAndUsage MUST include [PricingUnit](#datasets.costandusage.pricingunit).
   * CostAndUsage MUST include [RegionId](#datasets.costandusage.regionid) when the host provider supports deploying resources or services within a region.

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -140,7 +140,7 @@ CostAndUsage MUST adhere to the following requirements:
     * CostAndUsage MUST include PricingCurrencyEffectiveCost when the service provider supports prices in virtual currency and publishes unit prices exclusive of discounts.
     * CostAndUsage SHOULD include PricingCurrencyEffectiveCost when the service provider supports pricing and billing in different currencies and publishes unit prices exclusive of discounts.
     * CostAndUsage MAY include PricingCurrencyEffectiveCost in all other cases.
-  * CostAndUsage MUST adhere to the following [PricingCurrencyListUnitPrice](#datasets.costandusage.pricingcurrencyeffectivecost) presence requirements:
+  * CostAndUsage MUST adhere to the following [PricingCurrencyListUnitPrice](#datasets.costandusage.pricingcurrencylistunitprice) presence requirements:
     * CostAndUsage MUST include PricingCurrencyListUnitPrice when the service provider supports prices in virtual currency and publishes unit prices exclusive of discounts.
     * CostAndUsage SHOULD include PricingCurrencyListUnitPrice when the service provider supports pricing and billing in different currencies and publishes unit prices exclusive of discounts.
     * CostAndUsage MAY include PricingCurrencyListUnitPrice in all other cases.


### PR DESCRIPTION
## Summary

PR #1865 attempted to move all column presence requirements to the dataset level.  There are three columns that had a composite presence requirement that were not fully ported over in that PR.

This PR finishes the move of those requirements for the following columns:

* `CostAndUsage.PricingCurrencyContractedUnitPrice`
* `CostAndUsage.PricingCurrencyEffectiveCost`
* `CostAndUsage.PricingCurrencyListUnitPrice`

I have also applied a composite nullability (per editorial guidelines) on:

* `ContractCommitment.ContractCommitmentDiscountPercentage`

### Type of Change
- [x] Bug fix
- [ ] New feature / Specification update
- [ ] Editorial / Formatting

### Author Checklist
- [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
- [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
- [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
