### PR TITLE
AI #2064: Replace &dollar; entities with literal $ and harden makescripts

### DIFF
--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -154,6 +154,8 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Unordered List Style:** All unordered lists in Markdown MUST use asterisks (`*`) rather than dashes (`-`) or plus signs (`+`). This maintains visual consistency across the specification and aligns with our automated linting standards.
 
+* **Currency and Dollar Signs:** Use literal `$` for currency values in prose and tables. For build-pipeline behavior and troubleshooting related to dollar-sign parsing, see [MarkdownPP Guidelines](markdownpp-guidelines.md#currency-and-dollar-sign-handling).
+
 ### Example
 
 > **2.28. Pricing Quantity**

--- a/guidelines/contributors/markdownpp-guidelines.md
+++ b/guidelines/contributors/markdownpp-guidelines.md
@@ -190,6 +190,82 @@ All headers appearing after the !TOC directive automatically receive an HTML anc
 
 ***Note:*** *These anchors are generated for the HTML and PDF builds of the specification and differ from how GitHub natively generates anchors for markdown files. Links using these anchors will work in the built specification output but not when viewing the source markdown on GitHub.*
 
+## Currency and Dollar Sign Handling
+
+FOCUS content frequently includes monetary values. This section explains how literal dollar signs are interpreted by the build pipeline and how to avoid accidental math parsing.
+
+### Authoring Rule for Currency
+
+* Use a literal `$` for currency values in specification content (for example, `$1.00`, `$4,550.00`).
+* Write currency in normal prose and tables as needed. Contributors should not need to rewrite clear content to accommodate parser quirks.
+
+### How Dollar Parsing Works in This Repository
+
+The build pipeline has two relevant stages:
+
+* **MarkdownPP stage** (`markdown-pp`):
+    * The vendored LaTeX module in `vendored/MarkdownPP/Modules/LaTeXRender.py` can interpret dollar-delimited content as LaTeX.
+    * FOCUS includes local heuristic protections to reduce false positives for currency and prose patterns.
+* **Pandoc stage** (`spec.md` to HTML/PDF):
+    * The Makefile uses `-f gfm-tex_math_dollars` for Pandoc conversion so literal `$` currency is not interpreted as TeX math.
+
+### Intended Use of LaTeX Rendering
+
+* LaTeX rendering is available for intentional math expressions.
+* Currency and normal prose should not rely on LaTeX rendering.
+* If a contributor needs math rendering, use unambiguous math expressions and verify that output remains stable.
+
+### Examples: Rendered vs Not Rendered
+
+The following examples show expected behavior in this repository.
+
+**Example that SHOULD render as LaTeX:**
+
+```markdown
+The discount factor is $\alpha + \beta$.
+```
+
+**Examples that SHOULD NOT trigger LaTeX rendering:**
+
+```markdown
+Cost is $1.00 per hour.
+```
+
+```markdown
+Purchase amount: $4,550.00.
+```
+
+```markdown
+Difference $0.02 < Tolerance $1.00.
+```
+
+```markdown
+| BilledCost | EffectiveCost |
+| $402,960.00 | $0.00 |
+```
+
+### Troubleshooting
+
+If you suspect accidental dollar parsing:
+
+* Check MarkdownPP output for LaTeX rendering activity:
+
+```bash
+cd specification
+PYTHONPATH=../vendored ../vendored/bin/markdown-pp spec.mdpp -o spec.md 2>&1 | grep -n 'Rendering:'
+```
+
+* Check Pandoc output for TeX conversion warnings:
+
+```bash
+cd specification
+make -B spec.html spec.pdf 2>&1 | grep -nE 'Could not convert TeX math|WARNING'
+```
+
+No output from these commands typically indicates there are no active false-positive dollar parsing issues.
+
+If output does appear, the preferred fix is to improve parser/build behavior (MarkdownPP or Pandoc configuration), not to force content authors to degrade otherwise clear prose.
+
 ## Best Practices
 
 ### Header Conventions

--- a/specification/Makefile
+++ b/specification/Makefile
@@ -19,10 +19,10 @@ OS=$(shell uname)
 all: spec.md spec.pdf spec.html
 
 spec.html: spec.md
-	$(PANDOC) spec.md -o $@ -f gfm -F $(PANDOC_PROJECT_RELATIVE_LINKS) -M pathToProjectRoot=$(PATH_TO_PROJECT_ROOT) -s --css=styles/${STYLE}_html.css
+	$(PANDOC) spec.md -o $@ -f gfm-tex_math_dollars -F $(PANDOC_PROJECT_RELATIVE_LINKS) -M pathToProjectRoot=$(PATH_TO_PROJECT_ROOT) -s --css=styles/${STYLE}_html.css
 
 spec.pdf: spec.html
-	$(PANDOC) spec.md -o spec_pdf.html -f gfm -F $(PANDOC_PROJECT_RELATIVE_LINKS) -M pathToProjectRoot=$(PATH_TO_PROJECT_ROOT) -s --css=styles/${STYLE}.css $(PDF_MARGINS)
+	$(PANDOC) spec.md -o spec_pdf.html -f gfm-tex_math_dollars -F $(PANDOC_PROJECT_RELATIVE_LINKS) -M pathToProjectRoot=$(PATH_TO_PROJECT_ROOT) -s --css=styles/${STYLE}.css $(PDF_MARGINS)
 	$(WKHTMLTOPDF) --enable-local-file-access --footer-right "[page] of [topage]" --footer-font-name "Palatino" --footer-font-size 8 spec_pdf.html $@
 
 spec.md: $(SPEC_SOURCE_FILES)

--- a/specification/appendix/commitment_discounts/aws_reserved_instance_all_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/aws_reserved_instance_all_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Usage              |
 | Utilization                  | 100%               |
 | Hours Generated              | 24                 |
-| Annual Commitment            | &dollar;402,960.00 |
-| List Unit Price              | &dollar;69.00/hour |
+| Annual Commitment            | $402,960.00 |
+| List Unit Price              | $69.00/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/aws_reserved_instance_all_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost             | EffectiveCost        |
 | ---------------- | ----- | ---------------------- | -------------------- |
-| Purchase         | 1     | &dollar;402,960.00     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00           | &dollar;1,104.00     |
-| **Total**        | 25    | **&dollar;402,960.00** | **&dollar;1,104.00** |
+| Purchase         | 1     | $402,960.00     | $0.00         |
+| Usage (Used)     | 24    | $0.00           | $1,104.00     |
+| **Total**        | 25    | **$402,960.00** | **$1,104.00** |
 
 ## Column Interactions
 
@@ -50,8 +50,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;69.00      |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;69.00      |
+| **ListUnitPrice**       | List (public) unit price | $69.00      |
+| **ContractedUnitPrice** | Negotiated unit price    | $69.00      |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,8 +59,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost         | EffectiveCost | ListCost           |
 | ---------------- | ------------------ | ------------- | ------------------ |
-| **Purchase Row** | &dollar;402,960.00 | &dollar;0.00  | &dollar;402,960.00 |
-| **Used Row**     | &dollar;0.00       | &dollar;46.00 | &dollar;69.00      |
+| **Purchase Row** | $402,960.00 | $0.00  | $402,960.00 |
+| **Used Row**     | $0.00       | $46.00 | $69.00      |
 
 The following critical rules apply to commitment discount data:
 
@@ -73,8 +73,8 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------- |
 | ChargeCategory             | Purchase                             | Commitment purchase transaction                                                       |
 | ChargeFrequency            | One-Time                             | One-time upfront payment                                                              |
-| BilledCost                 | &dollar;402,960.00                   | Full annual commitment payment                                                        |
-| EffectiveCost              | &dollar;0.00                         | **must be 0** - cost is amortized to usage rows                                       |
+| BilledCost                 | $402,960.00                   | Full annual commitment payment                                                        |
+| EffectiveCost              | $0.00                         | **must be 0** - cost is amortized to usage rows                                       |
 | PricingQuantity            | 1                                    | One commitment unit purchased                                                         |
 | CommitmentDiscountStatus   | null                                 | Status only applies to usage rows                                                     |
 | CommitmentDiscountQuantity | 8760.00                              | Total commitment capacity for the 1-year term (1 instance-hr/hr &times; 8,760 hrs/yr) |
@@ -88,9 +88,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;46.00                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;69.00                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $46.00                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $69.00                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 1                                                     | Commitment units applied                   |

--- a/specification/appendix/commitment_discounts/aws_reserved_instance_partial_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/aws_reserved_instance_partial_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Usage              |
 | Utilization                  | 100%               |
 | Hours Generated              | 24                 |
-| Annual Commitment            | &dollar;440,014.80 |
-| List Unit Price              | &dollar;75.35/hour |
+| Annual Commitment            | $440,014.80 |
+| List Unit Price              | $75.35/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/aws_reserved_instance_partial_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost             | EffectiveCost        |
 | ---------------- | ----- | ---------------------- | -------------------- |
-| Purchase         | 2     | &dollar;236,884.68     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00           | &dollar;1,205.52     |
-| **Total**        | 26    | **&dollar;236,884.68** | **&dollar;1,205.52** |
+| Purchase         | 2     | $236,884.68     | $0.00         |
+| Usage (Used)     | 24    | $0.00           | $1,205.52     |
+| **Total**        | 26    | **$236,884.68** | **$1,205.52** |
 
 ## Column Interactions
 
@@ -50,8 +50,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;75.35      |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;75.35      |
+| **ListUnitPrice**       | List (public) unit price | $75.35      |
+| **ContractedUnitPrice** | Negotiated unit price    | $75.35      |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,9 +59,9 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario                     | BilledCost         | EffectiveCost | ListCost           |
 | ---------------------------- | ------------------ | ------------- | ------------------ |
-| **Purchase Row (One-Time)**  | &dollar;220,007.40 | &dollar;0.00  | &dollar;220,007.40 |
-| **Purchase Row (Recurring)** | &dollar;16,877.28  | &dollar;0.00  | &dollar;16,877.28  |
-| **Used Row**                 | &dollar;0.00       | &dollar;50.23 | &dollar;75.35      |
+| **Purchase Row (One-Time)**  | $220,007.40 | $0.00  | $220,007.40 |
+| **Purchase Row (Recurring)** | $16,877.28  | $0.00  | $16,877.28  |
+| **Used Row**                 | $0.00       | $50.23 | $75.35      |
 
 The following critical rules apply to commitment discount data:
 
@@ -74,8 +74,8 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------ |
 | ChargeCategory             | Purchase                             | Commitment purchase transaction                                                      |
 | ChargeFrequency            | One-Time                             | One-time upfront payment                                                             |
-| BilledCost                 | &dollar;220,007.40                   | Upfront portion (50% of annual commitment)                                           |
-| EffectiveCost              | &dollar;0.00                         | **must be 0** - cost is amortized to usage rows                                      |
+| BilledCost                 | $220,007.40                   | Upfront portion (50% of annual commitment)                                           |
+| EffectiveCost              | $0.00                         | **must be 0** - cost is amortized to usage rows                                      |
 | PricingQuantity            | 1                                    | One commitment unit purchased                                                        |
 | CommitmentDiscountStatus   | null                                 | Status only applies to usage rows                                                    |
 | CommitmentDiscountQuantity | 8760.00                              | Full commitment capacity for the 1-year term (1 instance-hr/hr &times; 8,760 hrs/yr) |
@@ -89,8 +89,8 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | -------------------------------------- | -------------------------------------------------------------- |
 | ChargeCategory             | Purchase                               | Commitment purchase transaction                                |
 | ChargeFrequency            | Recurring                              | Monthly recurring fee                                          |
-| BilledCost                 | &dollar;16,877.28                      | Monthly portion (hourly rate / 2 &times; 672 hours in Feb)     |
-| EffectiveCost              | &dollar;0.00                           | **must be 0** - cost is amortized to usage rows                |
+| BilledCost                 | $16,877.28                      | Monthly portion (hourly rate / 2 &times; 672 hours in Feb)     |
+| EffectiveCost              | $0.00                           | **must be 0** - cost is amortized to usage rows                |
 | PricingQuantity            | 1                                      | One commitment unit purchased                                  |
 | CommitmentDiscountStatus   | null                                   | Status only applies to usage rows                              |
 | CommitmentDiscountQuantity | 672.00                                 | Commitment capacity for Feb (1 instance-hr/hr &times; 672 hrs) |
@@ -104,9 +104,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;50.23                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;75.35                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $50.23                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $75.35                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 1                                                     | Commitment units applied                   |

--- a/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_0pct.md
+++ b/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_0pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Spend                |
 | Utilization                  | 0%                   |
 | Hours Generated              | 24                   |
-| Annual Commitment            | &dollar;353,028.00   |
-| List Unit Price              | &dollar;60.45/hour   |
+| Annual Commitment            | $353,028.00   |
+| List Unit Price              | $60.45/hour   |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/aws_savings_plan_all_upfront_0pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **zero utilization** where the commitment is purchase
 
 | Row Type           | Count   | BilledCost               | EffectiveCost         |
 | ------------------ | ------- | ------------------------ | --------------------- |
-| Purchase           | 1       | &dollar;353,028.00       | &dollar;0.00          |
-| Usage (Unused)     | 24      | &dollar;0.00             | &dollar;967.20        |
-| **Total**          | 25      | **&dollar;353,028.00**   | **&dollar;967.20**    |
+| Purchase           | 1       | $353,028.00       | $0.00          |
+| Usage (Unused)     | 24      | $0.00             | $967.20        |
+| **Total**          | 25      | **$353,028.00**   | **$967.20**    |
 
 ## Column Interactions
 
@@ -50,17 +50,17 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Column                    | Purpose                    | Commitment-Covered        |
 | ------------------------- | -------------------------- | ------------------------- |
-| **ListUnitPrice**         | List (public) unit price   | &dollar;1.00              |
-| **ContractedUnitPrice**   | Negotiated unit price      | &dollar;1.00              |
+| **ListUnitPrice**         | List (public) unit price   | $1.00              |
+| **ContractedUnitPrice**   | Negotiated unit price      | $1.00              |
 
-**Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices. For spend-based purchase and unused rows, PricingUnit is USD and ListUnitPrice is &dollar;1.00, because you are fundamentally purchasing a block of dollars.
+**Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices. For spend-based purchase and unused rows, PricingUnit is USD and ListUnitPrice is $1.00, because you are fundamentally purchasing a block of dollars.
 
 ### Cost Columns: BilledCost vs EffectiveCost vs ListCost
 
 | Scenario           | BilledCost         | EffectiveCost   | ListCost           |
 | ------------------ | ------------------ | --------------- | ------------------ |
-| **Purchase Row**   | &dollar;353,028.00 | &dollar;0.00    | &dollar;353,028.00 |
-| **Unused Row**     | &dollar;0.00       | &dollar;40.30   | &dollar;40.30      |
+| **Purchase Row**   | $353,028.00 | $0.00    | $353,028.00 |
+| **Unused Row**     | $0.00       | $40.30   | $40.30      |
 
 This scenario has no Used or Standard rows because utilization is 0% and no resources were consumed.
 
@@ -75,11 +75,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------ | ----------------------------------------------------------- |
 | ChargeCategory             | Purchase                             | Commitment purchase transaction                             |
 | ChargeFrequency            | One-Time                             | One-time upfront payment                                    |
-| BilledCost                 | &dollar;353,028.00                   | Full annual commitment payment                              |
-| EffectiveCost              | &dollar;0.00                         | **must be 0** - cost is amortized to usage rows             |
+| BilledCost                 | $353,028.00                   | Full annual commitment payment                              |
+| EffectiveCost              | $0.00                         | **must be 0** - cost is amortized to usage rows             |
 | PricingQuantity            | 353,028.00                           | Total commitment in USD (PricingUnit = USD)                 |
 | CommitmentDiscountStatus   | null                                 | Status only applies to usage rows                           |
-| CommitmentDiscountQuantity | 353,028.00                           | Full annual commitment (&dollar;40.30/hr &times; 8,760 hrs) |
+| CommitmentDiscountQuantity | 353,028.00                           | Full annual commitment ($40.30/hr &times; 8,760 hrs) |
 | CommitmentDiscountUnit     | USD                                  | Unit of commitment capacity (spend-based)                   |
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE         | Commitment purchase SKU                                     |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-UPFRONT | Price point for upfront purchase                            |
@@ -89,10 +89,10 @@ The following critical rules apply to commitment discount data:
 | Column                       | Value                                                          | Explanation                                        |
 | ---------------------------- | -------------------------------------------------------------- | -------------------------------------------------- |
 | ChargeCategory               | Usage                                                          | Represents commitment capacity                     |
-| BilledCost                   | &dollar;0.00                                                   | No additional billing (already paid at purchase)   |
-| EffectiveCost                | &dollar;40.30                                                  | **Wasted value** - lost commitment                 |
+| BilledCost                   | $0.00                                                   | No additional billing (already paid at purchase)   |
+| EffectiveCost                | $40.30                                                  | **Wasted value** - lost commitment                 |
 | PricingQuantity              | 40.30                                                          | Hourly commitment in USD (PricingUnit = USD)       |
-| ListCost                     | &dollar;40.30                                                  | &dollar;1.00 &times; 40.30 USD                     |
+| ListCost                     | $40.30                                                  | $1.00 &times; 40.30 USD                     |
 | ConsumedQuantity             | null                                                           | **No resource consumed**                           |
 | CommitmentDiscountQuantity   | 40.30                                                          | Commitment wasted                                  |
 | CommitmentDiscountStatus     | Unused                                                         | Commitment not utilized                            |
@@ -102,4 +102,4 @@ The following critical rules apply to commitment discount data:
 | SkuId                        | AWS-USEAST1-COMPUTE-PURCHASE                                   | must match Purchase row (no resource consumed)     |
 | SkuPriceId                   | AWS-USEAST1-COMPUTE-PURCHASE-UPFRONT                           | must match Purchase row (no resource consumed)     |
 
-For spend-based unused rows, PricingUnit is USD and PricingQuantity is the hourly commitment amount. ListCost = ListUnitPrice (&dollar;1.00) &times; PricingQuantity, which equals the wasted commitment dollars per hour.
+For spend-based unused rows, PricingUnit is USD and PricingQuantity is the hourly commitment amount. ListCost = ListUnitPrice ($1.00) &times; PricingQuantity, which equals the wasted commitment dollars per hour.

--- a/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Spend               |
 | Utilization                  | 100%                |
 | Hours Generated              | 24                  |
-| Annual Commitment            | &dollar;628,004.40  |
-| List Unit Price              | &dollar;107.54/hour |
+| Annual Commitment            | $628,004.40  |
+| List Unit Price              | $107.54/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/aws_savings_plan_all_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost             | EffectiveCost        |
 | ---------------- | ----- | ---------------------- | -------------------- |
-| Purchase         | 1     | &dollar;628,004.40     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00           | &dollar;1,720.56     |
-| **Total**        | 25    | **&dollar;628,004.40** | **&dollar;1,720.56** |
+| Purchase         | 1     | $628,004.40     | $0.00         |
+| Usage (Used)     | 24    | $0.00           | $1,720.56     |
+| **Total**        | 25    | **$628,004.40** | **$1,720.56** |
 
 ## Column Interactions
 
@@ -44,14 +44,14 @@ These three quantity columns serve different purposes and must be understood in 
 | **ConsumedQuantity**           | Actual resource consumption           | Usage rows with resources     | 1 (hours consumed)         |
 | **CommitmentDiscountQuantity** | Commitment capacity applied           | Rows with commitment discount | 71.69 (USD)                |
 
-**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a &dollar;71.69/hour commitment, this value is &dollar;71.69.
+**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a $71.69/hour commitment, this value is $71.69.
 
 ### Pricing Columns: ListUnitPrice vs ContractedUnitPrice
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;107.54     |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;107.54     |
+| **ListUnitPrice**       | List (public) unit price | $107.54     |
+| **ContractedUnitPrice** | Negotiated unit price    | $107.54     |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,8 +59,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost         | EffectiveCost | ListCost           |
 | ---------------- | ------------------ | ------------- | ------------------ |
-| **Purchase Row** | &dollar;628,004.40 | &dollar;0.00  | &dollar;628,004.40 |
-| **Used Row**     | &dollar;0.00       | &dollar;71.69 | &dollar;107.54     |
+| **Purchase Row** | $628,004.40 | $0.00  | $628,004.40 |
+| **Used Row**     | $0.00       | $71.69 | $107.54     |
 
 The following critical rules apply to commitment discount data:
 
@@ -73,11 +73,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------ | ----------------------------------------------------------- |
 | ChargeCategory             | Purchase                             | Commitment purchase transaction                             |
 | ChargeFrequency            | One-Time                             | One-time upfront payment                                    |
-| BilledCost                 | &dollar;628,004.40                   | Full annual commitment payment                              |
-| EffectiveCost              | &dollar;0.00                         | **must be 0** - cost is amortized to usage rows             |
+| BilledCost                 | $628,004.40                   | Full annual commitment payment                              |
+| EffectiveCost              | $0.00                         | **must be 0** - cost is amortized to usage rows             |
 | PricingQuantity            | 628,004.40                           | Total commitment in USD (PricingUnit = USD)                 |
 | CommitmentDiscountStatus   | null                                 | Status only applies to usage rows                           |
-| CommitmentDiscountQuantity | 628,004.40                           | Full annual commitment (&dollar;71.69/hr &times; 8,760 hrs) |
+| CommitmentDiscountQuantity | 628,004.40                           | Full annual commitment ($71.69/hr &times; 8,760 hrs) |
 | CommitmentDiscountUnit     | USD                                  | Unit of commitment capacity (spend-based)                   |
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE         | Commitment purchase SKU                                     |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-UPFRONT | Price point for upfront purchase                            |
@@ -88,9 +88,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;71.69                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;107.54                                        | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $71.69                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $107.54                                        | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 71.69                                                 | Hourly commitment spend applied            |

--- a/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_50pct.md
+++ b/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_50pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Spend               |
 | Utilization                  | 50%                 |
 | Hours Generated              | 24                  |
-| Annual Commitment            | &dollar;693,003.60  |
-| List Unit Price              | &dollar;118.67/hour |
+| Annual Commitment            | $693,003.60  |
+| List Unit Price              | $118.67/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/aws_savings_plan_all_upfront_50pct.csv)
 
