### PR TITLE
AI #2086: Clarify InvoiceIssuerName requirement across datasets

### DIFF
--- a/specification/datasets/billing_period/columns/invoiceissuername.md
+++ b/specification/datasets/billing_period/columns/invoiceissuername.md
@@ -9,7 +9,7 @@ InvoiceIssuerName MUST adhere to the following requirements:
 * InvoiceIssuerName MUST be of type String.
 * InvoiceIssuerName MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * InvoiceIssuerName MUST NOT be null.
-* InvoiceIssuerName MUST represent the entity that issued the invoice.
+* InvoiceIssuerName MUST represent the entity that issues invoices.
 
 See [Appendix: Participating Entity Identification Examples](#appendix.examples:participatingentityidentification) section for examples of Invoice Issuer Name values across various use case scenarios.
 

--- a/specification/datasets/contract_commitment/columns/invoiceissuername.md
+++ b/specification/datasets/contract_commitment/columns/invoiceissuername.md
@@ -9,6 +9,7 @@ InvoiceIssuerName MUST adhere to the following requirements:
 * InvoiceIssuerName MUST be of type String.
 * InvoiceIssuerName MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * InvoiceIssuerName MUST NOT be null.
+* InvoiceIssuerName MUST represent the entity that issues invoices.
 
 ## Column ID
 

--- a/specification/datasets/cost_and_usage/columns/invoiceissuername.md
+++ b/specification/datasets/cost_and_usage/columns/invoiceissuername.md
@@ -9,6 +9,7 @@ InvoiceIssuerName MUST adhere to the following requirements:
 * InvoiceIssuerName MUST be of type String.
 * InvoiceIssuerName MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * InvoiceIssuerName MUST NOT be null.
+* InvoiceIssuerName MUST represent the entity that issues invoices.
 
 See [Appendix: Participating Entity Identification Examples](#appendix.examples:participatingentityidentification) section for examples of Invoice Issuer Name values across various use case scenarios.
 


### PR DESCRIPTION
## Summary

Resolves #2086. Aligns the `InvoiceIssuerName` semantic requirement across all datasets that define the column.

* **Billing Period:** Updates wording from "issued the invoice" (past, singular) to "issues invoices" (present, plural) to match Invoice Detail.
* **Contract Commitment:** Adds the missing semantic requirement bullet.
* **Cost and Usage:** Adds the missing semantic requirement bullet.

All four datasets defining `InvoiceIssuerName` (Billing Period, Invoice Detail, Contract Commitment, Cost and Usage) now carry the identical normative requirement: `InvoiceIssuerName MUST represent the entity that issues invoices.`

### Type of Change
- [ ] Bug fix
- [x] New feature / Specification update
- [x] Editorial / Formatting

### Author Checklist
- [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
- [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
- [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.

### Change Log

* **2026-04-13:** Added the `InvoiceIssuerName` semantic requirement bullet to the Contract Commitment and Cost and Usage datasets to ensure uniform coverage across all datasets defining the column.
* **2026-04-10:** Revised the Billing Period `InvoiceIssuerName` requirement to present-tense plural phrasing ("issues invoices") to match Invoice Detail.