### PR TITLE
AI #2141: Apply changes to remove normative rules from editorial guidelines

### DIFF
--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -152,38 +152,6 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 
 * **Linking Only the First Time**: To prevent excessive linking within sections, Entity Names and Entity IDs (e.g., Column Names, Attribute IDs, and Glossary) will only be linked to their corresponding section or glossary the first time they appear in a section.
 
-### Normative Requirements
-
-* **Single Requirement per Statement:** Each normative statement MUST express a single requirement.
-
-* **Example** (Markdown, illustrative):
-
-  ```md
-  * ... MUST be of type String.
-  * ... MUST conform to CurrencyFormat requirements.
-  ```
-
-* **Explicit Conditions:** Normative requirements MUST include an explicit condition unless the rule applies in all cases.
-
-* **Condition Format:** Conditional clauses MUST use standardized patterns: “when / if / unless / only when / only if / except when / except if <condition>”.
-
-* **Example** (Markdown, illustrative):
-
-  ```md
-  * ... MUST be null when ChargeCategory is "Tax".
-  * ... MUST be null if ChargeCategory is "Tax".
-  * ... MUST be null unless ChargeCategory is "Usage".
-  ```
-
-* **Subject Consistency:** Each normative statement MUST clearly identify the subject being constrained.
-
-* **Example** (Markdown, illustrative):
-
-  ```md
-  * PricingQuantity MUST be greater than 0.
-  ```
-* **No Compound Conditions:** Normative requirements MUST NOT combine multiple conditions using “and” or “or” within a single statement.
-
 ### Entity References
 
 * **Entity IDs:** Entity IDs (e.g., Column IDs, Attribute IDs, Dataset IDs), formatting and usage conventions for normative requirements are defined in the Normative Requirements Guidelines. 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -162,12 +162,6 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 
 * **Display Names:** Display Names SHOULD be used in introductory or explanatory sections where natural language context is more appropriate. These names should follow normal text conventions, including spaces between words (e.g., Commitment Discount ID).
 
-* **Consistent Reference Type:** Normative requirements MUST use Entity IDs consistently.
-
-* **Consistent Reference Type:** MUST NOT mix Entity IDs and Display Names within the same statement.
-
-* **Multiple Entity References:** MUST use Entity IDs when referencing multiple entities in a normative statement.
-
 * **Entity Scope:** These rules apply to all entities defined in the FOCUS specification (e.g., Columns, Attributes, Datasets, Objects).
 
 ### Bullet Structure
@@ -192,8 +186,6 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 * **No Skipped Levels:** Nested bullets MUST NOT skip indentation levels.
 
 * **Consistent Indentation:** All bullets within the same list MUST use consistent indentation.
-
-* **Separate Conditions:** Alternative conditions MUST be expressed as separate bullet points.
 
 * **Example** (Markdown, illustrative):
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -3,6 +3,11 @@ The "Editorial Style Guidelines" section ensures consistency and clarity across 
 
 These guidelines can be modified through a Pull Request (PR), which the members must review and agree upon. This process ensures that any changes are thoughtfully considered and maintains the overall integrity of our editorial standards.
 
+### Normative Requirements
+Normative requirements are defined and authored exclusively according to the Normative Requirements Guidelines.
+
+Authors MUST refer to the Normative Requirements Guidelines when writing or modifying normative requirements.
+
 <table>
     <tr>
         <th>Component</th>
@@ -78,9 +83,9 @@ These guidelines can be modified through a Pull Request (PR), which the members 
         </td>
     </tr>
     <tr>
-        <td><strong>Normative Keywords &amp; Requirements Statements</strong></td>
+        <td><strong>Normative Keywords</strong>(Formatting Only)</td>
         <td>
-            MUST, MAY, MUST NOT and normative requirements statements
+            Normative keywords and statements (see Normative Requirements Guidelines)
         </td>
         <td>
             This column:</br>
@@ -89,8 +94,8 @@ These guidelines can be modified through a Pull Request (PR), which the members 
             &nbsp;&nbsp; * MAY be null for all other combinations of ... </br>
         </td>
         <td>