@@ -26,10 +26,10 @@ This scenario demonstrates **underutilization** at 50% where only 12 of 24 commi
 
 | Row Type         | Count | BilledCost             | EffectiveCost        |
 | ---------------- | ----- | ---------------------- | -------------------- |
-| Purchase         | 1     | &dollar;693,003.60     | &dollar;0.00         |
-| Usage (Used)     | 12    | &dollar;0.00           | &dollar;949.32       |
-| Usage (Unused)   | 12    | &dollar;0.00           | &dollar;949.32       |
-| **Total**        | 25    | **&dollar;693,003.60** | **&dollar;1,898.64** |
+| Purchase         | 1     | $693,003.60     | $0.00         |
+| Usage (Used)     | 12    | $0.00           | $949.32       |
+| Usage (Unused)   | 12    | $0.00           | $949.32       |
+| **Total**        | 25    | **$693,003.60** | **$1,898.64** |
 
 ## Column Interactions
 
@@ -45,14 +45,14 @@ These three quantity columns serve different purposes and must be understood in 
 | **ConsumedQuantity**           | Actual resource consumption           | Usage rows with resources     | 1 (hours consumed)         |
 | **CommitmentDiscountQuantity** | Commitment capacity applied           | Rows with commitment discount | 79.11 (USD)                |
 
-**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a &dollar;79.11/hour commitment, this value is &dollar;79.11.
+**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a $79.11/hour commitment, this value is $79.11.
 
 ### Pricing Columns: ListUnitPrice vs ContractedUnitPrice
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;118.67     |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;118.67     |
+| **ListUnitPrice**       | List (public) unit price | $118.67     |
+| **ContractedUnitPrice** | Negotiated unit price    | $118.67     |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -60,9 +60,9 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost         | EffectiveCost | ListCost           |
 | ---------------- | ------------------ | ------------- | ------------------ |
-| **Purchase Row** | &dollar;693,003.60 | &dollar;0.00  | &dollar;693,003.60 |
-| **Used Row**     | &dollar;0.00       | &dollar;79.11 | &dollar;118.67     |
-| **Unused Row**   | &dollar;0.00       | &dollar;79.11 | &dollar;79.11      |
+| **Purchase Row** | $693,003.60 | $0.00  | $693,003.60 |
+| **Used Row**     | $0.00       | $79.11 | $118.67     |
+| **Unused Row**   | $0.00       | $79.11 | $79.11      |
 
 The following critical rules apply to commitment discount data:
 
@@ -76,11 +76,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------ | ----------------------------------------------------------- |
 | ChargeCategory             | Purchase                             | Commitment purchase transaction                             |
 | ChargeFrequency            | One-Time                             | One-time upfront payment                                    |
-| BilledCost                 | &dollar;693,003.60                   | Full annual commitment payment                              |
-| EffectiveCost              | &dollar;0.00                         | **must be 0** - cost is amortized to usage rows             |
+| BilledCost                 | $693,003.60                   | Full annual commitment payment                              |
+| EffectiveCost              | $0.00                         | **must be 0** - cost is amortized to usage rows             |
 | PricingQuantity            | 693,003.60                           | Total commitment in USD (PricingUnit = USD)                 |
 | CommitmentDiscountStatus   | null                                 | Status only applies to usage rows                           |
-| CommitmentDiscountQuantity | 693,003.60                           | Full annual commitment (&dollar;79.11/hr &times; 8,760 hrs) |
+| CommitmentDiscountQuantity | 693,003.60                           | Full annual commitment ($79.11/hr &times; 8,760 hrs) |
 | CommitmentDiscountUnit     | USD                                  | Unit of commitment capacity (spend-based)                   |
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE         | Commitment purchase SKU                                     |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-UPFRONT | Price point for upfront purchase                            |
@@ -91,9 +91,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;79.11                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;118.67                                        | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $79.11                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $118.67                                        | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 79.11                                                 | Hourly commitment spend applied            |
@@ -107,10 +107,10 @@ The following critical rules apply to commitment discount data:
 | Column                     | Value                                                          | Explanation                                        |
 | -------------------------- | -------------------------------------------------------------- | -------------------------------------------------- |
 | ChargeCategory             | Usage                                                          | Represents commitment capacity                     |
-| BilledCost                 | &dollar;0.00                                                   | No additional billing (already paid at purchase)   |
-| EffectiveCost              | &dollar;79.11                                                  | **Wasted value** - lost commitment                 |
+| BilledCost                 | $0.00                                                   | No additional billing (already paid at purchase)   |
+| EffectiveCost              | $79.11                                                  | **Wasted value** - lost commitment                 |
 | PricingQuantity            | 79.11                                                          | Hourly commitment in USD (PricingUnit = USD)       |
-| ListCost                   | &dollar;79.11                                                  | &dollar;1.00 &times; 79.11 USD                     |
+| ListCost                   | $79.11                                                  | $1.00 &times; 79.11 USD                     |
 | ConsumedQuantity           | null                                                           | **No resource consumed**                           |
 | CommitmentDiscountQuantity | 79.11                                                          | Commitment wasted                                  |
 | CommitmentDiscountStatus   | Unused                                                         | Commitment not utilized                            |
@@ -120,4 +120,4 @@ The following critical rules apply to commitment discount data:
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE                                   | must match Purchase row (no resource consumed)     |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-UPFRONT                           | must match Purchase row                            |
 
-For spend-based unused rows, PricingUnit is USD and PricingQuantity is the hourly commitment amount. ListCost = ListUnitPrice (&dollar;1.00) &times; PricingQuantity, which equals the wasted commitment dollars per hour.
+For spend-based unused rows, PricingUnit is USD and PricingQuantity is the hourly commitment amount. ListCost = ListUnitPrice ($1.00) &times; PricingQuantity, which equals the wasted commitment dollars per hour.

--- a/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_75pct.md
+++ b/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_75pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Spend              |
 | Utilization                  | 75%                |
 | Hours Generated              | 24                 |
-| Annual Commitment            | &dollar;459,024.00 |
-| List Unit Price              | &dollar;78.60/hour |
+| Annual Commitment            | $459,024.00 |
+| List Unit Price              | $78.60/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/aws_savings_plan_all_upfront_75pct.csv)
 
@@ -26,10 +26,10 @@ This scenario demonstrates **underutilization** at 75% where only 18 of 24 commi
 
 | Row Type         | Count | BilledCost             | EffectiveCost        |
 | ---------------- | ----- | ---------------------- | -------------------- |
-| Purchase         | 1     | &dollar;459,024.00     | &dollar;0.00         |
-| Usage (Used)     | 18    | &dollar;0.00           | &dollar;943.20       |
-| Usage (Unused)   | 6     | &dollar;0.00           | &dollar;314.40       |
-| **Total**        | 25    | **&dollar;459,024.00** | **&dollar;1,257.60** |
+| Purchase         | 1     | $459,024.00     | $0.00         |
+| Usage (Used)     | 18    | $0.00           | $943.20       |
+| Usage (Unused)   | 6     | $0.00           | $314.40       |
+| **Total**        | 25    | **$459,024.00** | **$1,257.60** |
 
 ## Column Interactions
 
@@ -45,14 +45,14 @@ These three quantity columns serve different purposes and must be understood in 
 | **ConsumedQuantity**           | Actual resource consumption           | Usage rows with resources     | 1 (hours consumed)         |
 | **CommitmentDiscountQuantity** | Commitment capacity applied           | Rows with commitment discount | 52.40 (USD)                |
 
-**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a &dollar;52.40/hour commitment, this value is &dollar;52.40.
+**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a $52.40/hour commitment, this value is $52.40.
 
 ### Pricing Columns: ListUnitPrice vs ContractedUnitPrice
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;78.60      |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;78.60      |
+| **ListUnitPrice**       | List (public) unit price | $78.60      |
+| **ContractedUnitPrice** | Negotiated unit price    | $78.60      |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -60,9 +60,9 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost         | EffectiveCost | ListCost           |
 | ---------------- | ------------------ | ------------- | ------------------ |
-| **Purchase Row** | &dollar;459,024.00 | &dollar;0.00  | &dollar;459,024.00 |
-| **Used Row**     | &dollar;0.00       | &dollar;52.40 | &dollar;78.60      |
-| **Unused Row**   | &dollar;0.00       | &dollar;52.40 | &dollar;52.40      |
+| **Purchase Row** | $459,024.00 | $0.00  | $459,024.00 |
+| **Used Row**     | $0.00       | $52.40 | $78.60      |
+| **Unused Row**   | $0.00       | $52.40 | $52.40      |
 
 The following critical rules apply to commitment discount data:
 
@@ -76,11 +76,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------ | ----------------------------------------------------------- |
 | ChargeCategory             | Purchase                             | Commitment purchase transaction                             |
 | ChargeFrequency            | One-Time                             | One-time upfront payment                                    |
-| BilledCost                 | &dollar;459,024.00                   | Full annual commitment payment                              |
-| EffectiveCost              | &dollar;0.00                         | **must be 0** - cost is amortized to usage rows             |
+| BilledCost                 | $459,024.00                   | Full annual commitment payment                              |
+| EffectiveCost              | $0.00                         | **must be 0** - cost is amortized to usage rows             |
 | PricingQuantity            | 459,024.00                           | Total commitment in USD (PricingUnit = USD)                 |
 | CommitmentDiscountStatus   | null                                 | Status only applies to usage rows                           |
-| CommitmentDiscountQuantity | 459,024.00                           | Full annual commitment (&dollar;52.40/hr &times; 8,760 hrs) |
+| CommitmentDiscountQuantity | 459,024.00                           | Full annual commitment ($52.40/hr &times; 8,760 hrs) |
 | CommitmentDiscountUnit     | USD                                  | Unit of commitment capacity (spend-based)                   |
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE         | Commitment purchase SKU                                     |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-UPFRONT | Price point for upfront purchase                            |
@@ -91,9 +91,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;52.40                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;78.60                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $52.40                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $78.60                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 52.40                                                 | Hourly commitment spend applied            |
@@ -107,10 +107,10 @@ The following critical rules apply to commitment discount data:
 | Column                     | Value                                                          | Explanation                                        |
 | -------------------------- | -------------------------------------------------------------- | -------------------------------------------------- |
 | ChargeCategory             | Usage                                                          | Represents commitment capacity                     |
-| BilledCost                 | &dollar;0.00                                                   | No additional billing (already paid at purchase)   |
-| EffectiveCost              | &dollar;52.40                                                  | **Wasted value** - lost commitment                 |
+| BilledCost                 | $0.00                                                   | No additional billing (already paid at purchase)   |
+| EffectiveCost              | $52.40                                                  | **Wasted value** - lost commitment                 |
 | PricingQuantity            | 52.40                                                          | Hourly commitment in USD (PricingUnit = USD)       |
-| ListCost                   | &dollar;52.40                                                  | &dollar;1.00 &times; 52.40 USD                     |
+| ListCost                   | $52.40                                                  | $1.00 &times; 52.40 USD                     |
 | ConsumedQuantity           | null                                                           | **No resource consumed**                           |
 | CommitmentDiscountQuantity | 52.40                                                          | Commitment wasted                                  |
 | CommitmentDiscountStatus   | Unused                                                         | Commitment not utilized                            |
@@ -120,4 +120,4 @@ The following critical rules apply to commitment discount data:
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE                                   | must match Purchase row (no resource consumed)     |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-UPFRONT                           | must match Purchase row                            |
 
-For spend-based unused rows, PricingUnit is USD and PricingQuantity is the hourly commitment amount. ListCost = ListUnitPrice (&dollar;1.00) &times; PricingQuantity, which equals the wasted commitment dollars per hour.
+For spend-based unused rows, PricingUnit is USD and PricingQuantity is the hourly commitment amount. ListCost = ListUnitPrice ($1.00) &times; PricingQuantity, which equals the wasted commitment dollars per hour.

--- a/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_overage.md
+++ b/specification/appendix/commitment_discounts/aws_savings_plan_all_upfront_overage.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Spend                                                    |
 | Utilization                  | 100% (with overage to standard pricing)                  |
 | Hours Generated              | 24 committed + 12 standard overflow                      |
-| Annual Commitment            | &dollar;211,992.00                                       |
-| List Unit Price              | &dollar;36.30/hour                                       |
+| Annual Commitment            | $211,992.00                                       |
+| List Unit Price              | $36.30/hour                                       |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/aws_savings_plan_all_upfront_overage.csv)
 
@@ -26,10 +26,10 @@ This scenario demonstrates **100% utilization with overage** where demand exceed
 
 | Row Type         | Count | BilledCost             | EffectiveCost        |
 | ---------------- | ----- | ---------------------- | -------------------- |
