### PR TITLE
Process #1878: Editorial: Fix i.e. commas and contractions in commitmentdiscountquantity.md

### DIFF
--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountquantity.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountquantity.md
@@ -37,7 +37,7 @@ The amount of a *commitment discount* purchased or accounted for in *commitment 
 
 ## Usability Constraints
 
-**Aggregation:** When aggregating Commitment Discount Quantity for commitment utilization calculations, it is important to exclude [*commitment discount*](#glossary:commitment-discount) purchases (i.e., when Charge Category is "Purchase") that are paid to cover future eligible [*charges*](#glossary:charge) (e.g., *commitment discount*). Otherwise, when accounting for all upfront or accrued purchases, it is important to exclude *commitment discount* usage (i.e., when Charge Category is "Usage"). This exclusion helps prevent double counting of these quantities in the aggregation.
+**Aggregation:** When aggregating Commitment Discount Quantity for commitment utilization calculations, it's important to exclude [*commitment discount*](#glossary:commitment-discount) purchases (i.e., when Charge Category is "Purchase") that are paid to cover future eligible [*charges*](#glossary:charge) (e.g., *commitment discount*). Otherwise, when accounting for all upfront or accrued purchases, it's important to exclude *commitment discount* usage (i.e., when Charge Category is "Usage"). This exclusion helps prevent double counting of these quantities in the aggregation.
 
 ## Content constraints
 

--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountquantity.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountquantity.md
@@ -37,7 +37,7 @@ The amount of a *commitment discount* purchased or accounted for in *commitment 
 
 ## Usability Constraints
 
-**Aggregation:** When aggregating Commitment Discount Quantity for commitment utilization calculations, it's important to exclude [*commitment discount*](#glossary:commitment-discount) purchases (i.e. when Charge Category is "Purchase") that are paid to cover future eligible [*charges*](#glossary:charge) (e.g., *commitment discount*). Otherwise, when accounting for all upfront or accrued purchases, it's important to exclude *commitment discount* usage (i.e. when Charge Category is "Usage"). This exclusion helps prevent double counting of these quantities in the aggregation.
+**Aggregation:** When aggregating Commitment Discount Quantity for commitment utilization calculations, it is important to exclude [*commitment discount*](#glossary:commitment-discount) purchases (i.e., when Charge Category is "Purchase") that are paid to cover future eligible [*charges*](#glossary:charge) (e.g., *commitment discount*). Otherwise, when accounting for all upfront or accrued purchases, it is important to exclude *commitment discount* usage (i.e., when Charge Category is "Usage"). This exclusion helps prevent double counting of these quantities in the aggregation.
 
 ## Content constraints
 


### PR DESCRIPTION
## Summary

Addresses item D from the #1878 consistency review: fixes `commitmentdiscountquantity.md` which contains the same `i.e. when` pattern (missing trailing comma) and `it's` contractions fixed in `pricingquantity.md` by PR #2200.

**Changes to `specification/datasets/cost_and_usage/columns/commitmentdiscountquantity.md` line 40:**
- `i.e. when` → `i.e., when` (×2)
- `it's important` → `it is important` (×2)

Closes item D noted by @davidearney in #1878.

## Test plan

- [x] Single line change verified correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)