-           - All uppercase, without bold.<br>
-           - Bullet list format. <br>
+           - Formatting follows Editorial Guidelines.<br>
+           - Structure and usage are defined in the Normative Requirements Guidelines.<br>
         </td>
     </tr>
     <tr>
@@ -149,12 +154,6 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 ### Normative Requirements
 
-* **Normative Requirements as a Bullet List**: Normative requirements (those using Normative Keywords) MUST be written as bullet points instead of lengthy sentences.
-
-* **Normative Keyword Standardization:** To ensure consistency in the specification, normative language MUST use only the BCP-14 keywords MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY. The term "RECOMMENDED" as a normative keyword is deprecated starting December 2025. Where legacy text uses RECOMMENDED, it MUST be replaced with SHOULD.
-
-* **Non-Normative Use of “recommended”:** The lowercase word “recommended” may still be used in non-normative, descriptive text (e.g., “Feature level: Recommended”) provided it does not express a normative requirement on implementers.
-
 * **Single Requirement per Statement:** Each normative statement MUST express a single requirement.
 
 * **Example** (Markdown, illustrative):
@@ -187,7 +186,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 ### Entity References
 
-* **Entity IDs:** Entity IDs (e.g., Column IDs, Attribute IDs, Dataset IDs) SHOULD be used in normative text sections, such as when specifying mandatory rules, schema definitions, or other implementation-related content. 
+* **Entity IDs:** Entity IDs (e.g., Column IDs, Attribute IDs, Dataset IDs), formatting and usage conventions for normative requirements are defined in the Normative Requirements Guidelines. 
 
 * **Entity IDs:** MUST be formatted without spaces.
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -6,7 +6,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 ### Normative Requirements
 Normative requirements are defined and authored exclusively according to the Normative Requirements Guidelines.
 
-Authors MUST refer to the Normative Requirements Guidelines when writing or modifying normative requirements.
+Authors MUST refer to the [Normative Requirements Guidelines](normative-requirements-guidelines.md) when writing or modifying normative requirements.
 
 <table>
     <tr>

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -150,17 +150,19 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 
 ### Linking
 
-* **Linking Only the First Time**: To prevent excessive linking within sections, Entity Names and Entity IDs (e.g., Column Names, Attribute IDs, and Glossary) will only be linked to their corresponding section or glossary the first time they appear in a section.
+* **Linking Only the First Time:** To prevent excessive linking within sections, Entity Names and Entity IDs (e.g., Column Names, Attribute IDs, and Glossary) will only be linked to their corresponding section or glossary the first time they appear in a section.
 
 ### Entity References
 
-* **Entity IDs:** Entity IDs (e.g., Column IDs, Attribute IDs, Dataset IDs), formatting and usage conventions for normative requirements are defined in the Normative Requirements Guidelines. 
+* **Entity IDs - Reference:** Formatting and usage conventions for normative requirements are defined in the Normative Requirements Guidelines.
 
-* **Entity IDs:** MUST be formatted without spaces.
+* **Entity IDs - Formatting:** Entity IDs MUST be formatted without spaces.
 
-* **Entity IDs:** MUST match the exact naming conventions used in the schema (e.g., CommitmentDiscountId).
+* **Entity IDs - Naming:** Entity IDs MUST match the exact naming conventions used in the schema (e.g., CommitmentDiscountId).
 
-* **Display Names:** Display Names SHOULD be used in introductory or explanatory sections where natural language context is more appropriate. These names should follow normal text conventions, including spaces between words (e.g., Commitment Discount ID).
+* **Display Names - Usage:** Display Names SHOULD be used in introductory or explanatory sections where natural language context is more appropriate. 
+
+* **Display Names - Formatting:** Display Names SHOULD follow normal text conventions, including spaces between words (e.g., Commitment Discount ID).
 
 * **Entity Scope:** These rules apply to all entities defined in the FOCUS specification (e.g., Columns, Attributes, Datasets, Objects).
 