-| Purchase         | 1     | &dollar;211,992.00     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00           | &dollar;580.80       |
-| Usage (Standard) | 12    | &dollar;435.60         | &dollar;435.60       |
-| **Total**        | 37    | **&dollar;212,427.60** | **&dollar;1,016.40** |
+| Purchase         | 1     | $211,992.00     | $0.00         |
+| Usage (Used)     | 24    | $0.00           | $580.80       |
+| Usage (Standard) | 12    | $435.60         | $435.60       |
+| **Total**        | 37    | **$212,427.60** | **$1,016.40** |
 
 ## Column Interactions
 
@@ -45,14 +45,14 @@ These three quantity columns serve different purposes and must be understood in 
 | **ConsumedQuantity**           | Actual resource consumption           | Usage rows with resources     | 1 (hours consumed)         |
 | **CommitmentDiscountQuantity** | Commitment capacity applied           | Rows with commitment discount | 24.20 (USD)                |
 
-**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a &dollar;24.20/hour commitment, this value is &dollar;24.20.
+**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a $24.20/hour commitment, this value is $24.20.
 
 ### Pricing Columns: ListUnitPrice vs ContractedUnitPrice
 
 | Column                  | Purpose                  | Commitment-Covered | Standard      |
 | ----------------------- | ------------------------ | ------------------ | ------------- |
-| **ListUnitPrice**       | List (public) unit price | &dollar;36.30      | &dollar;36.30 |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;36.30      | &dollar;36.30 |
+| **ListUnitPrice**       | List (public) unit price | $36.30      | $36.30 |
+| **ContractedUnitPrice** | Negotiated unit price    | $36.30      | $36.30 |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -60,9 +60,9 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost         | EffectiveCost | ListCost           |
 | ---------------- | ------------------ | ------------- | ------------------ |
-| **Purchase Row** | &dollar;211,992.00 | &dollar;0.00  | &dollar;211,992.00 |
-| **Used Row**     | &dollar;0.00       | &dollar;24.20 | &dollar;36.30      |
-| **Standard Row** | &dollar;36.30      | &dollar;36.30 | &dollar;36.30      |
+| **Purchase Row** | $211,992.00 | $0.00  | $211,992.00 |
+| **Used Row**     | $0.00       | $24.20 | $36.30      |
+| **Standard Row** | $36.30      | $36.30 | $36.30      |
 
 The following critical rules apply to commitment discount data:
 
@@ -76,11 +76,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------ | ----------------------------------------------------------- |
 | ChargeCategory             | Purchase                             | Commitment purchase transaction                             |
 | ChargeFrequency            | One-Time                             | One-time upfront payment                                    |
-| BilledCost                 | &dollar;211,992.00                   | Full annual commitment payment                              |
-| EffectiveCost              | &dollar;0.00                         | **must be 0** - cost is amortized to usage rows             |
+| BilledCost                 | $211,992.00                   | Full annual commitment payment                              |
+| EffectiveCost              | $0.00                         | **must be 0** - cost is amortized to usage rows             |
 | PricingQuantity            | 211,992.00                           | Total commitment in USD (PricingUnit = USD)                 |
 | CommitmentDiscountStatus   | null                                 | Status only applies to usage rows                           |
-| CommitmentDiscountQuantity | 211,992.00                           | Full annual commitment (&dollar;24.20/hr &times; 8,760 hrs) |
+| CommitmentDiscountQuantity | 211,992.00                           | Full annual commitment ($24.20/hr &times; 8,760 hrs) |
 | CommitmentDiscountUnit     | USD                                  | Unit of commitment capacity (spend-based)                   |
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE         | Commitment purchase SKU                                     |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-UPFRONT | Price point for upfront purchase                            |
@@ -91,9 +91,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;24.20                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;36.30                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $24.20                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $36.30                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 24.20                                                 | Hourly commitment spend applied            |
@@ -108,14 +108,14 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------- | --------------------------------------------- |
 | ChargeCategory             | Usage                                 | Compute consumption (standard pricing)        |
 | PricingCategory            | Standard                              | No discount applied                           |
-| BilledCost                 | &dollar;36.30                         | Same as ListCost, no negotiation/commitments  |
-| EffectiveCost              | &dollar;36.30                         | Same as BilledCost, no pre/post payments      |
-| ListCost                   | &dollar;36.30                         | Public, non-negotiated cost                   |
+| BilledCost                 | $36.30                         | Same as ListCost, no negotiation/commitments  |
+| EffectiveCost              | $36.30                         | Same as BilledCost, no pre/post payments      |
+| ListCost                   | $36.30                         | Public, non-negotiated cost                   |
 | PricingQuantity            | 1                                     | Units priced                                  |
 | ConsumedQuantity           | 1                                     | Hours consumed                                |
 | CommitmentDiscountQuantity | null                                  | **No commitment applied**                     |
 | CommitmentDiscountStatus   | null                                  | No commitment                                 |
 | CommitmentDiscountId       | null                                  | No associated commitment                      |
-| ContractedUnitPrice        | &dollar;36.30                         | Equals ListUnitPrice (no negotiated discount) |
+| ContractedUnitPrice        | $36.30                         | Equals ListUnitPrice (no negotiated discount) |
 | SkuId                      | AWS-USEAST1-COMPUTE-ONDEMAND          | Standard (on-demand) resource SKU             |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-ONDEMAND-STANDARD | Price point for standard pricing              |

--- a/specification/appendix/commitment_discounts/aws_savings_plan_no_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/aws_savings_plan_no_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Spend              |
 | Utilization                  | 100%               |
 | Hours Generated              | 24                 |
-| Annual Commitment            | &dollar;462,966.00 |
-| List Unit Price              | &dollar;79.28/hour |
+| Annual Commitment            | $462,966.00 |
+| List Unit Price              | $79.28/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/aws_savings_plan_no_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost            | EffectiveCost        |
 | ---------------- | ----- | --------------------- | -------------------- |
-| Purchase         | 1     | &dollar;35,515.20     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00          | &dollar;1,268.40     |
-| **Total**        | 25    | **&dollar;35,515.20** | **&dollar;1,268.40** |
+| Purchase         | 1     | $35,515.20     | $0.00         |
+| Usage (Used)     | 24    | $0.00          | $1,268.40     |
+| **Total**        | 25    | **$35,515.20** | **$1,268.40** |
 
 ## Column Interactions
 
@@ -44,14 +44,14 @@ These three quantity columns serve different purposes and must be understood in 
 | **ConsumedQuantity**           | Actual resource consumption           | Usage rows with resources     | 1 (hours consumed)         |
 | **CommitmentDiscountQuantity** | Commitment capacity applied           | Rows with commitment discount | 52.85 (USD)                |
 
-**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a &dollar;52.85/hour commitment, this value is &dollar;52.85.
+**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a $52.85/hour commitment, this value is $52.85.
 
 ### Pricing Columns: ListUnitPrice vs ContractedUnitPrice
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;79.28      |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;79.28      |
+| **ListUnitPrice**       | List (public) unit price | $79.28      |
+| **ContractedUnitPrice** | Negotiated unit price    | $79.28      |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,8 +59,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost        | EffectiveCost | ListCost          |
 | ---------------- | ----------------- | ------------- | ----------------- |
-| **Purchase Row** | &dollar;35,515.20 | &dollar;0.00  | &dollar;35,515.20 |
-| **Used Row**     | &dollar;0.00      | &dollar;52.85 | &dollar;79.28     |
+| **Purchase Row** | $35,515.20 | $0.00  | $35,515.20 |
+| **Used Row**     | $0.00      | $52.85 | $79.28     |
 
 The following critical rules apply to commitment discount data:
 
@@ -73,11 +73,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------ | ---------------------------------------------------------------- |
 | ChargeCategory             | Purchase                             | Commitment purchase transaction                                  |
 | ChargeFrequency            | Recurring                            | Monthly recurring fee                                            |
-| BilledCost                 | &dollar;35,515.20                    | Monthly recurring payment (hourly rate &times; 672 hours in Feb) |
-| EffectiveCost              | &dollar;0.00                         | **must be 0** - cost is amortized to usage rows                  |
+| BilledCost                 | $35,515.20                    | Monthly recurring payment (hourly rate &times; 672 hours in Feb) |
+| EffectiveCost              | $0.00                         | **must be 0** - cost is amortized to usage rows                  |
 | PricingQuantity            | 35,515.20                            | Total commitment in USD (PricingUnit = USD)                      |
 | CommitmentDiscountStatus   | null                                 | Status only applies to usage rows                                |
-| CommitmentDiscountQuantity | 35,515.20                            | Commitment capacity for Feb (&dollar;52.85/hr &times; 672 hrs)   |
+| CommitmentDiscountQuantity | 35,515.20                            | Commitment capacity for Feb ($52.85/hr &times; 672 hrs)   |
 | CommitmentDiscountUnit     | USD                                  | Unit of commitment capacity (spend-based)                        |
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE         | Commitment purchase SKU                                          |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-MONTHLY | Price point for recurring purchase                               |
@@ -88,9 +88,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;52.85                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;79.28                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $52.85                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $79.28                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 52.85                                                 | Hourly commitment spend applied            |

--- a/specification/appendix/commitment_discounts/aws_savings_plan_partial_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/aws_savings_plan_partial_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Spend              |
 | Utilization                  | 100%               |
 | Hours Generated              | 24                 |
-| Annual Commitment            | &dollar;447,986.40 |
-| List Unit Price              | &dollar;76.71/hour |
+| Annual Commitment            | $447,986.40 |
+| List Unit Price              | $76.71/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/aws_savings_plan_partial_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost             | EffectiveCost        |
 | ---------------- | ----- | ---------------------- | -------------------- |
-| Purchase         | 2     | &dollar;241,176.24     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00           | &dollar;1,227.36     |
-| **Total**        | 26    | **&dollar;241,176.24** | **&dollar;1,227.36** |
+| Purchase         | 2     | $241,176.24     | $0.00         |
+| Usage (Used)     | 24    | $0.00           | $1,227.36     |
+| **Total**        | 26    | **$241,176.24** | **$1,227.36** |
 
 ## Column Interactions
 
@@ -44,14 +44,14 @@ These three quantity columns serve different purposes and must be understood in 
 | **ConsumedQuantity**           | Actual resource consumption           | Usage rows with resources     | 1 (hours consumed)         |
 | **CommitmentDiscountQuantity** | Commitment capacity applied           | Rows with commitment discount | 51.14 (USD)                |
 
-**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a &dollar;51.14/hour commitment, this value is &dollar;51.14.
+**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a $51.14/hour commitment, this value is $51.14.
 
 ### Pricing Columns: ListUnitPrice vs ContractedUnitPrice
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;76.71      |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;76.71      |
+| **ListUnitPrice**       | List (public) unit price | $76.71      |
+| **ContractedUnitPrice** | Negotiated unit price    | $76.71      |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,9 +59,9 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario                     | BilledCost         | EffectiveCost | ListCost           |
 | ---------------------------- | ------------------ | ------------- | ------------------ |
-| **Purchase Row (One-Time)**  | &dollar;223,993.20 | &dollar;0.00  | &dollar;223,993.20 |
-| **Purchase Row (Recurring)** | &dollar;17,183.04  | &dollar;0.00  | &dollar;17,183.04  |
-| **Used Row**                 | &dollar;0.00       | &dollar;51.14 | &dollar;76.71      |
+| **Purchase Row (One-Time)**  | $223,993.20 | $0.00  | $223,993.20 |
+| **Purchase Row (Recurring)** | $17,183.04  | $0.00  | $17,183.04  |
+| **Used Row**                 | $0.00       | $51.14 | $76.71      |
 
 The following critical rules apply to commitment discount data:
 
@@ -74,11 +74,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------ | --------------------------------------------------------------------------- |
 | ChargeCategory             | Purchase                             | Commitment purchase transaction                                             |
 | ChargeFrequency            | One-Time                             | One-time upfront payment                                                    |
-| BilledCost                 | &dollar;223,993.20                   | Upfront portion (50% of annual commitment)                                  |
-| EffectiveCost              | &dollar;0.00                         | **must be 0** - cost is amortized to usage rows                             |
+| BilledCost                 | $223,993.20                   | Upfront portion (50% of annual commitment)                                  |
+| EffectiveCost              | $0.00                         | **must be 0** - cost is amortized to usage rows                             |
 | PricingQuantity            | 223,993.20                           | Upfront portion in USD (PricingUnit = USD)                                  |
 | CommitmentDiscountStatus   | null                                 | Status only applies to usage rows                                           |
-| CommitmentDiscountQuantity | 447,986.40                           | Full annual commitment capacity (&dollar;51.14/hr &times; 8,760 hrs)        |
+| CommitmentDiscountQuantity | 447,986.40                           | Full annual commitment capacity ($51.14/hr &times; 8,760 hrs)        |
 | CommitmentDiscountUnit     | USD                                  | Unit of commitment capacity (spend-based)                                   |
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE         | Commitment purchase SKU                                                     |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-UPFRONT | Price point for upfront purchase                                            |
@@ -89,11 +89,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | -------------------------------------- | -------------------------------------------------------------------------- |
 | ChargeCategory             | Purchase                               | Commitment purchase transaction                                            |
 | ChargeFrequency            | Recurring                              | Monthly recurring fee                                                      |
-| BilledCost                 | &dollar;17,183.04                      | Monthly portion (hourly rate / 2 &times; 672 hours in Feb)                 |
-| EffectiveCost              | &dollar;0.00                           | **must be 0** - cost is amortized to usage rows                            |
+| BilledCost                 | $17,183.04                      | Monthly portion (hourly rate / 2 &times; 672 hours in Feb)                 |
+| EffectiveCost              | $0.00                           | **must be 0** - cost is amortized to usage rows                            |
 | PricingQuantity            | 17,183.04                              | Monthly portion in USD (PricingUnit = USD)                                 |
 | CommitmentDiscountStatus   | null                                   | Status only applies to usage rows                                          |
-| CommitmentDiscountQuantity | 34,366.08                              | Full monthly commitment capacity (&dollar;51.14/hr &times; 672 hrs)        |
+| CommitmentDiscountQuantity | 34,366.08                              | Full monthly commitment capacity ($51.14/hr &times; 672 hrs)        |
 | CommitmentDiscountUnit     | USD                                    | Unit of commitment capacity (spend-based)                                  |
 | SkuId                      | AWS-USEAST1-COMPUTE-PURCHASE           | Commitment purchase SKU                                                    |
 | SkuPriceId                 | AWS-USEAST1-COMPUTE-PURCHASE-RECURRING | Price point for recurring purchase                                         |
@@ -104,9 +104,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;51.14                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;76.71                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $51.14                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $76.71                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 51.14                                                 | Hourly commitment spend applied            |

--- a/specification/appendix/commitment_discounts/azure_reservation_all_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/azure_reservation_all_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Usage              |
 | Utilization                  | 100%               |
 | Hours Generated              | 24                 |
-| Annual Commitment            | &dollar;358,021.20 |
-| List Unit Price              | &dollar;61.31/hour |
+| Annual Commitment            | $358,021.20 |
+| List Unit Price              | $61.31/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/azure_reservation_all_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost             | EffectiveCost        |
 | ---------------- | ----- | ---------------------- | -------------------- |
-| Purchase         | 1     | &dollar;358,021.20     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00           | &dollar;980.88       |
-| **Total**        | 25    | **&dollar;358,021.20** | **&dollar;980.88**   |
+| Purchase         | 1     | $358,021.20     | $0.00         |
+| Usage (Used)     | 24    | $0.00           | $980.88       |
+| **Total**        | 25    | **$358,021.20** | **$980.88**   |
 
 ## Column Interactions
 
@@ -50,8 +50,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;61.31      |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;61.31      |
+| **ListUnitPrice**       | List (public) unit price | $61.31      |
+| **ContractedUnitPrice** | Negotiated unit price    | $61.31      |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,8 +59,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost         | EffectiveCost | ListCost           |
 | ---------------- | ------------------ | ------------- | ------------------ |
-| **Purchase Row** | &dollar;358,021.20 | &dollar;0.00  | &dollar;358,021.20 |
-| **Used Row**     | &dollar;0.00       | &dollar;40.87 | &dollar;61.31      |
+| **Purchase Row** | $358,021.20 | $0.00  | $358,021.20 |
+| **Used Row**     | $0.00       | $40.87 | $61.31      |
 
 The following critical rules apply to commitment discount data:
 
@@ -73,8 +73,8 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
 | ChargeCategory             | Purchase                              | Commitment purchase transaction                                                       |
 | ChargeFrequency            | One-Time                              | One-time upfront payment                                                              |
-| BilledCost                 | &dollar;358,021.20                    | Full annual commitment payment                                                        |
-| EffectiveCost              | &dollar;0.00                          | **must be 0** - cost is amortized to usage rows                                       |
+| BilledCost                 | $358,021.20                    | Full annual commitment payment                                                        |
+| EffectiveCost              | $0.00                          | **must be 0** - cost is amortized to usage rows                                       |
 | PricingQuantity            | 1                                     | One commitment unit purchased                                                         |
 | CommitmentDiscountStatus   | null                                  | Status only applies to usage rows                                                     |
 | CommitmentDiscountQuantity | 8760.00                               | Total commitment capacity for the 1-year term (1 instance-hr/hr &times; 8,760 hrs/yr) |
@@ -88,9 +88,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;40.87                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;61.31                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $40.87                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $61.31                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 1                                                     | Commitment units applied                   |

--- a/specification/appendix/commitment_discounts/azure_reservation_no_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/azure_reservation_no_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Usage               |
 | Utilization                  | 100%                |
 | Hours Generated              | 24                  |
