### PR TITLE
Process #1878: Consistency: Quote all allowed values in dimension column tables

### DIFF
--- a/specification/datasets/contract_commitment/columns/contractcommitmentbenefitcategory.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentbenefitcategory.md
@@ -51,10 +51,10 @@ Allowed values:
 
 | Value | Sort Order | Description | Typical Use Case |
 | :--- | :--- | :--- | :--- |
-| Discount | 10 | A financial reduction in the unit price or list rate, whether applied immediately or conditionally upon meeting usage or spend thresholds. | Flat rate negotiated reductions, Savings Plans, growth rebates, or volume-tier discounts. |
-| Entitlement | 20 | The contractual right to access and consume specific products, features, or software tiers that would otherwise be unavailable. | Marketplace SaaS purchases, Enterprise Agreements (e.g., Snowflake), or paid Proof of Concepts. |
-| Availability | 30 | A contractual assurance of resource access and physical capacity. | Capacity reservations or dedicated host guarantees. |
-| Other | 40 | Benefits not captured by standard categories. | Support access, training, or professional services. |
+| "Discount" | 10 | A financial reduction in the unit price or list rate, whether applied immediately or conditionally upon meeting usage or spend thresholds. | Flat rate negotiated reductions, Savings Plans, growth rebates, or volume-tier discounts. |
+| "Entitlement" | 20 | The contractual right to access and consume specific products, features, or software tiers that would otherwise be unavailable. | Marketplace SaaS purchases, Enterprise Agreements (e.g., Snowflake), or paid Proof of Concepts. |
+| "Availability" | 30 | A contractual assurance of resource access and physical capacity. | Capacity reservations or dedicated host guarantees. |
+| "Other" | 40 | Benefits not captured by standard categories. | Support access, training, or professional services. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentcategory.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentcategory.md
@@ -37,8 +37,8 @@ Allowed values:
 
 | Value   | Description                                                              |
 |:--------|:-------------------------------------------------------------------------|
-| Spend   | Contract commitments that require a predetermined amount of spend.       |
-| Usage   | Contract commitments that require a predetermined amount of usage.       |
+| "Spend"   | Contract commitments that require a predetermined amount of spend.       |
+| "Usage"   | Contract commitments that require a predetermined amount of usage.       |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentdurationtype.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentdurationtype.md
@@ -52,20 +52,20 @@ The following units should be used for the representation of time:
 
 | Time Unit |
 | :--- |
-| Minute |
-| Minutes |
-| Hour |
-| Hours |
-| Day |
-| Days |
-| Week |
-| Weeks |
-| Month |
-| Months |
-| Quarter |
-| Quarters |
-| Year |
-| Years |
+| "Minute" |
+| "Minutes" |
+| "Hour" |
+| "Hours" |
+| "Day" |
+| "Days" |
+| "Week" |
+| "Weeks" |
+| "Month" |
+| "Months" |
+| "Quarter" |
+| "Quarters" |
+| "Year" |
+| "Years" |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentfulfillmentinterval.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentfulfillmentinterval.md
@@ -40,16 +40,16 @@ Allowed values:
 
 | Value         | Sort Order | Description                                                                            | Typical Use Case                                                           |
 | ------------- | ---------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| Hourly        | 10         | Measured over a 60-minute period.                        | Continuous Model: Cloud-native RIs and Savings Plans.                      |