@@ -183,9 +185,9 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
           * ... MUST be of type ...
     ```
 
-* **No Skipped Levels:** Nested bullets MUST NOT skip indentation levels.
+* **No Skipped Levels:** Nested bullets points MUST NOT skip indentation levels.
 
-* **Consistent Indentation:** All bullets within the same list MUST use consistent indentation.
+* **Consistent Indentation:** All bullets points within the same list MUST use consistent indentation.
 
 * **Example** (Markdown, illustrative):
 
@@ -196,7 +198,7 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 
 ### Formatting
 
-* **Introductory Phrase for Rules:** Normative bullet lists SHOULD be preceded by a short introductory phrase ending with a colon (:). 
+* **Introductory Phrase for Rules:** Normative bullet lists SHOULD be preceded by a short introductory phrase ending with a colon (:).
 
 * **Example** (Markdown, illustrative):
 
@@ -217,7 +219,7 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 
 ### Section Structure
 
-* **Consistent Subsection Order:** Sections for the same entity type SHOULD follow the same subsection order (e.g., Title, Requirements, Entity ID, Display Name, Description, Content Constraints, Introduced (version)).
+* **Consistent Subsection Order:** Sections for the same entity type SHOULD follow a consistent subsection order (e.g., Title, Requirements, Entity ID, Display Name, Description, Content Constraints, Introduced (version)).
 
 * **Consistent Subsection Titles:** Subsection titles SHOULD match exactly across sections of the same entity type.
 
@@ -259,7 +261,7 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 
 * **Informative Notes:** Important notes MUST NOT contain normative keywords.
 
-* **Currency and Dollar Signs:** Use literal `$` for currency values in prose and tables. For build-pipeline behavior and troubleshooting related to dollar-sign parsing, see [MarkdownPP Guidelines](markdownpp-guidelines.md#currency-and-dollar-sign-handling).
+* **Currency and Dollar Signs:** The `$` symbol SHOULD be used for currency values in prose and tables. For build-pipeline behavior and troubleshooting related to dollar-sign parsing, see [MarkdownPP Guidelines](markdownpp-guidelines.md#currency-and-dollar-sign-handling).
 
 ### Example
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -154,15 +154,15 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 
 ### Entity References
 
-* **Entity IDs - Reference:** Formatting and usage conventions for normative requirements are defined in the Normative Requirements Guidelines.
+* **Entity IDs Reference:** Formatting and usage conventions for normative requirements are defined in the Normative Requirements Guidelines.
 
-* **Entity IDs - Formatting:** Entity IDs MUST be formatted without spaces.
+* **Entity IDs Formatting:** Entity IDs MUST be formatted without spaces.
 
-* **Entity IDs - Naming:** Entity IDs MUST match the exact naming conventions used in the schema (e.g., CommitmentDiscountId).
+* **Entity IDs Naming:** Entity IDs MUST match the exact naming conventions used in the schema (e.g., CommitmentDiscountId).
 
-* **Display Names - Usage:** Display Names SHOULD be used in introductory or explanatory sections where natural language context is more appropriate. 
+* **Display Names Usage:** Display Names SHOULD be used in introductory or explanatory sections where natural language context is more appropriate. 
 
-* **Display Names - Formatting:** Display Names SHOULD follow normal text conventions, including spaces between words (e.g., Commitment Discount ID).
+* **Display Names Formatting:** Display Names SHOULD follow normal text conventions, including spaces between words (e.g., Commitment Discount ID).
 
 * **Entity Scope:** These rules apply to all entities defined in the FOCUS specification (e.g., Columns, Attributes, Datasets, Objects).
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -205,7 +205,6 @@ Specifically:
 * Each normative bullet MUST contain exactly one BCP 14 keyword (MUST, SHOULD, MAY, MUST NOT, SHOULD NOT). See [BCP14](https://tools.ietf.org/html/bcp14) [[RFC2119](https://tools.ietf.org/html/rfc2119)][[RFC8174](https://tools.ietf.org/html/rfc8174)].
 * A bullet containing more than one normative keyword MUST be split.
 * The term **RECOMMENDED** MUST NOT be used as a normative keyword. The keyword **SHOULD** MUST be used instead.
-* The lowercase word “recommended” MAY be used in non-normative text, provided it does not express a normative requirement.
 
 * **Exception for Composite Requirements:** While each individual bullet (parent or nested) MUST contain only one BCP 14 keyword, a Composite Requirement as a whole MAY contain multiple keywords to express nuanced obligations. In such cases, the logical strength of the requirement is governed by the hierarchy defined in section [Composite Requirements](#composite-requirements).
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -96,14 +96,11 @@ The recommended pattern for a normative requirement is:
 ### Explicit Conditions in Normative Requirements
 
 * Normative requirements MUST include an explicit condition unless the rule applies universally.
-* Conditional clauses MUST use standardized patterns such as:
-   * when <condition>
-   * if <condition>
-   * unless <condition>  
-   * only when <condition>  
-   * only if <condition>  
-   * except when <condition>  
-   * except if <condition>
+* Conditional logic MUST be expressed using one of the following approved conditional keywords:
+  * `when`
+  * `unless`
+  * `only when`
+  * `except when`
 
 ### Structural Anchor Requirement
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -85,8 +85,7 @@ The recommended pattern for a normative requirement is:
 ```
 
 * Normative requirements MUST be expressed as individual bullet points.