-| Annual Commitment            | &dollar;664,008.00  |
-| List Unit Price              | &dollar;113.70/hour |
+| Annual Commitment            | $664,008.00  |
+| List Unit Price              | $113.70/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/azure_reservation_no_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost            | EffectiveCost        |
 | ---------------- | ----- | --------------------- | -------------------- |
-| Purchase         | 1     | &dollar;55,334.00     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00          | &dollar;1,819.20     |
-| **Total**        | 25    | **&dollar;55,334.00** | **&dollar;1,819.20** |
+| Purchase         | 1     | $55,334.00     | $0.00         |
+| Usage (Used)     | 24    | $0.00          | $1,819.20     |
+| **Total**        | 25    | **$55,334.00** | **$1,819.20** |
 
 ## Column Interactions
 
@@ -50,8 +50,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;113.70     |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;113.70     |
+| **ListUnitPrice**       | List (public) unit price | $113.70     |
+| **ContractedUnitPrice** | Negotiated unit price    | $113.70     |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,8 +59,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost        | EffectiveCost | ListCost          |
 | ---------------- | ----------------- | ------------- | ----------------- |
-| **Purchase Row** | &dollar;55,334.00 | &dollar;0.00  | &dollar;55,334.00 |
-| **Used Row**     | &dollar;0.00      | &dollar;75.80 | &dollar;113.70    |
+| **Purchase Row** | $55,334.00 | $0.00  | $55,334.00 |
+| **Used Row**     | $0.00      | $75.80 | $113.70    |
 
 The following critical rules apply to commitment discount data:
 
@@ -73,8 +73,8 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------- | -------------------------------------------------------------- |
 | ChargeCategory             | Purchase                              | Commitment purchase transaction                                |
 | ChargeFrequency            | Recurring                             | Monthly recurring fee                                          |
-| BilledCost                 | &dollar;55,334.00                     | Monthly recurring payment (annual / 12)                        |
-| EffectiveCost              | &dollar;0.00                          | **must be 0** - cost is amortized to usage rows                |
+| BilledCost                 | $55,334.00                     | Monthly recurring payment (annual / 12)                        |
+| EffectiveCost              | $0.00                          | **must be 0** - cost is amortized to usage rows                |
 | PricingQuantity            | 1                                     | One commitment unit purchased                                  |
 | CommitmentDiscountStatus   | null                                  | Status only applies to usage rows                              |
 | CommitmentDiscountQuantity | 672.00                                | Commitment capacity for Feb (1 instance-hr/hr &times; 672 hrs) |
@@ -88,9 +88,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;75.80                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;113.70                                        | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $75.80                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $113.70                                        | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 1                                                     | Commitment units applied                   |

--- a/specification/appendix/commitment_discounts/azure_savings_plan_all_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/azure_savings_plan_all_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Spend              |
 | Utilization                  | 100%               |
 | Hours Generated              | 24                 |
-| Annual Commitment            | &dollar;462,002.40 |
-| List Unit Price              | &dollar;79.11/hour |
+| Annual Commitment            | $462,002.40 |
+| List Unit Price              | $79.11/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/azure_savings_plan_all_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost             | EffectiveCost        |
 | ---------------- | ----- | ---------------------- | -------------------- |
-| Purchase         | 1     | &dollar;462,002.40     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00           | &dollar;1,265.76     |
-| **Total**        | 25    | **&dollar;462,002.40** | **&dollar;1,265.76** |
+| Purchase         | 1     | $462,002.40     | $0.00         |
+| Usage (Used)     | 24    | $0.00           | $1,265.76     |
+| **Total**        | 25    | **$462,002.40** | **$1,265.76** |
 
 ## Column Interactions
 
@@ -44,14 +44,14 @@ These three quantity columns serve different purposes and must be understood in 
 | **ConsumedQuantity**           | Actual resource consumption           | Usage rows with resources     | 1 (hours consumed)         |
 | **CommitmentDiscountQuantity** | Commitment capacity applied           | Rows with commitment discount | 52.74 (USD)                |
 
-**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a &dollar;52.74/hour commitment, this value is &dollar;52.74.
+**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a $52.74/hour commitment, this value is $52.74.
 
 ### Pricing Columns: ListUnitPrice vs ContractedUnitPrice
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;79.11      |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;79.11      |
+| **ListUnitPrice**       | List (public) unit price | $79.11      |
+| **ContractedUnitPrice** | Negotiated unit price    | $79.11      |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,8 +59,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost         | EffectiveCost | ListCost           |
 | ---------------- | ------------------ | ------------- | ------------------ |
-| **Purchase Row** | &dollar;462,002.40 | &dollar;0.00  | &dollar;462,002.40 |
-| **Used Row**     | &dollar;0.00       | &dollar;52.74 | &dollar;79.11      |
+| **Purchase Row** | $462,002.40 | $0.00  | $462,002.40 |
+| **Used Row**     | $0.00       | $52.74 | $79.11      |
 
 The following critical rules apply to commitment discount data:
 
@@ -73,11 +73,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ------------------------------------- | ----------------------------------------------------------- |
 | ChargeCategory             | Purchase                              | Commitment purchase transaction                             |
 | ChargeFrequency            | One-Time                              | One-time upfront payment                                    |
-| BilledCost                 | &dollar;462,002.40                    | Full annual commitment payment                              |
-| EffectiveCost              | &dollar;0.00                          | **must be 0** - cost is amortized to usage rows             |
+| BilledCost                 | $462,002.40                    | Full annual commitment payment                              |
+| EffectiveCost              | $0.00                          | **must be 0** - cost is amortized to usage rows             |
 | PricingQuantity            | 462,002.40                            | Total commitment in USD (PricingUnit = USD)                 |
 | CommitmentDiscountStatus   | null                                  | Status only applies to usage rows                           |
-| CommitmentDiscountQuantity | 462,002.40                            | Full annual commitment (&dollar;52.74/hr &times; 8,760 hrs) |
+| CommitmentDiscountQuantity | 462,002.40                            | Full annual commitment ($52.74/hr &times; 8,760 hrs) |
 | CommitmentDiscountUnit     | USD                                   | Unit of commitment capacity (spend-based)                   |
 | SkuId                      | Azure-EASTUS-COMPUTE-PURCHASE         | Commitment purchase SKU                                     |
 | SkuPriceId                 | Azure-EASTUS-COMPUTE-PURCHASE-UPFRONT | Price point for upfront purchase                            |
@@ -88,9 +88,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;52.74                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;79.11                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $52.74                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $79.11                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 52.74                                                 | Hourly commitment spend applied            |

