### PR TITLE
AI #2163: Implement Floating Release for `working_draft` Artifacts

### DIFF
--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -5,6 +5,10 @@ on:
       - "main"
       - "candidate_recommendation"
 
+# This permission is required for the action to overwrite tags/releases
+permissions:
+  contents: write
+
 jobs:
   # The job that will use the container image you just pushed to ghcr.io
   gen_pdf:
@@ -39,7 +43,7 @@ jobs:
         with:
           name: spec.md
           path: specification/spec.md
-      - name: Upload Spec
+      - name: Upload Spec (Native CI Artifact)
         uses: actions/upload-artifact@v4
         with:
           name: FOCUS_specification
@@ -49,3 +53,17 @@ jobs:
             specification/images/*
             specification/styles/*
             specification/requirements_model/build/*.json
+      - name: Update Floating Release Tag
+        uses: ncipollo/release-action@v1
+        # IMPORTANT: This ensures the draft links are ONLY overwritten by the working_draft branch
+        if: github.ref == 'refs/heads/working_draft'
+        with:
+          tag: "latest-draft"
+          name: "Latest Working Draft"
+          body: "Automatically generated artifacts representing the latest commits in the `working_draft` branch."
+          # Specify the exact files you want available as direct download links
+          artifacts: "specification/spec.html, specification/spec.pdf, specification/requirements_model/build/*.json"
+          allowUpdates: true
+          replacesArtifacts: true
+          makeLatest: false
+          prerelease: true

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4.2.2
+        
       - name: Install prequirements
         shell: bash
         run: |
@@ -26,23 +27,27 @@ jobs:
           DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make
           DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y -f ./wkhtmltox_0.12.6.1-3.jammy_amd64.deb
           /usr/bin/pip3 install --break-system-packages -r requirements.txt
+          
       - name: Build PDF
         shell: bash
         working-directory: ./specification
         run: |
           make STYLE=working_draft BRANCH=${GITHUB_REF_NAME}
+          
       - name: Build Requirements Model JSON
         shell: bash
         working-directory: ./specification/requirements_model
         run: |
           /usr/bin/pip3 install --break-system-packages -r requirements.txt
           ./build_json.py
+          
       - name: Upload on failure
         uses: actions/upload-artifact@v4
-        if: ${{ failure()}}
+        if: ${{ failure() }}
         with:
           name: spec.md
           path: specification/spec.md
+          
       - name: Upload Spec
         uses: actions/upload-artifact@v4
         with:
@@ -50,19 +55,27 @@ jobs:
           path: |
             specification/spec.html
             specification/spec.pdf
+            specification/spec.md
             specification/images/*
             specification/styles/*
             specification/requirements_model/build/*.json
+
+      # Bundle HTML with assets
+      - name: Package HTML Bundle
+        shell: bash
+        run: |
+          cd specification
+          zip -r spec_html_with_assets.zip spec.html images/ styles/
+
       - name: Update Floating Release Tag
         uses: ncipollo/release-action@v1
-        # IMPORTANT: This ensures the draft links are ONLY overwritten by the working_draft branch
         if: github.ref == 'refs/heads/working_draft'
         with:
           tag: "latest-draft"
           name: "Latest Working Draft"
-          body: "Automatically generated artifacts representing the latest commits in the `working_draft` branch."
-          # Specify the exact files you want available as direct download links
-          artifacts: "specification/spec.html, specification/spec.pdf, specification/requirements_model/build/*.json"
+          body: "Automatically generated artifacts from the `working_draft` branch. For the best offline HTML experience, download the .zip bundle."
+          # Added spec.md and the new zip bundle here
+          artifacts: "specification/spec.pdf, specification/spec.md, specification/spec.html, specification/spec_html_with_assets.zip, specification/requirements_model/build/*.json"
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: false

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           /usr/bin/apt-get -y update
           wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.jammy_amd64.deb
-          DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make
+          DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make zip
           DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y -f ./wkhtmltox_0.12.6.1-3.jammy_amd64.deb
           /usr/bin/pip3 install --break-system-packages -r requirements.txt
           
@@ -62,6 +62,7 @@ jobs:
 
       # Bundle HTML with assets
       - name: Package HTML Bundle
+        if: github.ref == 'refs/heads/working_draft'
         shell: bash
         run: |
           cd specification
@@ -74,7 +75,6 @@ jobs:
           tag: "latest-draft"
           name: "Latest Working Draft"
           body: "Automatically generated artifacts from the `working_draft` branch. For the best offline HTML experience, download the .zip bundle."
-          # Added spec.md and the new zip bundle here
           artifacts: "specification/spec.pdf, specification/spec.md, specification/spec.html, specification/spec_html_with_assets.zip, specification/requirements_model/build/*.json"
           allowUpdates: true
           replacesArtifacts: true

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           name: spec.md
           path: specification/spec.md
-      - name: Upload Spec (Native CI Artifact)
+      - name: Upload Spec
         uses: actions/upload-artifact@v4
         with:
           name: FOCUS_specification


### PR DESCRIPTION
## Summary

This PR introduces a "floating release" mechanism to the `working_draft` CI pipeline. It automatically provides static, permanent URLs for the latest compiled specification files (`.pdf`, `.html`, and `.json`) without requiring a formal, versioned release. 

**Key Changes:**
* **Added Workflow Permissions:** Granted `contents: write` permissions to allow the GitHub Action bot to create and overwrite tags and releases.
* **Added Floating Release Step:** Integrated the `ncipollo/release-action` to run exclusively when pushes occur on the `working_draft` branch. 
  * Automatically overwrites the `latest-draft` tag and replaces its attached assets (`spec.html`, `spec.pdf`, and JSON models) on every merge.
  * Configured as a `prerelease` and set `makeLatest: false` to ensure this rolling draft stays hidden from the repository's main release feed and prevents notification spam to repo watchers.

**Impact:**
Stakeholders and team members can now use a single, unchanging URL to always access or download the absolute latest draft of the specification.

### Type of Change
- [ ] Bug fix
- [x] New feature / Specification update
- [ ] Editorial / Formatting

### Author Checklist
- [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
- [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
- [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