-* Each bullet MUST represent exactly one normative requirement.
-* Each normative requirement MUST express a single requirement.
+* Each bullet MUST represent exactly one normative requirement expressing a single constraint.
 * Each normative requirement MUST:
   * identify exactly one **normative subject** to which the requirement applies
   * contain exactly one **BCP 14 keyword** (MUST, SHOULD, MAY, MUST NOT, etc.), indicating the obligation level

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -86,11 +86,25 @@ The recommended pattern for a normative requirement is:
 
 * Normative requirements MUST be expressed as individual bullet points.
 * Each bullet MUST represent exactly one normative requirement.
+* Each normative requirement MUST express a single requirement.
 * Each normative requirement MUST:
   * identify exactly one **normative subject** to which the requirement applies
   * contain exactly one **BCP 14 keyword** (MUST, SHOULD, MAY, MUST NOT, etc.), indicating the obligation level
   * express exactly one **verifiable constraint**
+  * be split into multiple bullets if it introduces multiple independent constraints.
 * Each normative requirement SHOULD describe a **verifiable state** of the object rather than behavior
+
+### Explicit Conditions in Normative Requirements
+
+* Normative requirements MUST include an explicit condition unless the rule applies universally.
+* Conditional clauses MUST use standardized patterns such as:
+   * when <condition>
+   * if <condition>
+   * unless <condition>  
+   * only when <condition>  
+   * only if <condition>  
+   * except when <condition>  
+   * except if <condition>
 
 ### Structural Anchor Requirement
 