--- a/specification/appendix/commitment_discounts/commitment_discounts.md
+++ b/specification/appendix/commitment_discounts/commitment_discounts.md
@@ -18,16 +18,16 @@ While customers are bound to the [*period*](#glossary:period) of a *commitment d
 * *No Upfront* - The *commitment discount* is paid on a repeated basis, typically over each [*billing period*](#glossary:billing-period) of the *period*.
 * *Partial Upfront* - Some of the *commitment discount* is paid before the *period* begins, and the rest is paid repeatedly over the *period*.
 
-For example, if a customer buys a 1-year, spend-based *commitment discount* with a &dollar;1.00 hourly commit and pays with the partial option, the *commitment discount's* payment consists of a one-time purchase in the beginning of the *period* *and* monthly recurring purchases. The one-time payment covers half of the annual commitment (AWS Savings Plans are half, Reserved Instances are a portion of the cost), while the recurring payment covers the remaining half and is calculated based on the exact number of hours in each [*billing period*](#glossary:billing-period):
+For example, if a customer buys a 1-year, spend-based *commitment discount* with a $1.00 hourly commit and pays with the partial option, the *commitment discount's* payment consists of a one-time purchase in the beginning of the *period* *and* monthly recurring purchases. The one-time payment covers half of the annual commitment (AWS Savings Plans are half, Reserved Instances are a portion of the cost), while the recurring payment covers the remaining half and is calculated based on the exact number of hours in each [*billing period*](#glossary:billing-period):
 
-1. *One-Time* - &dollar;4,380 (24 hours &times; 365 days &times; &dollar;1.00 &times; 0.5)
-2. *Recurring* - &dollar;336.00 for February (672 hours in the month &times; &dollar;1.00 &times; 0.5)
+1. *One-Time* - $4,380 (24 hours &times; 365 days &times; $1.00 &times; 0.5)
+2. *Recurring* - $336.00 for February (672 hours in the month &times; $1.00 &times; 0.5)
 
 ### Usage
 
 Commitment discounts follow a "use-it-or-lose-it" model where the [*amortization*](#glossary:amortization) of a *commitment discount's* purchase applies evenly to eligible *resources* over each [*charge period*](#glossary:charge-period) of the *period*.
 
-For example, if a customer buys a spend-based *commitment discount* with a &dollar;1.00 hourly commit in January (31 days), only &dollar;1.00 is eligible for consumption for each hourly *charge period*. If a customer has eligible *resources* running during this *charge period*, an amount of up to &dollar;1.00 will be allocated to these *resources*. Conversely, if a customer does not have eligible *resources* running that fully take advantage of this &dollar;1.00 during this *charge period*, then some or all of this amount will go to waste.
+For example, if a customer buys a spend-based *commitment discount* with a $1.00 hourly commit in January (31 days), only $1.00 is eligible for consumption for each hourly *charge period*. If a customer has eligible *resources* running during this *charge period*, an amount of up to $1.00 will be allocated to these *resources*. Conversely, if a customer does not have eligible *resources* running that fully take advantage of this $1.00 during this *charge period*, then some or all of this amount will go to waste.
 
 ## Data Generator Scenarios
 

--- a/specification/appendix/commitment_discounts/gcp_flex_cud_no_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/gcp_flex_cud_no_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Spend              |
 | Utilization                  | 100%               |
 | Hours Generated              | 24                 |
-| Annual Commitment            | &dollar;553,018.80 |
-| List Unit Price              | &dollar;94.70/hour |
+| Annual Commitment            | $553,018.80 |
+| List Unit Price              | $94.70/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/gcp_flex_cud_no_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost            | EffectiveCost        |
 | ---------------- | ----- | --------------------- | -------------------- |
-| Purchase         | 1     | &dollar;42,423.36     | &dollar;0.00         |
-| Usage (Used)     | 24    | &dollar;0.00          | &dollar;1,515.12     |
-| **Total**        | 25    | **&dollar;42,423.36** | **&dollar;1,515.12** |
+| Purchase         | 1     | $42,423.36     | $0.00         |
+| Usage (Used)     | 24    | $0.00          | $1,515.12     |
+| **Total**        | 25    | **$42,423.36** | **$1,515.12** |
 
 ## Column Interactions
 
@@ -44,14 +44,14 @@ These three quantity columns serve different purposes and must be understood in 
 | **ConsumedQuantity**           | Actual resource consumption           | Usage rows with resources     | 1 (hours consumed)         |
 | **CommitmentDiscountQuantity** | Commitment capacity applied           | Rows with commitment discount | 63.13 (USD)                |
 
-**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a &dollar;63.13/hour commitment, this value is &dollar;63.13.
+**For spend-based commitments:** CommitmentDiscountQuantity represents the dollar amount applied, not a count of resources. For a $63.13/hour commitment, this value is $63.13.
 
 ### Pricing Columns: ListUnitPrice vs ContractedUnitPrice
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;94.70      |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;94.70      |
+| **ListUnitPrice**       | List (public) unit price | $94.70      |
+| **ContractedUnitPrice** | Negotiated unit price    | $94.70      |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,8 +59,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost        | EffectiveCost | ListCost          |
 | ---------------- | ----------------- | ------------- | ----------------- |
-| **Purchase Row** | &dollar;42,423.36 | &dollar;0.00  | &dollar;42,423.36 |
-| **Used Row**     | &dollar;0.00      | &dollar;63.13 | &dollar;94.70     |
+| **Purchase Row** | $42,423.36 | $0.00  | $42,423.36 |
+| **Used Row**     | $0.00      | $63.13 | $94.70     |
 
 The following critical rules apply to commitment discount data:
 
@@ -73,11 +73,11 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | --------------------------------------- | -------------------------------------------------------------- |
 | ChargeCategory             | Purchase                                | Commitment purchase transaction                                |
 | ChargeFrequency            | Recurring                               | Monthly recurring fee                                          |
-| BilledCost                 | &dollar;42,423.36                       | Monthly fee (hourly rate &times; 672 hours in Feb)             |
-| EffectiveCost              | &dollar;0.00                            | **must be 0** - cost is amortized to usage rows                |
+| BilledCost                 | $42,423.36                       | Monthly fee (hourly rate &times; 672 hours in Feb)             |
+| EffectiveCost              | $0.00                            | **must be 0** - cost is amortized to usage rows                |
 | PricingQuantity            | 42,423.36                               | Total commitment in USD (PricingUnit = USD)                    |
 | CommitmentDiscountStatus   | null                                    | Status only applies to usage rows                              |
-| CommitmentDiscountQuantity | 42,423.36                               | Commitment capacity for Feb (&dollar;63.13/hr &times; 672 hrs) |
+| CommitmentDiscountQuantity | 42,423.36                               | Commitment capacity for Feb ($63.13/hr &times; 672 hrs) |
 | CommitmentDiscountUnit     | USD                                     | Unit of commitment capacity (spend-based)                      |
 | SkuId                      | GCP-USCENTRAL1-COMPUTE-PURCHASE         | Commitment purchase SKU                                        |
 | SkuPriceId                 | GCP-USCENTRAL1-COMPUTE-PURCHASE-MONTHLY | Price point for recurring purchase                             |
@@ -88,9 +88,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;63.13                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;94.70                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $63.13                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $94.70                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 63.13                                                 | Hourly commitment spend applied            |

--- a/specification/appendix/commitment_discounts/gcp_resource_cud_no_upfront_100pct.md
+++ b/specification/appendix/commitment_discounts/gcp_resource_cud_no_upfront_100pct.md
@@ -7,8 +7,8 @@
 | Commitment Discount Category | Usage              |
 | Utilization                  | 100%               |
 | Hours Generated              | 24                 |
-| Annual Commitment            | &dollar;257,982.00 |
-| List Unit Price              | &dollar;44.18/hour |
+| Annual Commitment            | $257,982.00 |
+| List Unit Price              | $44.18/hour |
 
 [CSV Example](/specification/data/commitment_discount_scenarios/gcp_resource_cud_no_upfront_100pct.csv)
 
@@ -26,9 +26,9 @@ This scenario demonstrates **full utilization** where exactly 100% of the commit
 
 | Row Type         | Count | BilledCost            | EffectiveCost      |
 | ---------------- | ----- | --------------------- | ------------------ |
-| Purchase         | 1     | &dollar;19,790.40     | &dollar;0.00       |
-| Usage (Used)     | 24    | &dollar;0.00          | &dollar;706.80     |
-| **Total**        | 25    | **&dollar;19,790.40** | **&dollar;706.80** |
+| Purchase         | 1     | $19,790.40     | $0.00       |
+| Usage (Used)     | 24    | $0.00          | $706.80     |
+| **Total**        | 25    | **$19,790.40** | **$706.80** |
 
 ## Column Interactions
 
@@ -50,8 +50,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Column                  | Purpose                  | Commitment-Covered |
 | ----------------------- | ------------------------ | ------------------ |
-| **ListUnitPrice**       | List (public) unit price | &dollar;44.18      |
-| **ContractedUnitPrice** | Negotiated unit price    | &dollar;44.18      |
+| **ListUnitPrice**       | List (public) unit price | $44.18      |
+| **ContractedUnitPrice** | Negotiated unit price    | $44.18      |
 
 **Why this matters:** ContractedUnitPrice reflects enterprise-negotiated pricing (e.g., EDP rates), not commitment discount savings. In non-negotiated scenarios, ContractedUnitPrice equals ListUnitPrice. Commitment discount savings are reflected in EffectiveCost, not in unit prices.
 
@@ -59,8 +59,8 @@ These three quantity columns serve different purposes and must be understood in 
 
 | Scenario         | BilledCost        | EffectiveCost | ListCost          |
 | ---------------- | ----------------- | ------------- | ----------------- |
-| **Purchase Row** | &dollar;19,790.40 | &dollar;0.00  | &dollar;19,790.40 |
-| **Used Row**     | &dollar;0.00      | &dollar;29.45 | &dollar;44.18     |
+| **Purchase Row** | $19,790.40 | $0.00  | $19,790.40 |
+| **Used Row**     | $0.00      | $29.45 | $44.18     |
 
 The following critical rules apply to commitment discount data:
 
@@ -73,8 +73,8 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | --------------------------------------- | -------------------------------------------------------------- |
 | ChargeCategory             | Purchase                                | Commitment purchase transaction                                |
 | ChargeFrequency            | Recurring                               | Monthly recurring fee                                          |
-| BilledCost                 | &dollar;19,790.40                       | Monthly fee (hourly rate &times; 672 hours in Feb)             |
-| EffectiveCost              | &dollar;0.00                            | **must be 0** - cost is amortized to usage rows                |
+| BilledCost                 | $19,790.40                       | Monthly fee (hourly rate &times; 672 hours in Feb)             |
+| EffectiveCost              | $0.00                            | **must be 0** - cost is amortized to usage rows                |
 | PricingQuantity            | 1                                       | One commitment unit purchased                                  |
 | CommitmentDiscountStatus   | null                                    | Status only applies to usage rows                              |
 | CommitmentDiscountQuantity | 672.00                                  | Commitment capacity for Feb (1 instance-hr/hr &times; 672 hrs) |
@@ -88,9 +88,9 @@ The following critical rules apply to commitment discount data:
 | -------------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | ChargeCategory             | Usage                                                 | Compute resource consumption               |
 | PricingCategory            | Committed                                             | Priced under commitment discount           |
-| BilledCost                 | &dollar;0.00                                          | **must be 0** - covered by commitment      |
-| EffectiveCost              | &dollar;29.45                                         | Amortized cost (annual / hours)            |
-| ListCost                   | &dollar;44.18                                         | What you would have paid at list price     |
+| BilledCost                 | $0.00                                          | **must be 0** - covered by commitment      |
+| EffectiveCost              | $29.45                                         | Amortized cost (annual / hours)            |
+| ListCost                   | $44.18                                         | What you would have paid at list price     |
 | PricingQuantity            | 1                                                     | Units priced                               |
 | ConsumedQuantity           | 1                                                     | Hours used                                 |
 | CommitmentDiscountQuantity | 1                                                     | Commitment units applied                   |

--- a/specification/appendix/rounding_variance_tolerance.md
+++ b/specification/appendix/rounding_variance_tolerance.md
@@ -21,35 +21,35 @@ The tolerance is the **greater** of the following values:
 ## Scenario 1: Small Invoice (Pass)
 
 * Data: A small invoice with 5 underlying CostAndUsage rows.
-* Values: CostAndUsage sums to &dollar;12.50. InvoiceDetail sums to &dollar;12.52. Difference is **&dollar;0.02**.
+* Values: CostAndUsage sums to $12.50. InvoiceDetail sums to $12.52. Difference is **$0.02**.
 * Limit Calculation:
-  * Statistical Limit: `SQRT(5) * 0.5 * 0.01` = &dollar;0.011.
-  * Floor Limit: `100 * 0.01` = &dollar;1.00.
-  * Effective Tolerance: **&dollar;1.00** (Greater of &dollar;0.011 and &dollar;1.00).
-* Result: **Pass** (Difference &dollar;0.02 < Tolerance &dollar;1.00).
+  * Statistical Limit: `SQRT(5) * 0.5 * 0.01` = $0.011.
+  * Floor Limit: `100 * 0.01` = $1.00.
+  * Effective Tolerance: **$1.00** (Greater of $0.011 and $1.00).
+* Result: **Pass** (Difference $0.02 < Tolerance $1.00).
 
 ## Scenario 2: Small Invoice (Fail)
 
-* Data: A small invoice with 5 underlying CostAndUsage rows where a &dollar;5.00 charge is missing from CostAndUsage.
-* Values: CostAndUsage sums to &dollar;10.00. InvoiceDetail sums to &dollar;15.00. Difference is **&dollar;5.00**.
+* Data: A small invoice with 5 underlying CostAndUsage rows where a $5.00 charge is missing from CostAndUsage.
+* Values: CostAndUsage sums to $10.00. InvoiceDetail sums to $15.00. Difference is **$5.00**.
 * Limit Calculation:
-  * Effective Tolerance: **&dollar;1.00**.
-* Result: **Fail** (Difference &dollar;5.00 > Tolerance &dollar;1.00).
+  * Effective Tolerance: **$1.00**.
+* Result: **Fail** (Difference $5.00 > Tolerance $1.00).
 
 ## Scenario 3: Large Invoice (Pass)
 
 * Data: An enterprise invoice with 1,000,000 underlying CostAndUsage rows.
-* Values: CostAndUsage sums to &dollar;5,000,000.00. InvoiceDetail sums to &dollar;5,000,004.50. Difference is **&dollar;4.50**.
+* Values: CostAndUsage sums to $5,000,000.00. InvoiceDetail sums to $5,000,004.50. Difference is **$4.50**.
 * Limit Calculation:
-  * Statistical Limit: `SQRT(1,000,000) * 0.5 * 0.01` = &dollar;5.00.
-  * Floor Limit: `100 * 0.01` = &dollar;1.00.
-  * Effective Tolerance: **&dollar;5.00** (Greater of &dollar;5.00 and &dollar;1.00).
-* Result: **Pass** (Difference &dollar;4.50 < Tolerance &dollar;5.00).
+  * Statistical Limit: `SQRT(1,000,000) * 0.5 * 0.01` = $5.00.
+  * Floor Limit: `100 * 0.01` = $1.00.
+  * Effective Tolerance: **$5.00** (Greater of $5.00 and $1.00).
+* Result: **Pass** (Difference $4.50 < Tolerance $5.00).
 
 ## Scenario 4: Large Invoice (Fail)
 
 * Data: An enterprise invoice with 1,000,000 underlying CostAndUsage rows with a systematic rounding error (truncation bias).
-* Values: CostAndUsage sums to &dollar;5,000,000.00. InvoiceDetail sums to &dollar;5,000,015.00. Difference is **&dollar;15.00**.
+* Values: CostAndUsage sums to $5,000,000.00. InvoiceDetail sums to $5,000,015.00. Difference is **$15.00**.
 * Limit Calculation:
-  * Effective Tolerance: **&dollar;5.00**.
-* Result: **Fail** (Difference &dollar;15.00 > Tolerance &dollar;5.00).
+  * Effective Tolerance: **$5.00**.
+* Result: **Fail** (Difference $15.00 > Tolerance $5.00).

--- a/specification/appendix/saas_examples/billing_scenario_examples.md
+++ b/specification/appendix/saas_examples/billing_scenario_examples.md
@@ -22,9 +22,9 @@ The *service provider*'s on-demand pricing for this example:
 
 | Service | SKU | Unit Price | Pricing Unit | Credits/Hour |
 | :------ | :-- | ---------: | :----------- | -----------: |
-| Virtual Warehouse Compute | XS Warehouse | &dollar;3.00 | Credits | 1 |
-| Virtual Warehouse Compute | Medium Warehouse | &dollar;3.00 | Credits | 4 |
-| Storage | Active Storage | &dollar;23.00 | TB | n/a |
+| Virtual Warehouse Compute | XS Warehouse | $3.00 | Credits | 1 |
+| Virtual Warehouse Compute | Medium Warehouse | $3.00 | Credits | 4 |
+| Storage | Active Storage | $23.00 | TB | n/a |
 
 Credit consumption varies by warehouse size. An XS warehouse consumes 1 credit per hour. A Medium warehouse consumes 4 credits per hour.
 
@@ -36,11 +36,11 @@ A customer runs two warehouses in the US East region during January 2025:
 
 Three usage charges appear on the January invoice:
 
-* XS Warehouse: `200 Credits x $3.00` = &dollar;600.00
-* Medium Warehouse: `320 Credits x $3.00` = &dollar;960.00
-* Active Storage: `5 TB x $23.00` = &dollar;115.00
+* XS Warehouse: `200 Credits x $3.00` = $600.00
+* Medium Warehouse: `320 Credits x $3.00` = $960.00
+* Active Storage: `5 TB x $23.00` = $115.00
 
-Total [BilledCost](#datasets.costandusage.billedcost): &dollar;1,675.00
+Total [BilledCost](#datasets.costandusage.billedcost): $1,675.00
 
 Here is how these charges appear in the data (relevant columns only):
 
@@ -50,16 +50,16 @@ Here is how these charges appear in the data (relevant columns only):
 | ChargeFrequency | Usage-Based | Usage-Based | Recurring |
 | ConsumedQuantity | 200 | 320 | 5 |
 | ConsumedUnit | Credits | Credits | TB |
-| BilledCost | &dollar;600.00 | &dollar;960.00 | &dollar;115.00 |
-| EffectiveCost | &dollar;600.00 | &dollar;960.00 | &dollar;115.00 |
-| ListCost | &dollar;600.00 | &dollar;960.00 | &dollar;115.00 |
-| ContractedCost | &dollar;600.00 | &dollar;960.00 | &dollar;115.00 |
+| BilledCost | $600.00 | $960.00 | $115.00 |
+| EffectiveCost | $600.00 | $960.00 | $115.00 |
+| ListCost | $600.00 | $960.00 | $115.00 |
+| ContractedCost | $600.00 | $960.00 | $115.00 |
 | PricingUnit | Credits | Credits | TB |
 | PricingCategory | Standard | Standard | Standard |
 
 Key observations:
 
-* Both warehouses share the same [ListUnitPrice](#datasets.costandusage.listunitprice) of &dollar;3.00 per credit. The credit price is determined by the service edition, not warehouse size.
+* Both warehouses share the same [ListUnitPrice](#datasets.costandusage.listunitprice) of $3.00 per credit. The credit price is determined by the service edition, not warehouse size.
 * [ConsumedUnit](#datasets.costandusage.consumedunit) is "Credits" for compute and "TB" for storage. The credit is the *service provider*'s unit of compute consumption.
 * [ChargeFrequency](#datasets.costandusage.chargefrequency) is "Usage-Based" for compute (metered by credit consumption) and "Recurring" for storage (billed per TB per month).
 * Storage has no [ResourceId](#datasets.costandusage.resourceid) or [ResourceName](#datasets.costandusage.resourcename) because it is an account-level charge, not tied to a specific [*resource*](#glossary:resource).
@@ -75,9 +75,9 @@ The *service provider*'s on-demand pricing for this example:
 
 | Service | SKU | Unit Price | Pricing Unit |
 | :------ | :-- | ---------: | :----------- |
-| Infrastructure Monitoring | Infra Pro | &dollar;18.00 | Hosts |
-| APM | APM Standard | &dollar;36.00 | Hosts |
-| Log Management | Log Ingestion | &dollar;0.10 | GB |
+| Infrastructure Monitoring | Infra Pro | $18.00 | Hosts |
+| APM | APM Standard | $36.00 | Hosts |
+| Log Management | Log Ingestion | $0.10 | GB |
 
 A customer uses the *service provider*'s monitoring platform on a month-to-month basis with no annual commitment. During January 2025, the customer's usage is:
 
@@ -87,11 +87,11 @@ A customer uses the *service provider*'s monitoring platform on a month-to-month
 
 Three usage charges appear on the January invoice:
 
-* Infrastructure Monitoring: `25 Hosts x $18.00` = &dollar;450.00
-* APM: `10 Hosts x $36.00` = &dollar;360.00
-* Log Management: `150 GB x $0.10` = &dollar;15.00
+* Infrastructure Monitoring: `25 Hosts x $18.00` = $450.00
+* APM: `10 Hosts x $36.00` = $360.00
+* Log Management: `150 GB x $0.10` = $15.00
 
-Total [BilledCost](#datasets.costandusage.billedcost): &dollar;825.00
+Total [BilledCost](#datasets.costandusage.billedcost): $825.00
 
 Here is how these charges appear in the data (relevant columns only):
 
@@ -101,10 +101,10 @@ Here is how these charges appear in the data (relevant columns only):
 | ChargeFrequency | Recurring | Recurring | Usage-Based |
 | ConsumedQuantity | 25 | 10 | 150 |
 | ConsumedUnit | Hosts | Hosts | GB |
-| BilledCost | &dollar;450.00 | &dollar;360.00 | &dollar;15.00 |
-| EffectiveCost | &dollar;450.00 | &dollar;360.00 | &dollar;15.00 |
-| ListCost | &dollar;450.00 | &dollar;360.00 | &dollar;15.00 |
-| ContractedCost | &dollar;450.00 | &dollar;360.00 | &dollar;15.00 |
+| BilledCost | $450.00 | $360.00 | $15.00 |
+| EffectiveCost | $450.00 | $360.00 | $15.00 |
+| ListCost | $450.00 | $360.00 | $15.00 |
+| ContractedCost | $450.00 | $360.00 | $15.00 |
 | PricingUnit | Hosts | Hosts | GB |
 | PricingCategory | Standard | Standard | Standard |
 
@@ -127,12 +127,12 @@ The [*service provider*](#glossary:service%20provider), SprintCanvas, offers a p
 
 | Billing Option | Unit Price | Monthly Cost (50 users) | Annual Cost |
 | :------------- | ---------: | ----------------------: | ----------: |
-| Monthly | &dollar;9.05/user/month | &dollar;452.50 | &dollar;5,430.00 |
-| Annual | &dollar;7.58/user/month | &dollar;379.00 | &dollar;4,550.00 |
+| Monthly | $9.05/user/month | $452.50 | $5,430.00 |
+| Annual | $7.58/user/month | $379.00 | $4,550.00 |
 
 The annual option represents a ~16% discount versus monthly billing.
 
-A customer subscribes to the Standard plan for 50 users on April 1, 2025. They choose the annual billing option, paying &dollar;4,550.00 upfront for a 12-month term ending April 1, 2026. All 50 seats are occupied in the first month.
+A customer subscribes to the Standard plan for 50 users on April 1, 2025. They choose the annual billing option, paying $4,550.00 upfront for a 12-month term ending April 1, 2026. All 50 seats are occupied in the first month.
 
 Two charges appear in the April 2025 [*billing period*](#glossary:billing-period):
 
@@ -148,35 +148,35 @@ Here is how these charges appear in the data (relevant columns only):
 | CommitmentDiscountUnit | USD | USD |
 | ConsumedQuantity | *(null)* | 50 |
 | ConsumedUnit | *(null)* | Users |
-| BilledCost | &dollar;4,550.00 | &dollar;0.00 |
-| EffectiveCost | &dollar;0.00 | &dollar;379.00 |
-| ListCost | &dollar;5,430.00 | &dollar;452.50 |
-| ContractedCost | &dollar;5,430.00 | &dollar;452.50 |
+| BilledCost | $4,550.00 | $0.00 |
+| EffectiveCost | $0.00 | $379.00 |
+| ListCost | $5,430.00 | $452.50 |
+| ContractedCost | $5,430.00 | $452.50 |
 | PricingUnit | Count | Users |
 | PricingCategory | Standard | Committed |
 
 **Purchase Charge:** [ChargeCategory](#datasets.costandusage.chargecategory) is "Purchase" with [ChargeFrequency](#datasets.costandusage.chargefrequency) "One-Time". The full annual amount is invoiced in a single payment.
 * The [*charge period*](#glossary:chargeperiod) spans the entire commitment term: April 1, 2025 through April 1, 2026.
-* [BilledCost](#datasets.costandusage.billedcost) is &dollar;4,550.00. This is the [*cash-based*](#glossary:cash-based-accounting) invoiced amount for the annual subscription.
-* [EffectiveCost](#datasets.costandusage.effectivecost) is &dollar;0.00. The purchase covers future usage. Cost is recognized on an [*accrual basis*](#glossary:accrual-based-accounting) as usage occurs.
-* [ListCost](#datasets.costandusage.listcost) is &dollar;5,430.00 (`50 users x $9.05/user/month x 12 months`). This represents the cost without the annual discount.
-* [ContractedCost](#datasets.costandusage.contractedcost) is &dollar;5,430.00, equal to [ListCost](#datasets.costandusage.listcost). Because no [*negotiated discounts*](#glossary:negotiated-discount) apply (the annual rate is a published [*commitment discount*](#glossary:commitment-discount), not a bilateral negotiation), [ContractedUnitPrice](#datasets.costandusage.contractedunitprice) defaults to [ListUnitPrice](#datasets.costandusage.listunitprice) per the spec. The difference between [ContractedCost](#datasets.costandusage.contractedcost) (&dollar;5,430.00) and [BilledCost](#datasets.costandusage.billedcost) (&dollar;4,550.00) represents the &dollar;880.00 in [*commitment discount*](#glossary:commitment-discount) savings at the point of purchase.
+* [BilledCost](#datasets.costandusage.billedcost) is $4,550.00. This is the [*cash-based*](#glossary:cash-based-accounting) invoiced amount for the annual subscription.
+* [EffectiveCost](#datasets.costandusage.effectivecost) is $0.00. The purchase covers future usage. Cost is recognized on an [*accrual basis*](#glossary:accrual-based-accounting) as usage occurs.
+* [ListCost](#datasets.costandusage.listcost) is $5,430.00 (`50 users x $9.05/user/month x 12 months`). This represents the cost without the annual discount.
+* [ContractedCost](#datasets.costandusage.contractedcost) is $5,430.00, equal to [ListCost](#datasets.costandusage.listcost). Because no [*negotiated discounts*](#glossary:negotiated-discount) apply (the annual rate is a published [*commitment discount*](#glossary:commitment-discount), not a bilateral negotiation), [ContractedUnitPrice](#datasets.costandusage.contractedunitprice) defaults to [ListUnitPrice](#datasets.costandusage.listunitprice) per the spec. The difference between [ContractedCost](#datasets.costandusage.contractedcost) ($5,430.00) and [BilledCost](#datasets.costandusage.billedcost) ($4,550.00) represents the $880.00 in [*commitment discount*](#glossary:commitment-discount) savings at the point of purchase.
 * [ResourceId](#datasets.costandusage.resourceid) equals [CommitmentDiscountId](#datasets.costandusage.commitmentdiscountid). The [*commitment discount*](#glossary:commitment-discount) itself is the [*resource*](#glossary:resource) being purchased.
 * [CommitmentDiscountCategory](#datasets.costandusage.commitmentdiscountcategory) is "Spend" because the commitment is denominated in dollars, not usage units.
 * [CommitmentDiscountQuantity](#datasets.costandusage.commitmentdiscountquantity) is 4,550.00 [CommitmentDiscountUnit](#datasets.costandusage.commitmentdiscountunit) (USD). This is the total spend eligible for consumption over the term.
 * [PricingCategory](#datasets.costandusage.pricingcategory) is "Standard". The purchase of the [*commitment discount*](#glossary:commitment-discount) is at the agreed-upon rate.
 
 **Usage Charge (April 2025):** [ChargeCategory](#datasets.costandusage.chargecategory) is "Usage" with [PricingCategory](#datasets.costandusage.pricingcategory) "Committed". The usage is covered by the annual purchase.
-* [BilledCost](#datasets.costandusage.billedcost) is &dollar;0.00. No additional invoiced amount. The usage is covered by the purchase charge.
-* [EffectiveCost](#datasets.costandusage.effectivecost) is &dollar;379.00. This is the [*accrual-based*](#glossary:accrual-based-accounting) recognized portion of the annual commitment: `$7.58/user x 50 users`.
-* [ListCost](#datasets.costandusage.listcost) is &dollar;452.50 (`50 users x $9.05/user`). The monthly list cost without the annual discount.
-* [ContractedCost](#datasets.costandusage.contractedcost) is &dollar;452.50, equal to [ListCost](#datasets.costandusage.listcost). No [*negotiated discounts*](#glossary:negotiated-discount) apply, so [ContractedUnitPrice](#datasets.costandusage.contractedunitprice) defaults to [ListUnitPrice](#datasets.costandusage.listunitprice).
-* The [*commitment discount*](#glossary:commitment-discount) savings appear in the difference between [ContractedCost](#datasets.costandusage.contractedcost) (&dollar;452.50) and [EffectiveCost](#datasets.costandusage.effectivecost) (&dollar;379.00): &dollar;73.50 per month.
+* [BilledCost](#datasets.costandusage.billedcost) is $0.00. No additional invoiced amount. The usage is covered by the purchase charge.
+* [EffectiveCost](#datasets.costandusage.effectivecost) is $379.00. This is the [*accrual-based*](#glossary:accrual-based-accounting) recognized portion of the annual commitment: `$7.58/user x 50 users`.
+* [ListCost](#datasets.costandusage.listcost) is $452.50 (`50 users x $9.05/user`). The monthly list cost without the annual discount.
+* [ContractedCost](#datasets.costandusage.contractedcost) is $452.50, equal to [ListCost](#datasets.costandusage.listcost). No [*negotiated discounts*](#glossary:negotiated-discount) apply, so [ContractedUnitPrice](#datasets.costandusage.contractedunitprice) defaults to [ListUnitPrice](#datasets.costandusage.listunitprice).
+* The [*commitment discount*](#glossary:commitment-discount) savings appear in the difference between [ContractedCost](#datasets.costandusage.contractedcost) ($452.50) and [EffectiveCost](#datasets.costandusage.effectivecost) ($379.00): $73.50 per month.
 * [CommitmentDiscountStatus](#datasets.costandusage.commitmentdiscountstatus) is "Used". All 50 seats are occupied.
 * [CommitmentDiscountQuantity](#datasets.costandusage.commitmentdiscountquantity) is 379.00 USD. This is the amount of spend consumed from the commitment in this [*charge period*](#glossary:chargeperiod).
 * [ResourceId](#datasets.costandusage.resourceid) is the actual [*resource*](#glossary:resource) (the customer's project management site), not the [*commitment discount*](#glossary:commitment-discount).
 
-**Rounding Note:** The per-user rate of &dollar;7.58 is derived from `$4,550 / 12 months / 50 users` = &dollar;7.5833, rounded to two decimal places. This means `$7.58 x 50 users x 12 months` = &dollar;4,548.00, which is &dollar;2.00 less than the &dollar;4,550.00 purchase. In a full 12-month dataset, the final month's charge would include a true-up to ensure the sum of [EffectiveCost](#datasets.costandusage.effectivecost) across all usage rows equals the [BilledCost](#datasets.costandusage.billedcost) of the purchase row.
+**Rounding Note:** The per-user rate of $7.58 is derived from `$4,550 / 12 months / 50 users` = $7.5833, rounded to two decimal places. This means `$7.58 x 50 users x 12 months` = $4,548.00, which is $2.00 less than the $4,550.00 purchase. In a full 12-month dataset, the final month's charge would include a true-up to ensure the sum of [EffectiveCost](#datasets.costandusage.effectivecost) across all usage rows equals the [BilledCost](#datasets.costandusage.billedcost) of the purchase row.
 
 [**CSV Example**](/specification/data/saas_examples/seat_based_saas_annual_a.csv)
 
@@ -188,26 +188,26 @@ The *service provider*'s on-demand pricing for this example:
 
 | Service | SKU | Unit Price | Pricing Unit |
 | :------ | :-- | ---------: | :----------- |
-| StoreStack Clusters | M10 Cluster | &dollar;0.08 | Hours |
-| StoreStack Clusters | M30 Cluster | &dollar;0.54 | Hours |
-| StoreStack Storage | SSD Storage | &dollar;0.25 | GB |
-| StoreStack Data Transfer | Data Transfer Out | &dollar;0.01 | GB |
+| StoreStack Clusters | M10 Cluster | $0.08 | Hours |
+| StoreStack Clusters | M30 Cluster | $0.54 | Hours |
+| StoreStack Storage | SSD Storage | $0.25 | GB |
+| StoreStack Data Transfer | Data Transfer Out | $0.01 | GB |
 
 A customer runs two dedicated database clusters in the US East region for the full month of January 2025 (744 hours). They also consume 100 GB of SSD storage and 50 GB of outbound data transfer.
 
-* 1x M10 cluster (analytics workload): 744 hours at &dollar;0.08/hour
-* 1x M30 cluster (production workload): 744 hours at &dollar;0.54/hour
+* 1x M10 cluster (analytics workload): 744 hours at $0.08/hour
+* 1x M30 cluster (production workload): 744 hours at $0.54/hour
 * 100 GB of SSD storage
 * 50 GB of outbound data transfer
 
 Four usage charges appear on the January invoice:
 
-* M10 Cluster: `744 Hours x $0.08` = &dollar;59.52
-* M30 Cluster: `744 Hours x $0.54` = &dollar;401.76
-* SSD Storage: `100 GB x $0.25` = &dollar;25.00
-* Data Transfer Out: `50 GB x $0.01` = &dollar;0.50
+* M10 Cluster: `744 Hours x $0.08` = $59.52
+* M30 Cluster: `744 Hours x $0.54` = $401.76
+* SSD Storage: `100 GB x $0.25` = $25.00
+* Data Transfer Out: `50 GB x $0.01` = $0.50
 
-Total [BilledCost](#datasets.costandusage.billedcost): &dollar;486.78
+Total [BilledCost](#datasets.costandusage.billedcost): $486.78
 
 Here is how these charges appear in the data (relevant columns only):
 
@@ -217,10 +217,10 @@ Here is how these charges appear in the data (relevant columns only):
 | ChargeFrequency | Usage-Based | Usage-Based | Recurring | Usage-Based |
 | ConsumedQuantity | 744 | 744 | 100 | 50 |
 | ConsumedUnit | Hours | Hours | GB | GB |
-| BilledCost | &dollar;59.52 | &dollar;401.76 | &dollar;25.00 | &dollar;0.50 |
-| EffectiveCost | &dollar;59.52 | &dollar;401.76 | &dollar;25.00 | &dollar;0.50 |
-| ListCost | &dollar;59.52 | &dollar;401.76 | &dollar;25.00 | &dollar;0.50 |
-| ContractedCost | &dollar;59.52 | &dollar;401.76 | &dollar;25.00 | &dollar;0.50 |
+| BilledCost | $59.52 | $401.76 | $25.00 | $0.50 |
+| EffectiveCost | $59.52 | $401.76 | $25.00 | $0.50 |
+| ListCost | $59.52 | $401.76 | $25.00 | $0.50 |
+| ContractedCost | $59.52 | $401.76 | $25.00 | $0.50 |
 | PricingUnit | Hours | Hours | GB | GB |
 | PricingCategory | Standard | Standard | Standard | Standard |
 | RegionId | us-east-1 | us-east-1 | us-east-1 | us-east-1 |
@@ -244,17 +244,17 @@ The *service provider*'s pricing for this example:
 
 | Service | SKU | Unit Price | Pricing Unit |
 | :------ | :-- | ---------: | :----------- |
-| CollabChat | Pro Unlimited | &dollar;349.00 | Subscriptions |
+| CollabChat | Pro Unlimited | $349.00 | Subscriptions |
 
-The *service provider* also offers an annual billing option at &dollar;299.00 per month (billed annually). This example uses the month-to-month option with no annual commitment.
+The *service provider* also offers an annual billing option at $299.00 per month (billed annually). This example uses the month-to-month option with no annual commitment.
 
 A customer subscribes to the Pro Unlimited plan on a month-to-month basis. During January 2025, the customer's team of 35 people uses the platform.
 
 One charge appears on the January invoice:
 
-* Pro Unlimited: `1 Subscription x $349.00` = &dollar;349.00
+* Pro Unlimited: `1 Subscription x $349.00` = $349.00
 
-Total [BilledCost](#datasets.costandusage.billedcost): &dollar;349.00
+Total [BilledCost](#datasets.costandusage.billedcost): $349.00
 
 Here is how this charge appears in the data (relevant columns only):
 
@@ -264,10 +264,10 @@ Here is how this charge appears in the data (relevant columns only):
 | ChargeFrequency | Recurring |
 | ConsumedQuantity | 1 |
 | ConsumedUnit | Subscriptions |
-| BilledCost | &dollar;349.00 |
-| EffectiveCost | &dollar;349.00 |
-| ListCost | &dollar;349.00 |
-| ContractedCost | &dollar;349.00 |
+| BilledCost | $349.00 |
+| EffectiveCost | $349.00 |
+| ListCost | $349.00 |
+| ContractedCost | $349.00 |
 | PricingUnit | Subscriptions |
 | PricingQuantity | 1 |
 | PricingCategory | Standard |
@@ -277,7 +277,7 @@ Key observations:
 * [ChargeFrequency](#datasets.costandusage.chargefrequency) is "Recurring". The subscription is a fixed monthly fee regardless of usage activity or user count within the [*billing period*](#glossary:billing-period).
 * [PricingUnit](#datasets.costandusage.pricingunit) is "Subscriptions" and [PricingQuantity](#datasets.costandusage.pricingquantity) is 1. Unlike per-seat or per-unit models, the entire platform is a single billable unit.
 * There is no relationship between [ConsumedQuantity](#datasets.costandusage.consumedquantity) and the number of users. The 35-person team does not affect the charge.
-* If the customer chose the annual billing option (&dollar;299.00/month billed annually), this would follow a [*commitment discount*](#glossary:commitment-discount) pattern similar to the Seat-Based SaaS Subscription example above, with a Purchase row for the annual payment and monthly Usage rows for amortized [EffectiveCost](#datasets.costandusage.effectivecost).
+* If the customer chose the annual billing option ($299.00/month billed annually), this would follow a [*commitment discount*](#glossary:commitment-discount) pattern similar to the Seat-Based SaaS Subscription example above, with a Purchase row for the annual payment and monthly Usage rows for amortized [EffectiveCost](#datasets.costandusage.effectivecost).
 * [BilledCost](#datasets.costandusage.billedcost) and [EffectiveCost](#datasets.costandusage.effectivecost) are equal because there are no purchase [*charges*](#glossary:charge) covering future usage (see the Credit-Based Consumption example for a full explanation of when these columns diverge).
 
 [**CSV Example**](/specification/data/saas_examples/flat_rate_saas_licensing_a.csv)
@@ -290,16 +290,16 @@ The *service provider*'s pricing for this example (Professional plan, 10 users):
 
 | Billing Option | Unit Price | Monthly Cost (10 users) | Annual Cost |
 | :------------- | ---------: | ----------------------: | ----------: |
-| Annual (pay upfront) | &dollar;90.00/user/month | &dollar;900.00 | &dollar;10,800.00 |
-| Annual (billed monthly) | &dollar;100.00/user/month | &dollar;1,000.00 | &dollar;12,000.00 |
+| Annual (pay upfront) | $90.00/user/month | $900.00 | $10,800.00 |
+| Annual (billed monthly) | $100.00/user/month | $1,000.00 | $12,000.00 |
 
-A customer subscribes to the Professional plan for 10 users, choosing the annual commitment with monthly billing. They pay &dollar;100.00 per user per month with no upfront payment.
+A customer subscribes to the Professional plan for 10 users, choosing the annual commitment with monthly billing. They pay $100.00 per user per month with no upfront payment.
 
 One charge appears on the January 2025 invoice:
 
-* Sales Platform Professional: `10 Users x $100.00` = &dollar;1,000.00
+* Sales Platform Professional: `10 Users x $100.00` = $1,000.00
 
-Total [BilledCost](#datasets.costandusage.billedcost): &dollar;1,000.00
+Total [BilledCost](#datasets.costandusage.billedcost): $1,000.00
 
 Here is how this charge appears in the data (relevant columns only):
 
@@ -309,19 +309,19 @@ Here is how this charge appears in the data (relevant columns only):
 | ChargeFrequency | Recurring |
 | ConsumedQuantity | 10 |
 | ConsumedUnit | Users |
-| BilledCost | &dollar;1,000.00 |
-| EffectiveCost | &dollar;1,000.00 |
-| ListCost | &dollar;1,000.00 |
-| ContractedCost | &dollar;1,000.00 |
+| BilledCost | $1,000.00 |
+| EffectiveCost | $1,000.00 |
+| ListCost | $1,000.00 |
+| ContractedCost | $1,000.00 |
 | PricingUnit | Users |
 | PricingCategory | Standard |
 
 Key observations:
 
-* [BilledCost](#datasets.costandusage.billedcost), [EffectiveCost](#datasets.costandusage.effectivecost), [ListCost](#datasets.costandusage.listcost), and [ContractedCost](#datasets.costandusage.contractedcost) are all equal at &dollar;1,000.00. Monthly billing on an annual contract produces no divergence between [*cash-based*](#glossary:cash-based-accounting) and [*accrual-based*](#glossary:accrual-based-accounting) costs because there is no upfront payment to amortize.
+* [BilledCost](#datasets.costandusage.billedcost), [EffectiveCost](#datasets.costandusage.effectivecost), [ListCost](#datasets.costandusage.listcost), and [ContractedCost](#datasets.costandusage.contractedcost) are all equal at $1,000.00. Monthly billing on an annual contract produces no divergence between [*cash-based*](#glossary:cash-based-accounting) and [*accrual-based*](#glossary:accrual-based-accounting) costs because there is no upfront payment to amortize.
 * [PricingCategory](#datasets.costandusage.pricingcategory) is "Standard" because the billed rate equals the [ListUnitPrice](#datasets.costandusage.listunitprice). The annual contract is a term commitment, not a pricing discount. No [*commitment discount*](#glossary:commitment-discount) columns are populated.
 * [ChargeFrequency](#datasets.costandusage.chargefrequency) is "Recurring" because the charge recurs monthly at a fixed per-seat rate regardless of usage activity within the [*billing period*](#glossary:billing-period).
-* If the customer chose the annual pay-upfront option (&dollar;90.00/user/month), the &dollar;10.00 per-seat discount would qualify as a [*commitment discount*](#glossary:commitment-discount), following the pattern in the Seat-Based SaaS Subscription example with a Purchase row and amortized [EffectiveCost](#datasets.costandusage.effectivecost).
+* If the customer chose the annual pay-upfront option ($90.00/user/month), the $10.00 per-seat discount would qualify as a [*commitment discount*](#glossary:commitment-discount), following the pattern in the Seat-Based SaaS Subscription example with a Purchase row and amortized [EffectiveCost](#datasets.costandusage.effectivecost).
 * This scenario demonstrates that an annual contract does not automatically produce a [*commitment discount*](#glossary:commitment-discount) in FOCUS. The distinguishing factor is whether the commitment provides a price reduction from the standard rate.
 
 [**CSV Example**](/specification/data/saas_examples/annual_commitment_billed_monthly_a.csv)
@@ -334,8 +334,8 @@ The *service provider*'s pricing for this example (Essentials 50K plan):
 
 | Component | Rate | Unit |
 | :-------- | ---: | :--- |
-| Plan fee (includes 50,000 emails) | &dollar;19.95 | Count |
-| Overage | &dollar;0.00133 | Emails |
+| Plan fee (includes 50,000 emails) | $19.95 | Count |
+| Overage | $0.00133 | Emails |
 
 This example covers two billing periods to show both under-minimum and over-minimum scenarios:
 
@@ -344,13 +344,13 @@ This example covers two billing periods to show both under-minimum and over-mini
 
 **January charges (under minimum):**
 
-The monthly plan fee of &dollar;19.95 appears as a Purchase charge. Two Usage charges split the commitment between used and unused portions:
+The monthly plan fee of $19.95 appears as a Purchase charge. Two Usage charges split the commitment between used and unused portions:
 
-* Purchase: &dollar;19.95 (plan fee covering 50,000 emails)
-* Used: 30,000 emails, [EffectiveCost](#datasets.costandusage.effectivecost) = &dollar;11.97 (`30,000 / 50,000 x $19.95`)
-* Unused: 20,000 emails, [EffectiveCost](#datasets.costandusage.effectivecost) = &dollar;7.98 (`20,000 / 50,000 x $19.95`)
+* Purchase: $19.95 (plan fee covering 50,000 emails)
+* Used: 30,000 emails, [EffectiveCost](#datasets.costandusage.effectivecost) = $11.97 (`30,000 / 50,000 x $19.95`)
+* Unused: 20,000 emails, [EffectiveCost](#datasets.costandusage.effectivecost) = $7.98 (`20,000 / 50,000 x $19.95`)
 
-Total [BilledCost](#datasets.costandusage.billedcost): &dollar;19.95
+Total [BilledCost](#datasets.costandusage.billedcost): $19.95
 
 Here is how the January charges appear in the data (relevant columns only):
 
@@ -364,10 +364,10 @@ Here is how the January charges appear in the data (relevant columns only):
 | CommitmentDiscountUnit | Emails | Emails | Emails |
 | ConsumedQuantity | *(null)* | 30,000 | *(null)* |
 | ConsumedUnit | *(null)* | Emails | *(null)* |
-| BilledCost | &dollar;19.95 | &dollar;0.00 | &dollar;0.00 |
-| EffectiveCost | &dollar;0.00 | &dollar;11.97 | &dollar;7.98 |
-| ListCost | &dollar;19.95 | &dollar;39.90 | &dollar;26.60 |
-| ContractedCost | &dollar;19.95 | &dollar;39.90 | &dollar;26.60 |
+| BilledCost | $19.95 | $0.00 | $0.00 |
+| EffectiveCost | $0.00 | $11.97 | $7.98 |
+| ListCost | $19.95 | $39.90 | $26.60 |
+| ContractedCost | $19.95 | $39.90 | $26.60 |
 | PricingUnit | Count | Emails | Emails |
 | PricingCategory | Standard | Committed | Committed |
 
@@ -375,11 +375,11 @@ Here is how the January charges appear in the data (relevant columns only):
 
 The customer uses all 50,000 plan emails plus 15,000 overage emails:
 
-* Purchase: &dollar;19.95 (plan fee covering 50,000 emails)
-* Used: 50,000 emails, [EffectiveCost](#datasets.costandusage.effectivecost) = &dollar;19.95 (full allowance consumed)
-* Overage: 15,000 emails at &dollar;0.00133 = &dollar;19.95 (standard pricing, not part of commitment)
+* Purchase: $19.95 (plan fee covering 50,000 emails)
+* Used: 50,000 emails, [EffectiveCost](#datasets.costandusage.effectivecost) = $19.95 (full allowance consumed)
+* Overage: 15,000 emails at $0.00133 = $19.95 (standard pricing, not part of commitment)
 
-Total [BilledCost](#datasets.costandusage.billedcost): &dollar;39.90
+Total [BilledCost](#datasets.costandusage.billedcost): $39.90
 
 Here is how the February charges appear in the data (relevant columns only):
 
@@ -393,21 +393,21 @@ Here is how the February charges appear in the data (relevant columns only):
 | CommitmentDiscountUnit | Emails | Emails | *(null)* |
 | ConsumedQuantity | *(null)* | 50,000 | 15,000 |
 | ConsumedUnit | *(null)* | Emails | Emails |
-| BilledCost | &dollar;19.95 | &dollar;0.00 | &dollar;19.95 |
-| EffectiveCost | &dollar;0.00 | &dollar;19.95 | &dollar;19.95 |
-| ListCost | &dollar;19.95 | &dollar;66.50 | &dollar;19.95 |
-| ContractedCost | &dollar;19.95 | &dollar;66.50 | &dollar;19.95 |
+| BilledCost | $19.95 | $0.00 | $19.95 |
+| EffectiveCost | $0.00 | $19.95 | $19.95 |
+| ListCost | $19.95 | $66.50 | $19.95 |
+| ContractedCost | $19.95 | $66.50 | $19.95 |
 | PricingUnit | Count | Emails | Emails |
 | PricingCategory | Standard | Committed | Standard |
 
 Key observations:
 
 * [CommitmentDiscountCategory](#datasets.costandusage.commitmentdiscountcategory) is "Usage" on all commitment-related rows. The plan minimum is denominated in email quantity (50,000 emails), not a dollar amount. This distinguishes it from the "Spend" category in the Seat-Based SaaS Subscription example.
-* [CommitmentDiscountStatus](#datasets.costandusage.commitmentdiscountstatus) shows "Used" and "Unused" on Usage rows. In January, the customer only consumed 30,000 of 50,000 emails, so the remaining 20,000 generate an "Unused" row. The Unused row has [BilledCost](#datasets.costandusage.billedcost) of &dollar;0.00 but [EffectiveCost](#datasets.costandusage.effectivecost) of &dollar;7.98, representing waste from the commitment.
-* The Purchase row has [BilledCost](#datasets.costandusage.billedcost) of &dollar;19.95 and [EffectiveCost](#datasets.costandusage.effectivecost) of &dollar;0.00. This follows the same pattern as the Seat-Based SaaS Subscription: the purchase captures the [*cash-based*](#glossary:cash-based-accounting) cost, while [*accrual-based*](#glossary:accrual-based-accounting) cost is recognized on the Usage rows.
+* [CommitmentDiscountStatus](#datasets.costandusage.commitmentdiscountstatus) shows "Used" and "Unused" on Usage rows. In January, the customer only consumed 30,000 of 50,000 emails, so the remaining 20,000 generate an "Unused" row. The Unused row has [BilledCost](#datasets.costandusage.billedcost) of $0.00 but [EffectiveCost](#datasets.costandusage.effectivecost) of $7.98, representing waste from the commitment.
+* The Purchase row has [BilledCost](#datasets.costandusage.billedcost) of $19.95 and [EffectiveCost](#datasets.costandusage.effectivecost) of $0.00. This follows the same pattern as the Seat-Based SaaS Subscription: the purchase captures the [*cash-based*](#glossary:cash-based-accounting) cost, while [*accrual-based*](#glossary:accrual-based-accounting) cost is recognized on the Usage rows.
 * The overage row in February has no [*commitment discount*](#glossary:commitment-discount) columns populated. Overage emails are billed at the standard per-email rate and are not part of the commitment.
-* [ContractedUnitPrice](#datasets.costandusage.contractedunitprice) and [ListUnitPrice](#datasets.costandusage.listunitprice) are both &dollar;0.00133 on all Usage rows. Because no [*negotiated discounts*](#glossary:negotiated-discount) apply, [ContractedUnitPrice](#datasets.costandusage.contractedunitprice) defaults to [ListUnitPrice](#datasets.costandusage.listunitprice) per the spec. The [*commitment discount*](#glossary:commitment-discount) savings are reflected in the difference between [ContractedCost](#datasets.costandusage.contractedcost) and [EffectiveCost](#datasets.costandusage.effectivecost), not in [ContractedUnitPrice](#datasets.costandusage.contractedunitprice).
-* [ListCost](#datasets.costandusage.listcost) and [ContractedCost](#datasets.costandusage.contractedcost) on Usage rows represent the market value of those emails at the per-email rate: `$0.00133 x 30,000` = &dollar;39.90 for the January Used row. These values exceed [BilledCost](#datasets.costandusage.billedcost) (&dollar;0.00) because the usage is covered by the plan fee, not billed individually. The gap between [ListCost](#datasets.costandusage.listcost) and [EffectiveCost](#datasets.costandusage.effectivecost) shows the [*commitment discount*](#glossary:commitment-discount) benefit per row.
+* [ContractedUnitPrice](#datasets.costandusage.contractedunitprice) and [ListUnitPrice](#datasets.costandusage.listunitprice) are both $0.00133 on all Usage rows. Because no [*negotiated discounts*](#glossary:negotiated-discount) apply, [ContractedUnitPrice](#datasets.costandusage.contractedunitprice) defaults to [ListUnitPrice](#datasets.costandusage.listunitprice) per the spec. The [*commitment discount*](#glossary:commitment-discount) savings are reflected in the difference between [ContractedCost](#datasets.costandusage.contractedcost) and [EffectiveCost](#datasets.costandusage.effectivecost), not in [ContractedUnitPrice](#datasets.costandusage.contractedunitprice).
+* [ListCost](#datasets.costandusage.listcost) and [ContractedCost](#datasets.costandusage.contractedcost) on Usage rows represent the market value of those emails at the per-email rate: `$0.00133 x 30,000` = $39.90 for the January Used row. These values exceed [BilledCost](#datasets.costandusage.billedcost) ($0.00) because the usage is covered by the plan fee, not billed individually. The gap between [ListCost](#datasets.costandusage.listcost) and [EffectiveCost](#datasets.costandusage.effectivecost) shows the [*commitment discount*](#glossary:commitment-discount) benefit per row.
 * [PricingUnit](#datasets.costandusage.pricingunit) is "Count" on the Purchase row because the plan fee is a single monthly purchase, not denominated in the usage unit (emails). On Usage rows, [PricingUnit](#datasets.costandusage.pricingunit) is "Emails" because those rows are priced per email.
 * [ChargeFrequency](#datasets.costandusage.chargefrequency) is "Recurring" on the Purchase rows (the plan fee recurs monthly). On the Usage rows, [ChargeFrequency](#datasets.costandusage.chargefrequency) is "Usage-Based" for both Used and Unused rows because the amounts vary based on actual email consumption each period.
 

--- a/specification/appendix/saas_examples/simple_agreements.md
+++ b/specification/appendix/saas_examples/simple_agreements.md
@@ -6,7 +6,7 @@ The scenarios described below illustrate how a Cost and Usage [*FOCUS dataset*](
 
 ## Scenario A1: Invoice Up-front for a Purchase of a Service
 
-ACME Corp allows its customers to purchase their service for a term (in this case, a year) for a &dollar;10,000. ACME provides AwesomeCorp with a single invoice for their usage. ACME does not provide detailed cost and usage reports to AwesomeCorp throughout the Charge Period after the initial purchase.
+ACME Corp allows its customers to purchase their service for a term (in this case, a year) for a $10,000. ACME provides AwesomeCorp with a single invoice for their usage. ACME does not provide detailed cost and usage reports to AwesomeCorp throughout the Charge Period after the initial purchase.
 
 Given that ACME does not charge based on or track usage, its usage details are irrelevant to this scenario.
 
@@ -15,14 +15,14 @@ Given that ACME does not charge based on or track usage, its usage details are i
 Note the following details in the example dataset:
 
 * The Charge Period is April 1st 2025 - April 1st 2026. The Billing Period is the month of April 2025 (when the licenses were ordered) and therefore will appear in the April invoice.
-* A single charge representing the total payment for the 12-month agreement (&dollar;10,000) is charged in the first invoice. BilledCost and EffectiveCost are realized in the same record since detailed usage records will not be provided during the 12-month period to realize amortized portions of this up-front payment.
+* A single charge representing the total payment for the 12-month agreement ($10,000) is charged in the first invoice. BilledCost and EffectiveCost are realized in the same record since detailed usage records will not be provided during the 12-month period to realize amortized portions of this up-front payment.
 * The single charge record does not include a List Unit Price, Pricing Quantity, or SKU-related information. Alternatively, the Pricing Quantity could have been set to 1, and the List Unit Price could be the same as the total charge.
   
 ## Scenario A2: Invoice Up-front for a Quantity of a Service
 
 ACME Corp offers its customer the ability to purchase a fixed quantity of licenses for their service. ACME provides AwesomeCorp with a single invoice for their usage. ACME does not provide detailed cost and usage reports to AwesomeCorp throughout the Charge Period after the initial purchase.
 
-On April 1st, 2025, ACME executes a contract and invoices AwesomeCorp &dollar;50,000 (Billed Cost) for a Charge Period of April 1st 2025 to April 1st 2026. As there is no negotiated discount, List Cost of the purchase is also &dollar;50,000.
+On April 1st, 2025, ACME executes a contract and invoices AwesomeCorp $50,000 (Billed Cost) for a Charge Period of April 1st 2025 to April 1st 2026. As there is no negotiated discount, List Cost of the purchase is also $50,000.
 
 [**CSV Example**](/specification/data/saas_examples/simple_agreements/simple_saas_agreements_a2.csv)
 
@@ -34,7 +34,7 @@ Note the following details in the example dataset:
 
 ## Scenario A3: Additional Purchase Records Provided in the SaaS Data Generator's FOCUS Dataset
 
-On June 1st 2025 ACME provides the following records due to AwesomeCorp's &dollar;1,000 mid-contract purchase of an additional 10 licenses for the same Charge Period (April 1st 2025 to April 1st 2026).
+On June 1st 2025 ACME provides the following records due to AwesomeCorp's $1,000 mid-contract purchase of an additional 10 licenses for the same Charge Period (April 1st 2025 to April 1st 2026).
 
 [**CSV Example**](/specification/data/saas_examples/simple_agreements/simple_saas_agreements_a3.csv)
 
@@ -46,7 +46,7 @@ Note the following additional details in the example dataset:
 
 Similar to Scenario A above, ACME Corp offers its customer the ability to purchase their service with a fixed quantity of licenses. However, in Scenario B, ACME issues the invoice at the end of the usage period.
 
-On April 1st, 2026, ACME invoices AwesomeCorp &dollar;50,000 (Billed Cost) for the Charge Period of April 1st 2025 to April 1st 2026. As there is no negotiated discount, List Cost of the purchase is also &dollar;50,000.
+On April 1st, 2026, ACME invoices AwesomeCorp $50,000 (Billed Cost) for the Charge Period of April 1st 2025 to April 1st 2026. As there is no negotiated discount, List Cost of the purchase is also $50,000.
 
 [**CSV Example**](/specification/data/saas_examples/simple_agreements/simple_saas_agreements_b.csv)
 
@@ -60,7 +60,7 @@ Like Scenario A2 above, ACME Corp offers its customers the ability to purchase t
 For this scenario, contract terms additionally include the following terms:
 
 * ACME charges users monthly for the licenses that were consumed in that Billing Period
-* The licenses are charged at &dollar;20 per license per month
+* The licenses are charged at $20 per license per month
 
 AwesomeCorp's consumption looks like this:
 

--- a/specification/appendix/saas_examples/spend_agreements.md
+++ b/specification/appendix/saas_examples/spend_agreements.md
@@ -9,7 +9,7 @@ The scenarios described below illustrate how a Cost and Usage [*FOCUS dataset*](
 The following baseline conditions apply to the scenarios described below:
 
 * AwesomeCorp has signed an agreement with SaaS service provider Acme Co to use their database services
-* On April 1 2025, AwesomeCorp agrees to spend &dollar;1200 (post-discounts) in the upcoming 12-months
+* On April 1 2025, AwesomeCorp agrees to spend $1200 (post-discounts) in the upcoming 12-months
 * AwesomeCorp receives a 20% negotiated discount in return for the commitment
 * Acme Co calculates the spend counted against the agreements after discounts (like the negotiated discounts). Other service providers may use the cost after discounts i.e., using List Cost for calculating the spend commitment.
 
@@ -27,7 +27,7 @@ For this scenario, contract additionally includes the following terms:
 
 AwesomeCorp's consumption looks like this:
 
-* In the first month, AwesomeCorp uses &dollar;48 of services (4 server hours). This usage has a List Cost of &dollar;60 (before discounts)
+* In the first month, AwesomeCorp uses $48 of services (4 server hours). This usage has a List Cost of $60 (before discounts)
 * In the following 2 months, AwesomeCorp has some more usage
 * For the final 9 months, AwesomeCorp does not use Acme services
 
@@ -41,11 +41,11 @@ Note the following details in the example dataset:
 
 The spend agreement with Acme requires the customer to spend a minimum amount in each Billing Period (monthly). Unused fees are charged per Billing Period when the consumption is below this level (use-it or lose-it). For this scenario, contract additionally includes the following terms:
 
-* A minimum of &dollar;60 needs to be spent each month
+* A minimum of $60 needs to be spent each month
 
 AwesomeCorp's consumption looks like this:
 
-* In the first month, the AwesomeCorp uses &dollar;48 of services (4 server hours). This usage has a List Cost of &dollar;60 (before discounts). For this month, Acme charges &dollar;12 (ListCost of &dollar;15) for not meeting the monthly minimum
+* In the first month, the AwesomeCorp uses $48 of services (4 server hours). This usage has a List Cost of $60 (before discounts). For this month, Acme charges $12 (ListCost of $15) for not meeting the monthly minimum
 * In the following 2 months, AwesomeCorp has usage at or above the minimum requirement
 * For the final 9 months, AwesomeCorp does not use Acme services
 
@@ -70,8 +70,8 @@ Scenario B1 is similar to scenario A1 with the difference being that it's a pre-
 
 Note the following details in the example dataset:
 
-* A purchase record for the initial &dollar;1200 payment is present representing List, Billed, and Contracted cost of the purchase
-* The charge for the unused amount has a &dollar;0 BilledCost (since the total amount was billed with the prepayment). However, the charge captures the unused portion as an EffectiveCost.
+* A purchase record for the initial $1200 payment is present representing List, Billed, and Contracted cost of the purchase
+* The charge for the unused amount has a $0 BilledCost (since the total amount was billed with the prepayment). However, the charge captures the unused portion as an EffectiveCost.
 * The unused charge rows apply to the entire Charge Period the contract was signed for.
 * This scenario shows List Cost and Contracted Cost column double counting dynamic (described here in [ListCost](#datasets.costandusage.listcost) and [ContractedCost](#datasets.costandusage.contractedcost)) where either the [ChargeCategory](#datasets.costandusage.chargecategory) Purchase or Usage rows need to be excluded depending on the reporting scenario.
 
@@ -83,7 +83,7 @@ Scenario B2 is similar to A2 with the difference being that it's a pre-paid cont
 
 Note the following details in the example dataset:
 
-* A purchase record for the initial &dollar;1200 payment is present representing List, Billed, and Contracted cost of the purchase
-* The monthly charge for the unused amount has a &dollar;0 BilledCost (since the total amount was billed with the prepayment). However, the charge captures the unused portion as an EffectiveCost.
+* A purchase record for the initial $1200 payment is present representing List, Billed, and Contracted cost of the purchase
+* The monthly charge for the unused amount has a $0 BilledCost (since the total amount was billed with the prepayment). However, the charge captures the unused portion as an EffectiveCost.
 * The final month has a charge that captures the overall unmet spend requirement for the 12-month contract. Alternatively, this could be provided as two charges, one for the unused portion of the final month, and one to capture the overall unmet spend requirement.
 * This scenario shows List Cost and Contracted Cost column double counting dynamic (described here in [ListCost](#datasets.costandusage.listcost) and [ContractedCost](#datasets.costandusage.contractedcost)) where either the Purchase or Usage rows need to be excluded depending on the reporting scenario.

--- a/specification/appendix/saas_examples/virtual_currency_pricing_model.md
+++ b/specification/appendix/saas_examples/virtual_currency_pricing_model.md
@@ -11,7 +11,7 @@ The following baseline conditions apply to the scenarios described below:
 * AwesomeCorp has signed an agreement with SaaS service provider Acme Co to use their services.
 * Acme Co offers a virtual currency pricing model for their services and requires a purchase of virtual currency in advance of usage. Their denomination of virtual currency is called "tokens".
 * Acme Co requires purchase of additional tokens in the event of usage exceeding purchased tokens.
-* Acme Co publicly lists the cost of their tokens at &dollar;2 per token.
+* Acme Co publicly lists the cost of their tokens at $2 per token.
 * Acme Co treats token purchases as resources; therefore, charges for token purchases include values for ResourceId, ResourceName, and ResourceType.
 * Acme Co publicly lists their usage to token rates. These rates are as follows:
   * 1 Q Widget Execution = 1 token
@@ -28,7 +28,7 @@ For this scenario, contract terms include the following terms in addition to the
 
 For this scenario, the initial purchase of virtual currency is executed as follows:
 
-* On April 1, 2025, AwesomeCorp agrees to purchase 100,000 tokens at &dollar;2 per token for a total spend &dollar;200,000. These tokens are only valid for 12 months.
+* On April 1, 2025, AwesomeCorp agrees to purchase 100,000 tokens at $2 per token for a total spend $200,000. These tokens are only valid for 12 months.
 
 [**CSV Example**](/specification/data/saas_examples/virtual_currency_pricing_model_a1.csv)
 
@@ -36,10 +36,10 @@ Note the following details in the example dataset:
 
 * The Charge Period is April 1st 2025 - April 1st 2026. The Billing Period is the month of April 2025 (when the tokens were purchased) and therefore will appear in the April invoice.
 * Because Acme Co uses a virtual currency pricing model for usage and publishes their token price in terms of dollars and their usage cost in terms of tokens, their Cost and Usage [*FOCUS dataset*](#glossary:FOCUS-dataset) includes the columns PricingCurrency, PricingCurrencyContractedUnitPrice, PricingCurrencyEffectiveCost, and PricingCurrencyListUnitPrice.
-* A single charge representing the total payment for the initial token purchase agreement (&dollar;200,000) is charged in the first invoice.
+* A single charge representing the total payment for the initial token purchase agreement ($200,000) is charged in the first invoice.
   * ListCost, BilledCost, and ContractedCost of the purchase are all represented in this charge, however EffectiveCost is zero since the tokens are not yet consumed.
 * PricingQuantity is set to the total tokens purchased.
-* Because Awesome Corp is paying the list price, ListUnitPrice and ContractedUnitPrice are all set to the same value of &dollar;2.
+* Because Awesome Corp is paying the list price, ListUnitPrice and ContractedUnitPrice are all set to the same value of $2.
 
 ## Scenario A2: Usage of Virtual Currency Purchased Without a Discount
 
@@ -68,7 +68,7 @@ For this scenario, contract terms include the following terms in addition to the
 
 For this scenario, the initial purchase of virtual currency is executed as follows:
 
-* On April 1, 2025, AwesomeCorp agrees to purchase 100,000 tokens at discounted cost of &dollar;1 per token for a total spend &dollar;100,000. These tokens are only valid for 12 months.
+* On April 1, 2025, AwesomeCorp agrees to purchase 100,000 tokens at discounted cost of $1 per token for a total spend $100,000. These tokens are only valid for 12 months.
 
 [**CSV Example**](/specification/data/saas_examples/virtual_currency_pricing_model_b1.csv)
 
@@ -76,10 +76,10 @@ Note the following details in the example dataset:
 
 * The Charge Period is April 1st 2025 - April 1st 2026. The Billing Period is the month of April 2025 (when the tokens were purchased) and therefore will appear in the April invoice.
 * Because Acme Co uses a virtual currency pricing model for usage and publishes their token price in terms of dollars and their usage cost in terms of tokens, their *FOCUS dataset* includes the columns PricingCurrency, PricingCurrencyContractedUnitPrice, PricingCurrencyEffectiveCost, and PricingCurrencyListUnitPrice.
-* A single charge representing the total payment for the initial token purchase agreement (&dollar;100,000) is charged in the first invoice.
+* A single charge representing the total payment for the initial token purchase agreement ($100,000) is charged in the first invoice.
   * ListCost, BilledCost, and ContractedCost of the purchase are all represented in this charge, however EffectiveCost is zero, as required for prepaid purchases.
 * PricingQuantity is set to the total tokens purchased.
-* Because Awesome Corp is receiving a discount on the token price, the ListUnitPrice is set to &dollar;2 and the ContractedUnitPrice is set to &dollar;1. A ListCost of (&dollar;200,000) and ContractedCost (&dollar;100,000) reflect the cost of the tokens at the list price and contracted price respectively. The BilledCost is set to &dollar;100,000 since this is the amount that Awesome Corp will be charged for the purchase of tokens.
+* Because Awesome Corp is receiving a discount on the token price, the ListUnitPrice is set to $2 and the ContractedUnitPrice is set to $1. A ListCost of ($200,000) and ContractedCost ($100,000) reflect the cost of the tokens at the list price and contracted price respectively. The BilledCost is set to $100,000 since this is the amount that Awesome Corp will be charged for the purchase of tokens.
 
 ## Scenario B2: Usage of Virtual Currency Purchased at a Discount
 
@@ -112,7 +112,7 @@ Additionally, Acme Co offers a modified usage to token ratio for one of their se
 
 Note the following details in the example dataset:
 
-* Because of the modified rate for Workflow Operations, the PricingCurrencyContractedUnitPrice and PricingCurrencyListUnitPrice are different for this charge. The ContractedUnitPrice is set to &dollar;1 and the ListUnitPrice is set to &dollar;2.
+* Because of the modified rate for Workflow Operations, the PricingCurrencyContractedUnitPrice and PricingCurrencyListUnitPrice are different for this charge. The ContractedUnitPrice is set to $1 and the ListUnitPrice is set to $2.
 * The PricingCurrencyEffectiveCost is 240 tokens for this charge, which is less than example B2 above due to the modified rate.
 * ListCost reflects the cost of the charge at both the list cost of the tokens and the list rate for which the usage consumes tokens.
 
@@ -120,7 +120,7 @@ Note the following details in the example dataset:
 
 For this scenario, Awesome Corp has exceeded their purchased tokens on October 1st 2025 by 1,500 tokens and Acme Co has charged them for the overage. The following conditions apply:
 
-* Acme Co has charged Awesome Corp for the cost of tokens at the list price of &dollar;2 per token, and this purchase is effective from April 1st 2025 to the date of the purchase, October 1st 2025.
+* Acme Co has charged Awesome Corp for the cost of tokens at the list price of $2 per token, and this purchase is effective from April 1st 2025 to the date of the purchase, October 1st 2025.
 * Awesome Corp purchases an additional 25,000 tokens to facilitate usage to the end of their contract. These tokens are valid from October 1st 2025 to April 1st 2026.
 
 [**CSV Example**](/specification/data/saas_examples/virtual_currency_pricing_model_c.csv)

--- a/vendored/MarkdownPP/Modules/LaTeXRender.py
+++ b/vendored/MarkdownPP/Modules/LaTeXRender.py
@@ -22,7 +22,7 @@ from MarkdownPP.Transform import Transform
 #
 # Keep detection broad, then apply a content heuristic before rendering to
 # avoid treating currency/prose as LaTeX. Escaped dollars ("\$") are ignored.
-singlelinere = re.compile(r"(?<!\\)\$(\$?).+?(?<!\\)\$(\$?)")
+singlelinere = re.compile(r"(?<!\\)(?<!\$)(\$\$(?!\$)|\$(?!\$))(.+?)(?<!\\)\1(?!\$)")
 # $... or ...$ (or $$... or ...$$)
 startorendre = re.compile(r"^(?<!\\)\$(\$?)(?!\d)|^\S.*(?<!\\)\$(\$?)$")
 

--- a/vendored/MarkdownPP/Modules/LaTeXRender.py
+++ b/vendored/MarkdownPP/Modules/LaTeXRender.py
@@ -22,7 +22,8 @@ from MarkdownPP.Transform import Transform
 #
 # Keep detection broad, then apply a content heuristic before rendering to
 # avoid treating currency/prose as LaTeX. Escaped dollars ("\$") are ignored.
-singlelinere = re.compile(r"(?<!\\)(?<!\$)(\$\$(?!\$)|\$(?!\$))(.+?)(?<!\\)\1(?!\$)")
+# Also enforces no space immediately after the opening $ or before the closing $
+singlelinere = re.compile(r"(?<!\\)(?<!\$)(\$\$(?!\$)|\$(?!\$))(?!\s)(.+?)(?<!\s)(?<!\\)\1(?!\$)")
 # $... or ...$ (or $$... or ...$$)
 startorendre = re.compile(r"^(?<!\\)\$(\$?)(?!\d)|^\S.*(?<!\\)\$(\$?)$")
 

--- a/vendored/MarkdownPP/Modules/LaTeXRender.py
+++ b/vendored/MarkdownPP/Modules/LaTeXRender.py
@@ -19,12 +19,17 @@ from MarkdownPP.Module import Module
 from MarkdownPP.Transform import Transform
 
 # $...$ (or $$...$$)
-singlelinere = re.compile(r"\$(\$?)..*\$(\$?)")
+#
+# Keep detection broad, then apply a content heuristic before rendering to
+# avoid treating currency/prose as LaTeX. Escaped dollars ("\$") are ignored.
+singlelinere = re.compile(r"(?<!\\)\$(\$?).+?(?<!\\)\$(\$?)")
 # $... or ...$ (or $$... or ...$$)
-startorendre = re.compile(r"^\$(\$?)|^\S.*\$(\$?)$")
+startorendre = re.compile(r"^(?<!\\)\$(\$?)(?!\d)|^\S.*(?<!\\)\$(\$?)$")
 
 codere = re.compile(r"^(    |\t)")
 spancodere = re.compile(r'(`[^`]+\`)')  # code between backticks
+mathcommandre = re.compile(r"\\[A-Za-z]+")
+wordre = re.compile(r"[A-Za-z]{2,}")
 
 # Support for Pandoc style code blocks with attributes
 fencedcodere = re.compile(r"^((> *)?```\w*|(> *)?~~~~*(\s*{.*})?)$")
@@ -35,6 +40,44 @@ class LaTeXRender(Module):
     Module for rendering LaTeX enclosed between $ dollar signs $.
     Rendering is performed using QuickLaTeX via ProblemSetMarmoset.
     """
+
+    def should_render(self, tex):
+        """Return True when a $...$ candidate is likely math, not currency."""
+        content = tex.strip().strip("$").strip()
+        if not content:
+            return False
+
+        # Fragments that end with an operator (e.g. "0.00133 = ") are
+        # typically prose/currency splits, not complete LaTeX expressions.
+        if content.rstrip().endswith(("=", "+", "-", "*", "/", "^", "<", ">")):
+            return False
+
+        # Table rows often produce matches like "$402,960.00 | $0.00".
+        # Treat pipe-delimited content as non-LaTeX unless explicit commands exist.
+        if "|" in content and not mathcommandre.search(content):
+            return False
+
+        # Pure numeric/currency values are not LaTeX expressions.
+        if re.match(r"^\s*[0-9][0-9,]*(\.[0-9]+)?\s*$", content):
+            return False
+
+        # Explicit LaTeX command is a strong signal.
+        if mathcommandre.search(content):
+            return True
+
+        has_digit = re.search(r"\d", content) is not None
+        word_count = len(wordre.findall(content))
+
+        # Numeric prose patterns such as "$4,380 / 12 months / 50 users" or
+        # "$0.02 < Tolerance $1.00" are common false positives.
+        if has_digit and word_count > 0 and not mathcommandre.search(content):
+            return False
+
+        # Long prose between dollars is almost never intentional LaTeX.
+        if word_count > 2:
+            return False
+
+        return re.search(r"[A-Za-z0-9]|[+\-*/^_=<>{}()]", content) is not None
 
     def transform(self, data):
         transforms = []
@@ -72,10 +115,11 @@ class LaTeXRender(Module):
                         before_tex = line[0:line.find(tex)]
                         after_tex = line[(line.find(tex) + len(tex)):
                                          len(line)]
-                        transforms.append(Transform(linenum, "swap",
-                                                    before_tex +
-                                                    self.render(tex) +
-                                                    after_tex))
+                        if self.should_render(tex):
+                            transforms.append(Transform(linenum, "swap",
+                                                        before_tex +
+                                                        self.render(tex) +
+                                                        after_tex))
                 else:
                     match = startorendre.search(line)
                     if match:

--- a/vendored/MarkdownPP/Modules/LaTeXRender.py
+++ b/vendored/MarkdownPP/Modules/LaTeXRender.py
@@ -77,7 +77,7 @@ class LaTeXRender(Module):
         if word_count > 2:
             return False
 
-        return re.search(r"[A-Za-z0-9]|[+\-*/^_=<>{}()]", content) is not None
+        return re.search(r"[A-Za-z0-9+\-*/^_=<>{}()]", content) is not None
 
     def transform(self, data):
         transforms = []

--- a/vendored/MarkdownPP/Modules/LaTeXRender.py
+++ b/vendored/MarkdownPP/Modules/LaTeXRender.py
@@ -76,7 +76,7 @@ class LaTeXRender(Module):
 
         # Numeric prose patterns such as "$4,380 / 12 months / 50 users" or
         # "$0.02 < Tolerance $1.00" are common false positives.
-        if has_digit and word_count > 0 and not mathcommandre.search(content):
+        if has_digit and word_count > 0:
             return False
 
         # Long prose between dollars is almost never intentional LaTeX.

--- a/vendored/MarkdownPP/Modules/LaTeXRender.py
+++ b/vendored/MarkdownPP/Modules/LaTeXRender.py
@@ -48,6 +48,11 @@ class LaTeXRender(Module):
         if not content:
             return False
 
+        # A valid inline math candidate should not contain additional
+        # unescaped dollar delimiters in its interior.
+        if re.search(r"(?<!\\)\$", content):
+            return False
+
         # Fragments that end with an operator (e.g. "0.00133 = ") are
         # typically prose/currency splits, not complete LaTeX expressions.
         if content.rstrip().endswith(("=", "+", "-", "*", "/", "^", "<", ">")):
@@ -102,26 +107,37 @@ class LaTeXRender(Module):
                     transforms.append(Transform(linenum, "drop"))
                     current_block += "\n" + line
 
-                match = singlelinere.search(line)
-                if match:
-                    code_pos = []
-                    for m in spancodere.finditer(line):
-                        code_pos += range(*m.span())
+                search_start = 0
+                match = None
+                code_pos = []
+                for m in spancodere.finditer(line):
+                    code_pos += range(*m.span())
 
-                    if not (match.start(0) in code_pos or
-                            match.end(0) in code_pos):
+                while True:
+                    match = singlelinere.search(line, search_start)
+                    if not match:
+                        break
 
-                        # Single LaTeX line
-                        tex = match.group(0)
-                        before_tex = line[0:line.find(tex)]
-                        after_tex = line[(line.find(tex) + len(tex)):
-                                         len(line)]
-                        if self.should_render(tex):
-                            transforms.append(Transform(linenum, "swap",
-                                                        before_tex +
-                                                        self.render(tex) +
-                                                        after_tex))
-                else:
+                    if match.start(0) in code_pos or match.end(0) in code_pos:
+                        search_start = match.start(0) + 1
+                        continue
+
+                    # Single LaTeX line
+                    tex = match.group(0)
+                    if not self.should_render(tex):
+                        search_start = match.start(0) + 1
+                        continue
+
+                    before_tex = line[0:line.find(tex)]
+                    after_tex = line[(line.find(tex) + len(tex)):
+                                     len(line)]
+                    transforms.append(Transform(linenum, "swap",
+                                                before_tex +
+                                                self.render(tex) +
+                                                after_tex))
+                    break
+
+                if not match:
                     match = startorendre.search(line)
                     if match:
                         # Starting or ending a multi-line LaTeX block


### PR DESCRIPTION
## Summary

- replace HTML &dollar; with literal $ across commitment discount, SaaS, and rounding appendix markdown examples
- update vendored MarkdownPP LaTeXRender heuristics to avoid false-positive $...$ rendering for currency/prose/table content
- preserve intentional inline LaTeX rendering behavior while suppressing noisy "Rendering:" output during spec build
-  disable pandoc dollar-math parsing and harden LaTeXRender for currency text

### Type of Change
- [X] Bug fix
- [ ] New feature / Specification update
- [ ] Editorial / Formatting

### Author Checklist
- [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
- [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
- [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