-| Daily         | 20         | Measured over a calendar day.                                                | Daily active user (DAU) caps or daily license minimums.                    |
-| Weekly        | 30         | Measured over a rolling or fixed 7-day period.                                         | Burstable bandwidth or weekly sprint-based SaaS usage.                     |
-| Monthly       | 40         | Measured over a calendar month.                                               | Discontinuous Model: SaaS MRR minimums or tiered discounts.                |
-| Quarterly     | 50         | Measured over a 3-month fiscal period.                                                 | Enterprise true-ups or volume-based rebate targets.                        |
-| Semi-Annual   | 60         | Measured over a 6-month period.                                                                 | Mid-year budget alignments or review cycles.                               |
-| Annual        | 70         | Measured over a 12-month period.                                                       | Discontinuous Model: Cloud EAs (Enterprise Agreements).                    |
-| Total Term    | 80         | The commitment applies to the entire duration of the contract with no internal resets. | Multi-year "Pool of Funds" or total contract value (TCV) commits.          |
-| Transactional | 90         | No time-based reset; based purely on event volume or credit consumption.               | API call bundles or "Credit Packs" with no expiration date.                |
-| Custom        | 100        | A bespoke interval that does not fit standard calendar units.                          | Bridge contracts, unique POCs, or non-standard durations (e.g., 100 days). |
+| "Hourly"        | 10         | Measured over a 60-minute period.                        | Continuous Model: Cloud-native RIs and Savings Plans.                      |
+| "Daily"         | 20         | Measured over a calendar day.                                                | Daily active user (DAU) caps or daily license minimums.                    |
+| "Weekly"        | 30         | Measured over a rolling or fixed 7-day period.                                         | Burstable bandwidth or weekly sprint-based SaaS usage.                     |
+| "Monthly"       | 40         | Measured over a calendar month.                                               | Discontinuous Model: SaaS MRR minimums or tiered discounts.                |
+| "Quarterly"     | 50         | Measured over a 3-month fiscal period.                                                 | Enterprise true-ups or volume-based rebate targets.                        |
+| "Semi-Annual"   | 60         | Measured over a 6-month period.                                                                 | Mid-year budget alignments or review cycles.                               |
+| "Annual"        | 70         | Measured over a 12-month period.                                                       | Discontinuous Model: Cloud EAs (Enterprise Agreements).                    |
+| "Total Term"    | 80         | The commitment applies to the entire duration of the contract with no internal resets. | Multi-year "Pool of Funds" or total contract value (TCV) commits.          |
+| "Transactional" | 90         | No time-based reset; based purely on event volume or credit consumption.               | API call bundles or "Credit Packs" with no expiration date.                |
+| "Custom"        | 100        | A bespoke interval that does not fit standard calendar units.                          | Bridge contracts, unique POCs, or non-standard durations (e.g., 100 days). |
 
 Note: the sort orders and use cases presented above are included for convenience and are not defined as separate FOCUS columns.
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentlifecyclestatus.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentlifecyclestatus.md
@@ -38,13 +38,13 @@ The current lifecycle state of a [*contract commitment*](#glossary:contract-comm
 
 | Value | Sort Order | Description |
 | :--- | :--- | :--- |
-| Proposed | 10 | The commitment is being negotiated or modeled; it has no legal or financial impact on current data. |
-| Pending | 20 | The commitment is finalized or signed, but the effective start date is in the future. |
-| Active | 30 | The commitment is currently in effect, and it has remaining value. |
-| Exhausted | 40 | The commitment is currently in effect, but its value has been fully consumed. |
-| Expired | 50 | The commitment is no longer active because it reached its scheduled end date. |
-| Canceled | 60 | The commitment is no longer active because it was terminated by either party prior to its scheduled end date. |
-| Superseded | 70 | The commitment is no longer active because it was replaced by a newer version prior to its scheduled end date. |
+| "Proposed" | 10 | The commitment is being negotiated or modeled; it has no legal or financial impact on current data. |
+| "Pending" | 20 | The commitment is finalized or signed, but the effective start date is in the future. |
+| "Active" | 30 | The commitment is currently in effect, and it has remaining value. |
+| "Exhausted" | 40 | The commitment is currently in effect, but its value has been fully consumed. |
+| "Expired" | 50 | The commitment is no longer active because it reached its scheduled end date. |
+| "Canceled" | 60 | The commitment is no longer active because it was terminated by either party prior to its scheduled end date. |
+| "Superseded" | 70 | The commitment is no longer active because it was replaced by a newer version prior to its scheduled end date. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentmodel.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentmodel.md
@@ -51,8 +51,8 @@ Allowed values:
 
 | Value         | Description                                                                                                                                                     |
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Continuous    | A flat, constant "floor" of commitment (e.g., RIs, Savings Plans). Coverage is applied at a fixed rate per [Contract Commitment Fulfillment Interval](#datasets.contractcommitment.contractcommitmentfulfillmentinterval) (usually hourly), and benefits are not carried over to subsequent intervals.                                    |
-| Discontinuous | A flexible, aggregate commitment (e.g., Enterprise Agreements, SaaS Minimum Spend). Coverage is measured over a broad window or against a total monetary value. |
+| "Continuous"    | A flat, constant "floor" of commitment (e.g., RIs, Savings Plans). Coverage is applied at a fixed rate per [Contract Commitment Fulfillment Interval](#datasets.contractcommitment.contractcommitmentfulfillmentinterval) (usually hourly), and benefits are not carried over to subsequent intervals.                                    |
+| "Discontinuous" | A flexible, aggregate commitment (e.g., Enterprise Agreements, SaaS Minimum Spend). Coverage is measured over a broad window or against a total monetary value. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentoffercategory.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentoffercategory.md
@@ -46,8 +46,8 @@ Allowed values:
 
 | Value      | Description                                                                                                        | Typical Use Case                                                                                                |
 | ---------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| Public     | Terms that are generally available to all customers via a service provider's standard rate card or portal.                 | Standard Savings Plans or Reserved Instances purchased via the cloud console without a custom discount.         |
-| Negotiated | Terms and pricing that have been specifically modified through an agreement between the customer and the service provider. | Enterprise Agreements (EA), private marketplace offers, or custom SaaS contracts with volume-based discounting. |
+| "Public"     | Terms that are generally available to all customers via a service provider's standard rate card or portal.                 | Standard Savings Plans or Reserved Instances purchased via the cloud console without a custom discount.         |
+| "Negotiated" | Terms and pricing that have been specifically modified through an agreement between the customer and the service provider. | Enterprise Agreements (EA), private marketplace offers, or custom SaaS contracts with volume-based discounting. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentpaymentinterval.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentpaymentinterval.md
@@ -41,12 +41,12 @@ Allowed values:
 
 | Value       | Sort Order | Description                                                         | Typical Use Case                                  |
 | ----------- | ---------- | ------------------------------------------------------------------- | ------------------------------------------------- |
-| One-Time    | 10         | A single invoice is generated for the entire obligation.            | All Upfront models (e.g., 3yr All-Upfront RI) or single-invoice arrears paid at the end of a term.    |
-| Monthly     | 20         | Invoices for the deferred balance are generated once per month.     | No Upfront Savings Plans or Monthly SaaS.         |
-| Quarterly   | 30         | Invoices for the deferred balance are generated every three months. | Partial Upfront deals with 90-day true-ups.       |
-| Semi-Annual | 40         | Invoices for the deferred balance are generated every six months.   | Split-payment agreements.                         |
-| Annual      | 50         | Invoices for the deferred balance are generated once per year.      | Partial Upfront EAs billed yearly.                |
-| Custom      | 60         | Hourly/Daily or other irregular cycles.                             | Irregular bridge contracts or non-standard terms. |
+| "One-Time"    | 10         | A single invoice is generated for the entire obligation.            | All Upfront models (e.g., 3yr All-Upfront RI) or single-invoice arrears paid at the end of a term.    |
+| "Monthly"     | 20         | Invoices for the deferred balance are generated once per month.     | No Upfront Savings Plans or Monthly SaaS.         |
+| "Quarterly"   | 30         | Invoices for the deferred balance are generated every three months. | Partial Upfront deals with 90-day true-ups.       |
+| "Semi-Annual" | 40         | Invoices for the deferred balance are generated every six months.   | Split-payment agreements.                         |
+| "Annual"      | 50         | Invoices for the deferred balance are generated once per year.      | Partial Upfront EAs billed yearly.                |
+| "Custom"      | 60         | Hourly/Daily or other irregular cycles.                             | Irregular bridge contracts or non-standard terms. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentpaymentmodel.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentpaymentmodel.md
@@ -48,9 +48,9 @@ Allowed values:
 
 | Value           | Sort Order | Description                                                                                  | Typical Use Case                                              |
 | --------------- | ---------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| No Upfront      | 10         | The obligation is settled entirely through deferred payment(s) (typically multiple recurring charges) with no initial payment. | Pay-as-you-go Savings Plans or monthly-billed SaaS.           |
-| Partial Upfront | 20         | The obligation is settled through a combination of an initial payment and deferred payment(s) (typically multiple recurring charges). | Hybrid RIs or EAs with a "Year 1" deposit plus installments.  |
-| All Upfront     | 30         | The total obligation is settled via a single payment at the start of the duration.           | High-discount RIs or multi-year contracts paid in full Day 1. |
+| "No Upfront"      | 10         | The obligation is settled entirely through deferred payment(s) (typically multiple recurring charges) with no initial payment. | Pay-as-you-go Savings Plans or monthly-billed SaaS.           |
+| "Partial Upfront" | 20         | The obligation is settled through a combination of an initial payment and deferred payment(s) (typically multiple recurring charges). | Hybrid RIs or EAs with a "Year 1" deposit plus installments.  |
+| "All Upfront"     | 30         | The total obligation is settled via a single payment at the start of the duration.           | High-discount RIs or multi-year contracts paid in full Day 1. |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/capacityreservationstatus.md
+++ b/specification/datasets/cost_and_usage/columns/capacityreservationstatus.md
@@ -40,10 +40,10 @@ Indicates whether the *charge* represents either the consumption of a *capacity 
 
 Allowed values:
 
-| Value  | Description                                                                 |
-| :----- | :-------------------------------------------------------------------------- |
-| Used   | *Charges* that utilized a specific amount of a *capacity reservation*.      |
-| Unused | *Charges* that represent the unused portion of a *capacity reservation*.    |
+| Value    | Description                                                                 |
+| :------- | :-------------------------------------------------------------------------- |
+| "Used"   | *Charges* that utilized a specific amount of a *capacity reservation*.      |
+| "Unused" | *Charges* that represent the unused portion of a *capacity reservation*.    |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountcategory.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountcategory.md
@@ -37,10 +37,10 @@ Indicates whether the *commitment discount* identified in the CommitmentDiscount
 
 Allowed values:
 
-| Value   | Description                                                              |
-|:--------|:-------------------------------------------------------------------------|
-| Spend   | Commitment discounts that require a predetermined amount of spend. |
-| Usage   | Commitment discounts that require a predetermined amount of usage. |
+| Value     | Description                                                              |
+|:----------|:-------------------------------------------------------------------------|
+| "Spend"   | Commitment discounts that require a predetermined amount of spend. |
+| "Usage"   | Commitment discounts that require a predetermined amount of usage. |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountstatus.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountstatus.md
@@ -39,10 +39,10 @@ Indicates whether the *charge* corresponds with the consumption of a *commitment
 
 Allowed values:
 
-| Value  | Description                                                             |
-| :----- | :---------------------------------------------------------------------- |
-| Used   | *Charges* that utilized a specific amount of a commitment discount.     |
-| Unused | *Charges* that represent the unused portion of the commitment discount. |
+| Value    | Description                                                             |
+| :------- | :---------------------------------------------------------------------- |
+| "Used"   | *Charges* that utilized a specific amount of a commitment discount.     |
+| "Unused" | *Charges* that represent the unused portion of the commitment discount. |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/pricingcategory.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcategory.md
@@ -44,12 +44,12 @@ Describes the pricing model used for a *charge* at the time of use or purchase.
 
 Allowed values:
 
-| Value     | Description                                                                                                                                                                                                                          |
-| :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Standard  | *Charges* priced at the agreed upon rate for the billing account, including [*negotiated discounts*](#glossary:negotiated-discount). This pricing includes any flat rate and volume/tiered pricing but does not include dynamic pricing or reduced pricing due to the application of a *commitment discount*. This does include the purchase of a commitment discount at agreed upon rates. |
-| Dynamic   | *Charges* priced at a variable rate determined by the service provider. This includes any product or service with a unit price the service provider can change without notice, like interruptible or low priority [*resources*](#glossary:resource). |
-| Committed | *Charges* with reduced pricing due to the application of the *commitment discount* specified by the Commitment Discount ID.                                                                                                          |
-| Other     | *Charges* priced in a way not covered by another pricing category.                                                                                                                                                                   |
+| Value       | Description                                                                                                                                                                                                                          |
+| :---------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Standard"  | *Charges* priced at the agreed upon rate for the billing account, including [*negotiated discounts*](#glossary:negotiated-discount). This pricing includes any flat rate and volume/tiered pricing but does not include dynamic pricing or reduced pricing due to the application of a *commitment discount*. This does include the purchase of a commitment discount at agreed upon rates. |
+| "Dynamic"   | *Charges* priced at a variable rate determined by the service provider. This includes any product or service with a unit price the service provider can change without notice, like interruptible or low priority [*resources*](#glossary:resource). |
+| "Committed" | *Charges* with reduced pricing due to the application of the *commitment discount* specified by the Commitment Discount ID.                                                                                                          |
+| "Other"     | *Charges* priced in a way not covered by another pricing category.                                                                                                                                                                   |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/servicesubcategory.md
+++ b/specification/datasets/cost_and_usage/columns/servicesubcategory.md
@@ -36,90 +36,90 @@ Secondary classification of the Service Category for a *service* based on its co
 
 Allowed values:
 
-| Service Category          | Service Subcategory                   | Service Subcategory Description                                                                               |
+| Service Category | Service Subcategory | Service Subcategory Description                                                                               |
 | ------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| AI and Machine Learning   | AI Platforms                          | Unified solution that combines artificial intelligence and machine learning technologies.                     |
-| AI and Machine Learning   | Bots                                  | Automated performance of tasks such as customer service, data collection, and content moderation.             |
-| AI and Machine Learning   | Generative AI                         | Creation of content like text, images, and music by learning patterns from existing data.                     |
-| AI and Machine Learning   | Machine Learning                      | Creation, training, and deployment of statistical algorithms that learn from and perform tasks based on data. |
-| AI and Machine Learning   | Natural Language Processing           | Generation of human language, handling tasks like translation, sentiment analysis, and text summarization.    |
-| AI and Machine Learning   | Other (AI and Machine Learning)       | AI and Machine Learning services that do not fall into one of the defined subcategories.                      |
-| Analytics                 | Analytics Platforms                   | Unified solution that combines technologies across the entire analytics lifecycle.                            |
-| Analytics                 | Business Intelligence                 | Semantic models, dashboards, reports, and data visualizations to track performance and identify trends.       |
-| Analytics                 | Data Processing                       | Integration and transformation tasks to prepare data for analysis.                                            |
-| Analytics                 | Search                                | Discovery of information by indexing and retrieving data from various sources.                                |
-| Analytics                 | Streaming Analytics                   | Real-time data stream processes to detect patterns, trends, and anomalies as they occur.                      |
-| Analytics                 | Other (Analytics)                     | Analytics services that do not fall into one of the defined subcategories.                                    |
-| Business Applications     | Productivity and Collaboration        | Tools that facilitate individuals managing tasks and working together.                                        |
-| Business Applications     | Other (Business Applications)         | Business Applications services that do not fall into one of the defined subcategories.                        |
-| Compute                   | Containers                            | Management and orchestration of containerized compute platforms.                                              |
-| Compute                   | End User Computing                    | Virtualized desktop infrastructure and device / endpoint management.                                          |
-| Compute                   | Quantum Compute                       | Resources and simulators that leverage the principles of quantum mechanics.                                   |
-| Compute                   | Serverless Compute                    | Enablement of compute capabilities without provisioning or managing servers.                                  |
-| Compute                   | Virtual Machines                      | Computing environments ranging from hosts with abstracted operating systems to bare-metal servers.            |
-| Compute                   | Other (Compute)                       | Compute services that do not fall into one of the defined subcategories.                                      |
-| Databases                 | Caching                               | Low-latency and high-throughput access to frequently accessed data.                                           |
-| Databases                 | Data Warehouses                       | Big data storage and querying capabilities.                                                                   |
-| Databases                 | Ledger Databases                      | Immutable and transparent databases to record tamper-proof and cryptographically secure transactions.         |
-| Databases                 | NoSQL Databases                       | Unstructured or semi-structured data storage and querying capabilities.                                       |
-| Databases                 | Relational Databases                  | Structured data storage and querying capabilities.                                                            |
-| Databases                 | Time Series Databases                 | Time-stamped data storage and querying capabilities.                                                          |
-| Databases                 | Other (Databases)                     | Database services that do not fall into one of the defined subcategories.                                     |
-| Developer Tools           | Developer Platforms                   | Unified solution that combines technologies across multiple areas of the software development lifecycle.      |
-| Developer Tools           | Continuous Integration and Deployment | CI/CD tools and services that support building and deploying code for software and systems.                   |
-| Developer Tools           | Development Environments              | Tools and services that support authoring code for software and systems.                                      |
-| Developer Tools           | Source Code Management                | Tools and services that support version control of code for software and systems.                             |
-| Developer Tools           | Quality Assurance                     | Tools and services that support testing code for software and systems.                                        |
-| Developer Tools           | Other (Developer Tools)               | Developer Tools services that do not fall into one of the defined subcategories.                              |
-| Identity                  | Identity and Access Management        | Technologies that ensure users have appropriate access to resources.                                          |
-| Identity                  | Other (Identity)                      | Identity services that do not fall into one of the defined subcategories.                                     |
-| Integration               | API Management                        | Creation, publishing, and management of application programming interfaces.                                   |
-| Integration               | Messaging                             | Asynchronous communication between distributed applications.                                                  |
-| Integration               | Workflow Orchestration                | Design, execution, and management of business processes and workflows.                                        |
-| Integration               | Other (Integration)                   | Integration services that do not fall into one of the defined subcategories.                                  |
-| Internet of Things        | IoT Analytics                         | Examination of data collected from IoT devices.                                                               |
-| Internet of Things        | IoT Platforms                         | Unified solution that combines IoT data collection, processing, visualization, and device management.         |
-| Internet of Things        | Other (Internet of Things)            | Internet of Things (IoT) services that do not fall into one of the defined subcategories.                     |
-| Management and Governance | Architecture                          | Planning, design, and construction of software systems.                                                       |
-| Management and Governance | Compliance                            | Adherence to regulatory standards and industry best practices.                                                |
-| Management and Governance | Cost Management                       | Monitoring and controlling expenses of systems and services.                                                  |
-| Management and Governance | Data Governance                       | Management of the availability, usability, integrity, and security of data.                                   |
-| Management and Governance | Disaster Recovery                     | Plans and procedures that ensure systems and services can recover from disruptions.                           |
-| Management and Governance | Endpoint Management                   | Tools that configure and secure access to devices.                                                            |
-| Management and Governance | Observability                         | Monitoring, logging, and tracing of data to track the performance and health of systems.                      |
-| Management and Governance | Support                               | Assistance and expertise supplied by service providers.                                                       |
-| Management and Governance | Other (Management and Governance)     | Management and governance services that do not fall into one of the defined subcategories.                    |
-| Media                     | Content Creation                      | Production of media content.                                                                                  |
-| Media                     | Gaming                                | Development and delivery of gaming services.                                                                  |
-| Media                     | Media Streaming                       | Multimedia delivered and rendered in real-time on devices.                                                    |
-| Media                     | Mixed Reality                         | Technologies that blend real-world and computer-generated environments.                                       |
-| Media                     | Other (Media)                         | Media services that do not fall into one of the defined subcategories.                                        |
-| Migration                 | Data Migration                        | Movement of stored data from one location to another.                                                         |
-| Migration                 | Resource Migration                    | Movement of resources from one location to another.                                                           |
-| Migration                 | Other (Migration)                     | Migration services that do not fall into one of the defined subcategories.                                    |
-| Mobile                    | Other (Mobile)                        | All Mobile services.                                                                                          |
-| Multicloud                | Multicloud Integration                | Environments that facilitate consumption of services from multiple cloud service providers.                   |
-| Multicloud                | Other (Multicloud)                    | Multicloud services that do not fall into one of the defined subcategories.                                   |
-| Networking                | Application Networking                | Distribution of incoming network traffic across application-based workloads.                                  |
-| Networking                | Content Delivery                      | Distribution of digital content using a network of servers (CDNs).                                            |
-| Networking                | Network Connectivity                  | Facilitates communication between networks or network segments.                                               |
-| Networking                | Network Infrastructure                | Configuration, monitoring, and troubleshooting of network devices.                                            |
-| Networking                | Network Routing                       | Services that select paths for traffic within or across networks.                                             |
-| Networking                | Network Security                      | Protection from unauthorized network access and cyber threats using firewalls and anti-malware tools.         |
-| Networking                | Other (Networking)                    | Networking services that do not fall into one of the defined subcategories.                                   |
-| Security                  | Secret Management                     | Information used to authenticate users and systems, including secrets, certificates, tokens, and other keys.  |
-| Security                  | Security Posture Management           | Tools that help organizations configure, monitor, and improve system security.                                |
-| Security                  | Threat Detection and Response         | Collect and analyze security data to identify and respond to potential security threats and vulnerabilities.  |
-| Security                  | Other (Security)                      | Security services that do not fall into one of the defined subcategories.                                     |
-| Storage                   | Backup Storage                        | Secondary storage to protect against data loss.                                                               |
-| Storage                   | Block Storage                         | High performance, low latency storage that provides random access.                                            |
-| Storage                   | File Storage                          | Scalable, sharable storage for file-based data.                                                               |
-| Storage                   | Object Storage                        | Highly available, durable storage for unstructured data.                                                      |
-| Storage                   | Storage Platforms                     | Unified solution that supports multiple storage types.                                                        |
-| Storage                   | Other (Storage)                       | Storage services that do not fall into one of the defined subcategories.                                      |
-| Web                       | Application Platforms                 | Integrated environments that run web applications.                                                            |
-| Web                       | Other (Web)                           | Web services that do not fall into one of the defined subcategories.                                          |
-| Other                     | Other (Other)                         | Services that do not fall into one of the defined categories.                                                 |
+| "AI and Machine Learning" | "AI Platforms" | Unified solution that combines artificial intelligence and machine learning technologies.                     |
+| "AI and Machine Learning" | "Bots" | Automated performance of tasks such as customer service, data collection, and content moderation.             |
+| "AI and Machine Learning" | "Generative AI" | Creation of content like text, images, and music by learning patterns from existing data.                     |
+| "AI and Machine Learning" | "Machine Learning" | Creation, training, and deployment of statistical algorithms that learn from and perform tasks based on data. |
+| "AI and Machine Learning" | "Natural Language Processing" | Generation of human language, handling tasks like translation, sentiment analysis, and text summarization.    |
+| "AI and Machine Learning" | "Other (AI and Machine Learning)" | AI and Machine Learning services that do not fall into one of the defined subcategories.                      |
+| "Analytics" | "Analytics Platforms" | Unified solution that combines technologies across the entire analytics lifecycle.                            |
+| "Analytics" | "Business Intelligence" | Semantic models, dashboards, reports, and data visualizations to track performance and identify trends.       |
+| "Analytics" | "Data Processing" | Integration and transformation tasks to prepare data for analysis.                                            |
+| "Analytics" | "Search" | Discovery of information by indexing and retrieving data from various sources.                                |
+| "Analytics" | "Streaming Analytics" | Real-time data stream processes to detect patterns, trends, and anomalies as they occur.                      |
+| "Analytics" | "Other (Analytics)" | Analytics services that do not fall into one of the defined subcategories.                                    |
+| "Business Applications" | "Productivity and Collaboration" | Tools that facilitate individuals managing tasks and working together.                                        |
+| "Business Applications" | "Other (Business Applications)" | Business Applications services that do not fall into one of the defined subcategories.                        |
+| "Compute" | "Containers" | Management and orchestration of containerized compute platforms.                                              |
+| "Compute" | "End User Computing" | Virtualized desktop infrastructure and device / endpoint management.                                          |
+| "Compute" | "Quantum Compute" | Resources and simulators that leverage the principles of quantum mechanics.                                   |
+| "Compute" | "Serverless Compute" | Enablement of compute capabilities without provisioning or managing servers.                                  |
+| "Compute" | "Virtual Machines" | Computing environments ranging from hosts with abstracted operating systems to bare-metal servers.            |
+| "Compute" | "Other (Compute)" | Compute services that do not fall into one of the defined subcategories.                                      |
+| "Databases" | "Caching" | Low-latency and high-throughput access to frequently accessed data.                                           |
+| "Databases" | "Data Warehouses" | Big data storage and querying capabilities.                                                                   |
+| "Databases" | "Ledger Databases" | Immutable and transparent databases to record tamper-proof and cryptographically secure transactions.         |
+| "Databases" | "NoSQL Databases" | Unstructured or semi-structured data storage and querying capabilities.                                       |
+| "Databases" | "Relational Databases" | Structured data storage and querying capabilities.                                                            |
+| "Databases" | "Time Series Databases" | Time-stamped data storage and querying capabilities.                                                          |
+| "Databases" | "Other (Databases)" | Database services that do not fall into one of the defined subcategories.                                     |
+| "Developer Tools" | "Developer Platforms" | Unified solution that combines technologies across multiple areas of the software development lifecycle.      |
+| "Developer Tools" | "Continuous Integration and Deployment" | CI/CD tools and services that support building and deploying code for software and systems.                   |
+| "Developer Tools" | "Development Environments" | Tools and services that support authoring code for software and systems.                                      |
+| "Developer Tools" | "Source Code Management" | Tools and services that support version control of code for software and systems.                             |
+| "Developer Tools" | "Quality Assurance" | Tools and services that support testing code for software and systems.                                        |
+| "Developer Tools" | "Other (Developer Tools)" | Developer Tools services that do not fall into one of the defined subcategories.                              |
+| "Identity" | "Identity and Access Management" | Technologies that ensure users have appropriate access to resources.                                          |
+| "Identity" | "Other (Identity)" | Identity services that do not fall into one of the defined subcategories.                                     |
+| "Integration" | "API Management" | Creation, publishing, and management of application programming interfaces.                                   |
+| "Integration" | "Messaging" | Asynchronous communication between distributed applications.                                                  |
+| "Integration" | "Workflow Orchestration" | Design, execution, and management of business processes and workflows.                                        |
+| "Integration" | "Other (Integration)" | Integration services that do not fall into one of the defined subcategories.                                  |
+| "Internet of Things" | "IoT Analytics" | Examination of data collected from IoT devices.                                                               |
+| "Internet of Things" | "IoT Platforms" | Unified solution that combines IoT data collection, processing, visualization, and device management.         |
+| "Internet of Things" | "Other (Internet of Things)" | Internet of Things (IoT) services that do not fall into one of the defined subcategories.                     |
+| "Management and Governance" | "Architecture" | Planning, design, and construction of software systems.                                                       |
+| "Management and Governance" | "Compliance" | Adherence to regulatory standards and industry best practices.                                                |
+| "Management and Governance" | "Cost Management" | Monitoring and controlling expenses of systems and services.                                                  |
+| "Management and Governance" | "Data Governance" | Management of the availability, usability, integrity, and security of data.                                   |
+| "Management and Governance" | "Disaster Recovery" | Plans and procedures that ensure systems and services can recover from disruptions.                           |
+| "Management and Governance" | "Endpoint Management" | Tools that configure and secure access to devices.                                                            |
+| "Management and Governance" | "Observability" | Monitoring, logging, and tracing of data to track the performance and health of systems.                      |
+| "Management and Governance" | "Support" | Assistance and expertise supplied by service providers.                                                       |
+| "Management and Governance" | "Other (Management and Governance)" | Management and governance services that do not fall into one of the defined subcategories.                    |
+| "Media" | "Content Creation" | Production of media content.                                                                                  |
+| "Media" | "Gaming" | Development and delivery of gaming services.                                                                  |
+| "Media" | "Media Streaming" | Multimedia delivered and rendered in real-time on devices.                                                    |
+| "Media" | "Mixed Reality" | Technologies that blend real-world and computer-generated environments.                                       |
+| "Media" | "Other (Media)" | Media services that do not fall into one of the defined subcategories.                                        |
+| "Migration" | "Data Migration" | Movement of stored data from one location to another.                                                         |
+| "Migration" | "Resource Migration" | Movement of resources from one location to another.                                                           |
+| "Migration" | "Other (Migration)" | Migration services that do not fall into one of the defined subcategories.                                    |
+| "Mobile" | "Other (Mobile)" | All Mobile services.                                                                                          |
+| "Multicloud" | "Multicloud Integration" | Environments that facilitate consumption of services from multiple cloud service providers.                   |
+| "Multicloud" | "Other (Multicloud)" | Multicloud services that do not fall into one of the defined subcategories.                                   |
+| "Networking" | "Application Networking" | Distribution of incoming network traffic across application-based workloads.                                  |
+| "Networking" | "Content Delivery" | Distribution of digital content using a network of servers (CDNs).                                            |
+| "Networking" | "Network Connectivity" | Facilitates communication between networks or network segments.                                               |
+| "Networking" | "Network Infrastructure" | Configuration, monitoring, and troubleshooting of network devices.                                            |
+| "Networking" | "Network Routing" | Services that select paths for traffic within or across networks.                                             |
+| "Networking" | "Network Security" | Protection from unauthorized network access and cyber threats using firewalls and anti-malware tools.         |
+| "Networking" | "Other (Networking)" | Networking services that do not fall into one of the defined subcategories.                                   |
+| "Security" | "Secret Management" | Information used to authenticate users and systems, including secrets, certificates, tokens, and other keys.  |
+| "Security" | "Security Posture Management" | Tools that help organizations configure, monitor, and improve system security.                                |
+| "Security" | "Threat Detection and Response" | Collect and analyze security data to identify and respond to potential security threats and vulnerabilities.  |
+| "Security" | "Other (Security)" | Security services that do not fall into one of the defined subcategories.                                     |
+| "Storage" | "Backup Storage" | Secondary storage to protect against data loss.                                                               |
+| "Storage" | "Block Storage" | High performance, low latency storage that provides random access.                                            |
+| "Storage" | "File Storage" | Scalable, sharable storage for file-based data.                                                               |
+| "Storage" | "Object Storage" | Highly available, durable storage for unstructured data.                                                      |
+| "Storage" | "Storage Platforms" | Unified solution that supports multiple storage types.                                                        |
+| "Storage" | "Other (Storage)" | Storage services that do not fall into one of the defined subcategories.                                      |
+| "Web" | "Application Platforms" | Integrated environments that run web applications.                                                            |
+| "Web" | "Other (Web)" | Web services that do not fall into one of the defined subcategories.                                          |
+| "Other" | "Other (Other)" | Services that do not fall into one of the defined categories.                                                 |
 
 ## Introduced (version)
 

--- a/specification/datasets/invoice_detail/columns/chargecategory.md
+++ b/specification/datasets/invoice_detail/columns/chargecategory.md
@@ -35,13 +35,13 @@ Represents the highest-level classification of a *charge* based on the nature of
 
 ## Allowed Values
 
-| Value      | Description                                                                                                                                    |
-| :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------|
-| Usage      | Positive or negative *charges* based on the quantity of a service or resource that was consumed over a given period of time including refunds. |
-| Purchase   | Positive or negative *charges* for the acquisition of a service or resource bought upfront or on a recurring basis including refunds.          |
-| Tax        | Positive or negative applicable taxes that are levied by the relevant authorities including refunds. Tax *charges* may vary depending on factors such as the location, jurisdiction, and local or federal regulations. |
-| Credit     | Positive or negative *charges* granted by the service provider for various scenarios (e.g., promotional credits, corrections to promotional credits).    |
-| Adjustment | Positive or negative *charges* the service provider applies that do not fall into other category values.                                               |
+| Value        | Description                                                                                                                                    |
+| :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------|
+| "Usage"      | Positive or negative *charges* based on the quantity of a service or resource that was consumed over a given period of time including refunds. |
+| "Purchase"   | Positive or negative *charges* for the acquisition of a service or resource bought upfront or on a recurring basis including refunds.          |
+| "Tax"        | Positive or negative applicable taxes that are levied by the relevant authorities including refunds. Tax *charges* may vary depending on factors such as the location, jurisdiction, and local or federal regulations. |
+| "Credit"     | Positive or negative *charges* granted by the service provider for various scenarios (e.g., promotional credits, corrections to promotional credits).    |
+| "Adjustment" | Positive or negative *charges* the service provider applies that do not fall into other category values.                                               |
 
 ## Introduced (version)
 

--- a/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
+++ b/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
@@ -49,11 +49,11 @@ The publication state of the invoice and the reliability of its associated deliv
 
 ## Allowed Values
 
-| Value  | Description |
-| :---   | :---        |
-| Open   | The invoice is provisional and subject to change. It is not a valid financial obligation and the associated delivered data is preliminary. |
-| Issued | The invoice has been formally issued by the provider. It represents a valid financial obligation with finalized associated data. |
-| Voided | The invoice was previously issued but has been retracted or nullified. It is not a valid financial obligation. |
+| Value    | Description |
+| :------- | :---        |
+| "Open"   | The invoice is provisional and subject to change. It is not a valid financial obligation and the associated delivered data is preliminary. |
+| "Issued" | The invoice has been formally issued by the provider. It represents a valid financial obligation with finalized associated data. |
+| "Voided" | The invoice was previously issued but has been retracted or nullified. It is not a valid financial obligation. |
 
 ## Introduced (version)
 


### PR DESCRIPTION
## Summary

- Adds double-quotes around allowed values in the `Value` column of all allowed values tables
- Covers `cost_and_usage`, `invoice_detail`, and `contract_commitment` dataset columns not addressed in PR #2200
- Files updated: `capacityreservationstatus.md`, `commitmentdiscountcategory.md`, `commitmentdiscountstatus.md`, `pricingcategory.md`, `servicesubcategory.md` (C&U); `chargecategory.md`, `invoiceissuestatus.md` (invoice_detail); 9 `contractcommitment*.md` files

## Context

Part of the 1.4 consistency review (issue #1878). Addresses item F: unquoted allowed values in dimension tables. Consistent with the quoting convention already used in other columns (e.g., `chargeclass.md`, `chargefrequency.md`).

## Test plan

- [ ] Verify all changed files render correctly as markdown tables
- [ ] Verify no header rows were accidentally quoted
- [ ] Verify requirement lines referencing values continue to use double-quotes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)