@@ -118,6 +132,8 @@ For **Attribute Requirements** sections, a different canonical form applies:
 See [Section Structural Anchor Requirement for Attributes](#structural-anchor-requirement-for-attributes) for details.
 
 ### Normative Subject
+
+* Each normative requirement MUST clearly identify the subject being constrained.
 
 #### Terminology Usage in Normative Requirements
 
@@ -200,6 +216,7 @@ A requirement MUST be split into multiple bullets if it:
 
 * contains more than one BCP 14 keyword,
 * combines multiple obligations (e.g., multiple verifiable state descriptors, multiple objects, or multiple conditions that result in distinct constraints),
+* combines multiple independent conditions using “and” or “or” that result in distinct constraints,
 * contains a hidden constraint expressed as a definition (e.g., `ColumnA MUST be Z, where Z is defined as Y`),
 * applies constraints to multiple subjects, even with a single BCP 14 keyword (e.g., `ColumnA and ColumnB MUST be X`).
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -84,6 +84,8 @@ The recommended pattern for a normative requirement is:
 <Subject (+qualifier)> + <BCP 14 Keyword> + <Verifiable State Descriptor> + <Object (+qualifier)> [+ Conditions]
 ```
 
+* Normative requirements MUST be expressed as individual bullet points.
+* Each bullet MUST represent exactly one normative requirement.
 * Each normative requirement MUST:
   * identify exactly one **normative subject** to which the requirement applies
   * contain exactly one **BCP 14 keyword** (MUST, SHOULD, MAY, MUST NOT, etc.), indicating the obligation level
@@ -116,6 +118,12 @@ For **Attribute Requirements** sections, a different canonical form applies:
 See [Section Structural Anchor Requirement for Attributes](#structural-anchor-requirement-for-attributes) for details.
 
 ### Normative Subject
+
+#### Terminology Usage in Normative Requirements
+
+* Column references in normative requirements MUST use the ColumnId.
+* Display Names MUST NOT be used in normative requirements.
+* Display Names MAY be used in non-normative sections for readability.
 
 #### Allowed Subjects
 
@@ -181,6 +189,8 @@ Specifically:
 
 * Each normative bullet MUST contain exactly one BCP 14 keyword (MUST, SHOULD, MAY, MUST NOT, SHOULD NOT). See [BCP14](https://tools.ietf.org/html/bcp14) [[RFC2119](https://tools.ietf.org/html/rfc2119)][[RFC8174](https://tools.ietf.org/html/rfc8174)].
 * A bullet containing more than one normative keyword MUST be split.
+* The term **RECOMMENDED** MUST NOT be used as a normative keyword. The keyword **SHOULD** MUST be used instead.
+* The lowercase word “recommended” MAY be used in non-normative text, provided it does not express a normative requirement.
 
 * **Exception for Composite Requirements:** While each individual bullet (parent or nested) MUST contain only one BCP 14 keyword, a Composite Requirement as a whole MAY contain multiple keywords to express nuanced obligations. In such cases, the logical strength of the requirement is governed by the hierarchy defined in section [Composite Requirements](#composite-requirements).
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -216,7 +216,7 @@ A requirement MUST be split into multiple bullets if it:
 
 * contains more than one BCP 14 keyword,
 * combines multiple obligations (e.g., multiple verifiable state descriptors, multiple objects, or multiple conditions that result in distinct constraints),
-* combines multiple independent conditions using “and” or “or” that result in distinct constraints,
+* combines multiple independent conditions using “and” or “or” that result in distinct constraints
 * contains a hidden constraint expressed as a definition (e.g., `ColumnA MUST be Z, where Z is defined as Y`),
 * applies constraints to multiple subjects, even with a single BCP 14 keyword (e.g., `ColumnA and ColumnB MUST be X`).
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -84,7 +84,7 @@ The recommended pattern for a normative requirement is:
 <Subject (+qualifier)> + <BCP 14 Keyword> + <Verifiable State Descriptor> + <Object (+qualifier)> [+ Conditions]
 ```
 
-* Normative requirements MUST be expressed as individual bullet points.
+* Each normative requirement MUST be expressed as an individual bullet point, except for structural anchor requirements (see [Structural Anchor Requirement](#structural-anchor-requirement)).
 * Each bullet MUST represent exactly one normative requirement expressing a single constraint.
 * Each normative requirement MUST:
   * identify exactly one **normative subject** to which the requirement applies

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -90,7 +90,6 @@ The recommended pattern for a normative requirement is:
   * identify exactly one **normative subject** to which the requirement applies
   * contain exactly one **BCP 14 keyword** (MUST, SHOULD, MAY, MUST NOT, etc.), indicating the obligation level
   * express exactly one **verifiable constraint**
-  * be split into multiple bullets if it introduces multiple independent constraints.
 * Each normative requirement SHOULD describe a **verifiable state** of the object rather than behavior
 
 ### Explicit Conditions in Normative Requirements


### PR DESCRIPTION
## Summary

This change removes duplication and establishes the Normative Requirements Guidelines as the single source of truth for all normative authoring rules. 

### Type of Change
- [ ] Bug fix
- [ ] New feature / Specification update
- [x] Editorial / Formatting

### Author Checklist
- [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
- [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
- [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
