### PR TITLE
Process #1878: Add guidelines to support 1.4 consistency review PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ AI agents generating or reviewing content MUST act as strict technical editors e
 * **Column/Attribute IDs:** PascalCase without spaces (e.g., PricingQuantity). Entity IDs SHOULD be used in normative text sections.
 * **Column/Attribute Display Names:** Normal text with spaces (e.g., "Pricing Quantity"). These SHOULD be used in introductory or explanatory non-normative text.
 * **No Mixing:** Do not mix Entity IDs and Display Names within the same normative requirement.
-* **Column values:** Enclosed in double quotes (e.g., `"Usage"`, `"Tax"`).
+* **Column values:** Enclosed in backticks (e.g., `Usage`, `Tax`).
 * **Glossary terms:** Link with `[*term*](#glossary:term)` format.
 * **Linking Rule:** First mention of Column/Attribute names and Glossary terms should link to their definition section. They MUST ONLY be hyperlinked the *first occurrence* per section.
 * **Lists:** All unordered lists MUST use asterisks (`*`), never dashes (`-`) or plus signs (`+`). Nested bullet points MUST use exactly two spaces per level.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ AI agents generating or reviewing content MUST act as strict technical editors e
 * **Column/Attribute IDs:** PascalCase without spaces (e.g., PricingQuantity). Entity IDs SHOULD be used in normative text sections.
 * **Column/Attribute Display Names:** Normal text with spaces (e.g., "Pricing Quantity"). These SHOULD be used in introductory or explanatory non-normative text.
 * **No Mixing:** Do not mix Entity IDs and Display Names within the same normative requirement.
-* **Column values:** Enclosed in backticks (e.g., `Usage`, `Tax`).
+* **Column values:** Enclosed in double quotes (e.g., `"Usage"`, `"Tax"`).
 * **Glossary terms:** Link with `[*term*](#glossary:term)` format.
 * **Linking Rule:** First mention of Column/Attribute names and Glossary terms should link to their definition section. They MUST ONLY be hyperlinked the *first occurrence* per section.
 * **Lists:** All unordered lists MUST use asterisks (`*`), never dashes (`-`) or plus signs (`+`). Nested bullet points MUST use exactly two spaces per level.

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -152,38 +152,6 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 
 * **Linking Only the First Time**: To prevent excessive linking within sections, Entity Names and Entity IDs (e.g., Column Names, Attribute IDs, and Glossary) will only be linked to their corresponding section or glossary the first time they appear in a section.
 
-### Normative Requirements
-
-* **Single Requirement per Statement:** Each normative statement MUST express a single requirement.
-
-* **Example** (Markdown, illustrative):
-
-  ```md
-  * ... MUST be of type String.
-  * ... MUST conform to CurrencyFormat requirements.
-  ```
-
-* **Explicit Conditions:** Normative requirements MUST include an explicit condition unless the rule applies in all cases.
-
-* **Condition Format:** Conditional clauses MUST use standardized patterns: “when / if / unless / only when / only if / except when / except if <condition>”.
-
-* **Example** (Markdown, illustrative):
-
-  ```md
-  * ... MUST be null when ChargeCategory is "Tax".
-  * ... MUST be null if ChargeCategory is "Tax".
-  * ... MUST be null unless ChargeCategory is "Usage".
-  ```
-
-* **Subject Consistency:** Each normative statement MUST clearly identify the subject being constrained.
-
-* **Example** (Markdown, illustrative):
-
-  ```md
-  * PricingQuantity MUST be greater than 0.
-  ```
-* **No Compound Conditions:** Normative requirements MUST NOT combine multiple conditions using “and” or “or” within a single statement.
-
 ### Entity References
 
 * **Entity IDs:** Entity IDs (e.g., Column IDs, Attribute IDs, Dataset IDs), formatting and usage conventions for normative requirements are defined in the Normative Requirements Guidelines. 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -247,7 +247,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Consistent Introductory Phrases:** Introductory phrases for normative lists SHOULD be consistent within a section.
 
-* **Sentence Spacing:** Sentences MUST be delineated with a single space.
+* **Sentence Spacing:** Sentences within paragraphs MUST be delineated with a single space.
 
 ### JSON Formatting
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -162,12 +162,6 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 
 * **Display Names:** Display Names SHOULD be used in introductory or explanatory sections where natural language context is more appropriate. These names should follow normal text conventions, including spaces between words (e.g., Commitment Discount ID).
 
-* **Consistent Reference Type:** Normative requirements MUST use Entity IDs consistently.
-
-* **Consistent Reference Type:** MUST NOT mix Entity IDs and Display Names within the same statement.
-
-* **Multiple Entity References:** MUST use Entity IDs when referencing multiple entities in a normative statement.
-
 * **Entity Scope:** These rules apply to all entities defined in the FOCUS specification (e.g., Columns, Attributes, Datasets, Objects).
 
 ### Bullet Structure
@@ -192,8 +186,6 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
 * **No Skipped Levels:** Nested bullets MUST NOT skip indentation levels.
 
 * **Consistent Indentation:** All bullets within the same list MUST use consistent indentation.
-
-* **Separate Conditions:** Alternative conditions MUST be expressed as separate bullet points.
 
 * **Example** (Markdown, illustrative):
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -70,7 +70,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
         </td>
         <td>
             This column:<br>
-            &nbsp;&nbsp; * MUST be null when ChargeCategory is "Tax" ...
+            &nbsp;&nbsp; * MUST be null when ChargeCategory is `Tax` ...
         </td>
         <td>
             - Enclosed in backticks (e.g., `Usage`)<br>
@@ -171,9 +171,9 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 * **Example** (Markdown, illustrative):
 
   ```md
-  * ... MUST be null when ChargeCategory is "Tax".
-  * ... MUST be null if ChargeCategory is "Tax".
-  * ... MUST be null unless ChargeCategory is "Usage".
+  * ... MUST be null when ChargeCategory is `Tax`.
+  * ... MUST be null if ChargeCategory is `Tax`.
+  * ... MUST be null unless ChargeCategory is `Usage`.
   ```
 
 * **Subject Consistency:** Each normative statement MUST clearly identify the subject being constrained.
@@ -237,8 +237,8 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 * **Example** (Markdown, illustrative):
 
   ```md
-  * ... MUST be null when ChargeCategory is "Tax".
-  * ... MUST be null when ChargeCategory is "Adjustment".
+  * ... MUST be null when ChargeCategory is `Tax`.
+  * ... MUST be null when ChargeCategory is `Adjustment`.
   ```
 
 ### Formatting
@@ -346,7 +346,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 >
 > **3.1.45.5. Usability Constraints**
 >
-> **Aggregation:** When aggregating Pricing Quantity for commitment utilization calculations, it's important to exclude commitment discount purchases (i.e. when Charge Category is "Purchase") that are paid to cover future eligible charges (e.g., commitment discount ). Otherwise, when accounting for all upfront or accrued purchases, it's important to exclude commitment discount usage (i.e. when Charge Category is "Usage"). This exclusion helps prevent double counting of these quantities in the aggregation.
+> **Aggregation:** When aggregating Pricing Quantity for commitment utilization calculations, it's important to exclude commitment discount purchases (i.e. when Charge Category is `Purchase`) that are paid to cover future eligible charges (e.g., commitment discount ). Otherwise, when accounting for all upfront or accrued purchases, it's important to exclude commitment discount usage (i.e., when Charge Category is `Usage`). This exclusion helps prevent double counting of these quantities in the aggregation.
 >
 > **3.1.45.6. Content Constraints**
 >

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -255,6 +255,9 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Sentence Spacing:** Sentences within paragraphs MUST be delineated with a single space.
 
+* **Spelling Out Numbers**: In standard prose, numbers zero through nine MUST be spelled out as words (e.g., "one", "two", "nine"), while numbers 10 and above MUST be written as numerals (e.g., "10", "42"). 
+  * **Exception:** This rule DOES NOT apply to technical values, mathematical formulas, JSON examples, or explicit column constraints (e.g., write `BilledCost MUST be 0`, not `BilledCost MUST be zero`).
+
 ### JSON Formatting
 
 * **Valid JSON:** JSON examples MUST be valid and complete.

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -3,6 +3,11 @@ The "Editorial Style Guidelines" section ensures consistency and clarity across 
 
 These guidelines can be modified through a Pull Request (PR), which the members must review and agree upon. This process ensures that any changes are thoughtfully considered and maintains the overall integrity of our editorial standards.
 
+### Normative Requirements
+Normative requirements are defined and authored exclusively according to the Normative Requirements Guidelines.
+
+Authors MUST refer to the Normative Requirements Guidelines when writing or modifying normative requirements.
+
 <table>
     <tr>
         <th>Component</th>
@@ -78,9 +83,9 @@ These guidelines can be modified through a Pull Request (PR), which the members 
         </td>
     </tr>
     <tr>
-        <td><strong>Normative Keywords &amp; Requirements Statements</strong></td>
+        <td><strong>Normative Keywords</strong>(Formatting Only)</td>
         <td>
-            MUST, MAY, MUST NOT and normative requirements statements
+            Normative keywords and statements (see Normative Requirements Guidelines)
         </td>
         <td>
             This column:</br>
@@ -89,8 +94,8 @@ These guidelines can be modified through a Pull Request (PR), which the members 
             &nbsp;&nbsp; * MAY be null for all other combinations of ... </br>
         </td>
         <td>
-           - All uppercase, without bold.<br>
-           - Bullet list format. <br>
+           - Formatting follows Editorial Guidelines.<br>
+           - Structure and usage are defined in the Normative Requirements Guidelines.<br>
         </td>
     </tr>
     <tr>
@@ -149,12 +154,6 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 ### Normative Requirements
 
-* **Normative Requirements as a Bullet List**: Normative requirements (those using Normative Keywords) MUST be written as bullet points instead of lengthy sentences.
-
-* **Normative Keyword Standardization:** To ensure consistency in the specification, normative language MUST use only the BCP-14 keywords MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY. The term "RECOMMENDED" as a normative keyword is deprecated starting December 2025. Where legacy text uses RECOMMENDED, it MUST be replaced with SHOULD.
-
-* **Non-Normative Use of “recommended”:** The lowercase word “recommended” may still be used in non-normative, descriptive text (e.g., “Feature level: Recommended”) provided it does not express a normative requirement on implementers.
-
 * **Single Requirement per Statement:** Each normative statement MUST express a single requirement.
 
 * **Example** (Markdown, illustrative):
@@ -187,7 +186,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 ### Entity References
 
-* **Entity IDs:** Entity IDs (e.g., Column IDs, Attribute IDs, Dataset IDs) SHOULD be used in normative text sections, such as when specifying mandatory rules, schema definitions, or other implementation-related content. 
+* **Entity IDs:** Entity IDs (e.g., Column IDs, Attribute IDs, Dataset IDs), formatting and usage conventions for normative requirements are defined in the Normative Requirements Guidelines. 
 
 * **Entity IDs:** MUST be formatted without spaces.
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -6,7 +6,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 ### Normative Requirements
 Normative requirements are defined and authored exclusively according to the Normative Requirements Guidelines.
 
-Authors MUST refer to the Normative Requirements Guidelines when writing or modifying normative requirements.
+Authors MUST refer to the [Normative Requirements Guidelines](normative-requirements-guidelines.md) when writing or modifying normative requirements.
 
 <table>
     <tr>

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -258,6 +258,11 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 * **Spelling Out Numbers**: In standard prose, numbers zero through nine MUST be spelled out as words (e.g., "one", "two", "nine"), while numbers 10 and above MUST be written as numerals (e.g., "10", "42"). 
   * **Exception:** This rule DOES NOT apply to technical values, mathematical formulas, JSON examples, or explicit column constraints (e.g., write `BilledCost MUST be 0`, not `BilledCost MUST be zero`).
 
+* **Dash Formatting:**
+  * An unspaced hyphen (`-`) MUST be used for compound words (e.g., `cost-only`) and ranges (e.g., `2024-2025`).
+  * A spaced hyphen (` - `) MUST be used to set off parenthetical phrases (e.g., `The metric - BilledCost - is required.`).
+  * HTML entities and special unicode dash characters SHOULD NOT be used.
+
 ### JSON Formatting
 
 * **Valid JSON:** JSON examples MUST be valid and complete.

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -269,7 +269,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **No Normative Leakage:** Normative keywords (MUST, SHOULD, MAY, etc.) MUST NOT be used in any section other than "Requirements".
 
-* **Title Case for Subheaders**: Subheaders MUST be denoted in Title Case. All words MUST be capitalized except articles (a, an, the), coordinating conjunctions (and, but, or), and short prepositions (e.g., in, on, at), unless they begin the subheader.
+* **Title Case for Subheaders**: Subheaders MUST be denoted in Title Case, with all words capitalized except articles (a, an, the), coordinating conjunctions (and, but, or), and short prepositions (e.g., in, on, at), unless they begin the subheader.
 
 * **Example** (Markdown, illustrative):
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -69,17 +69,17 @@ Authors MUST refer to the [Normative Requirements Guidelines](normative-requirem
     <tr>
         <td><strong>Column Values:</strong></td>
         <td>
-            - `Usage`<br>
-            - `Tax`<br>
-            - `TB`<br>
+            - "Usage"<br>
+            - "Tax"<br>
+            - "TB"<br>
         </td>
         <td>
             This column:<br>
-            &nbsp;&nbsp; * MUST be null when ChargeCategory is `Tax` ...
+            &nbsp;&nbsp; * MUST be null when ChargeCategory is "Tax" ...
         </td>
         <td>
-            - Enclosed in backticks (e.g., `Usage`)<br>
-            - Formatted as inline code
+            - Enclosed in double quotation marks<br>
+            - Normal text without bold or italics
         </td>
     </tr>
     <tr>
@@ -208,8 +208,8 @@ To ensure consistent language when describing relationships and evaluations betw
 * **Example** (Markdown, illustrative):
 
   ```md
-  * ... MUST be null when ChargeCategory is `Tax`.
-  * ... MUST be null when ChargeCategory is `Adjustment`.
+  * ... MUST be null when ChargeCategory is "Tax".
+  * ... MUST be null when ChargeCategory is "Adjustment".
   ```
 
 ### Formatting

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -255,6 +255,9 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Consistent Structure:** JSON examples SHOULD follow consistent formatting and indentation.
 
+* **Sentence Spacing**: Sentences between paragraphs MUST be delienated with a single space; double spaces are not permitted.
+
+* **No Contractions**: In order to maintain a formal, professional tone throughout the specification, contractions MUST NOT be used (e.g., use "do not" instead of "don't").
 
 ### Section Structure
 
@@ -265,6 +268,8 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 * **Normative Scope:** Normative requirements (those using BCP-14 keywords) MUST appear only in the "Requirements" section.
 
 * **No Normative Leakage:** Normative keywords (MUST, SHOULD, MAY, etc.) MUST NOT be used in any section other than "Requirements".
+
+* **Title Case for Subheaders**: Subheaders MUST be denoted in Title Case. All words MUST be capitalized except articles (a, an, the), coordinating conjunctions (and, but, or), and short prepositions (e.g., in, on, at), unless they begin the subheader.
 
 * **Example** (Markdown, illustrative):
 
@@ -346,6 +351,9 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 >
 > 1.0-preview
 
+### Tables
+
+* **Markdown Table Spacing**: Markdown tables MUST use only a single space after values. Markdown tables MUST NOT be justified or padded with extra spaces simply to align the vertical pipes visually in the raw markdown.
 
 ### Example HTML Table
 This is an example of a complex table with merged rows and columns, along with an additional header row.

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -349,7 +349,9 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 ### Tables
 
-* **Markdown Table Formatting:** Markdown tables MUST use exactly one space after values, without additional padding or justification to align vertical pipes in the raw markdown.
+* **Markdown Table Spacing:**
+  * When a markdown table has a maximum row width of less than 120 characters, the table SHOULD be padded with spaces to align the vertical pipes visually.
+  * When a markdown table has a maximum row width of 120 characters or more, the table SHOULD use exactly one space after values without additional padding.
 
 ### Example HTML Table
 This is an example of a complex table with merged rows and columns, along with an additional header row.

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -353,7 +353,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 ### Tables
 
-* **Markdown Table Spacing**: Markdown tables MUST use only a single space after values. Markdown tables MUST NOT be justified or padded with extra spaces simply to align the vertical pipes visually in the raw markdown.
+* **Markdown Table Formatting**: Markdown tables MUST use exactly one space after values, without additional padding or justification to align vertical pipes in the raw markdown.
 
 ### Example HTML Table
 This is an example of a complex table with merged rows and columns, along with an additional header row.

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -247,7 +247,9 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Consistent Introductory Phrases:** Introductory phrases for normative lists SHOULD be consistent within a section.
 
-* **Sentence Spacing**: Sentences MUST be delineated with a single space.
+* **Sentence Spacing:** Sentences MUST be delineated with a single space.
+
+* **No Contractions:** In order to maintain a formal, professional tone throughout the specification, contractions MUST NOT be used (e.g., use "do not" instead of "don't").
 
 ### JSON Formatting
 
@@ -269,7 +271,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **No Normative Leakage:** Normative keywords (MUST, SHOULD, MAY, etc.) MUST NOT be used in any section other than "Requirements".
 
-* **Title Case for Subheaders**: Subheaders MUST be denoted in Title Case, with all words capitalized except articles (a, an, the), coordinating conjunctions (and, but, or), and short prepositions (e.g., in, on, at), unless they begin the subheader.
+* **Title Case for Subheaders:** Subheaders MUST be denoted in Title Case, with all words capitalized except articles (a, an, the), coordinating conjunctions (and, but, or), and short prepositions (e.g., in, on, at), unless they begin the subheader.
 
 * **Example** (Markdown, illustrative):
 
@@ -353,7 +355,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 ### Tables
 
-* **Markdown Table Formatting**: Markdown tables MUST use exactly one space after values, without additional padding or justification to align vertical pipes in the raw markdown.
+* **Markdown Table Formatting:** Markdown tables MUST use exactly one space after values, without additional padding or justification to align vertical pipes in the raw markdown.
 
 ### Example HTML Table
 This is an example of a complex table with merged rows and columns, along with an additional header row.

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -259,8 +259,6 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Consistent Structure:** JSON examples SHOULD follow consistent formatting and indentation.
 
-* **No Contractions**: In order to maintain a formal, professional tone throughout the specification, contractions MUST NOT be used (e.g., use "do not" instead of "don't").
-
 ### Section Structure
 
 * **Consistent Subsection Order:** Sections for the same entity type SHOULD follow the same subsection order (e.g., Title, Requirements, Entity ID, Display Name, Description, Content Constraints, Introduced (version)).

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -178,7 +178,9 @@ To ensure consistent language when describing relationships and evaluations betw
 
 * **Numeric Values:** Use "equal" or "be equal to" when comparing numeric values, costs, quantities, or mathematical sums (e.g., "ContractedCost MUST be equal to BilledCost"). Do not use "match".
 * **Identifiers and Strings:** Use "match" when comparing strings, IDs, or names (e.g., "HostProviderName MUST match ServiceProviderName"). Do not use "equal".
-* **State and Conditions:** Use "is" when evaluating if a column contains a specific value (e.g., "when ChargeCategory is `Purchase`"). Do not use "equals".
+* **State and Conditions:** Use forms of the verb "to be" (e.g., "is", "are", "be") when evaluating if a column contains a specific value or state (e.g., "when ChargeCategory is `Purchase`" or "ChargeCategory MAY be `Usage`"). Do not use "equals" or "equal".
+* **Inequalities:** When expressing range or directional limits, the standard phrases "greater than or equal to" and "less than or equal to" MUST be used, even for non-numeric data types like timestamps or dates (e.g., "BillingPeriodLastUpdated MUST be greater than or equal to BillingPeriodCreated"). 
+* **Semantic Comparisons:** When comparing concepts, formats, or values that share the same meaning but may not be strictly identical strings, use "equivalent" or "semantically equivalent" (e.g., "PricingUnit MUST be semantically equivalent to the corresponding pricing measurement unit..."). Do not use "equal".
 
 ### Bullet Structure
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -247,6 +247,8 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Consistent Introductory Phrases:** Introductory phrases for normative lists SHOULD be consistent within a section.
 
+* **Sentence Spacing**: Sentences MUST be delineated with a single space.
+
 ### JSON Formatting
 
 * **Valid JSON:** JSON examples MUST be valid and complete.
@@ -254,8 +256,6 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 * **JSON Quotation Marks:** JSON keys MUST use double quotation marks.
 
 * **Consistent Structure:** JSON examples SHOULD follow consistent formatting and indentation.
-
-* **Sentence Spacing**: Sentences between paragraphs MUST be delienated with a single space; double spaces are not permitted.
 
 * **No Contractions**: In order to maintain a formal, professional tone throughout the specification, contractions MUST NOT be used (e.g., use "do not" instead of "don't").
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -74,7 +74,7 @@ These guidelines can be modified through a Pull Request (PR), which the members 
         </td>
         <td>
             - Enclosed in backticks (e.g., `Usage`)<br>
-            - Normal text without bold or italics
+            - Formatted as inline code
         </td>
     </tr>
     <tr>
@@ -326,8 +326,8 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 > * PricingQuantity MUST conform to NumericFormat requirements.
 > * PricingQuantity nullability is defined as follows:
 >   * PricingQuantity MUST be null when SkuPriceId is null.
->   * PricingQuantity MUST be null when ChargeCategory is "Tax"
->   * PricingQuantity MUST NOT be null when ChargeCategory is "Usage" or "Purchase" and ChargeClass is not "Correction"
+>   * PricingQuantity MUST be null when ChargeCategory is `Tax`
+>   * PricingQuantity MUST NOT be null when ChargeCategory is `Usage` or `Purchase` and ChargeClass is not `Correction`
 >   * PricingQuantity MAY be null in all other cases.
 > * PricingQuantity MUST be a valid decimal value when not null.
 > * Cost metric (e.g., ContractedCost) MUST equal the product of the corresponding unit price (e.g., ContractedUnitPrice) and PricingQuantity when the unit price is not null and

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -64,16 +64,16 @@ These guidelines can be modified through a Pull Request (PR), which the members 
     <tr>
         <td><strong>Column Values:</strong></td>
         <td>
-            - "Usage"<br>
-            - "Tax"<br>
-            - "TB"<br>
+            - `Usage`<br>
+            - `Tax`<br>
+            - `TB`<br>
         </td>
         <td>
             This column:<br>
             &nbsp;&nbsp; * MUST be null when ChargeCategory is "Tax" ...
         </td>
         <td>
-            - Enclosed in double quotation marks<br>
+            - Enclosed in backticks (e.g., `Usage`)<br>
             - Normal text without bold or italics
         </td>
     </tr>
@@ -202,6 +202,12 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 * **Multiple Entity References:** MUST use Entity IDs when referencing multiple entities in a normative statement.
 
 * **Entity Scope:** These rules apply to all entities defined in the FOCUS specification (e.g., Columns, Attributes, Datasets, Objects).
+
+### Column Values
+
+* **Inline Code for Values:** When referencing specific string values that a column can contain, the value MUST be enclosed in backticks to render as inline code (e.g., `Usage`). 
+
+* **Consistent Formatting:** This formatting MUST be used consistently across all normative requirements, descriptions, and tables when referencing a specific string value.
 
 ### Bullet Structure
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -249,8 +249,6 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Sentence Spacing:** Sentences MUST be delineated with a single space.
 
-* **No Contractions:** In order to maintain a formal, professional tone throughout the specification, contractions MUST NOT be used (e.g., use "do not" instead of "don't").
-
 ### JSON Formatting
 
 * **Valid JSON:** JSON examples MUST be valid and complete.
@@ -268,8 +266,6 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 * **Normative Scope:** Normative requirements (those using BCP-14 keywords) MUST appear only in the "Requirements" section.
 
 * **No Normative Leakage:** Normative keywords (MUST, SHOULD, MAY, etc.) MUST NOT be used in any section other than "Requirements".
-
-* **Title Case for Subheaders:** Subheaders MUST be denoted in Title Case, with all words capitalized except articles (a, an, the), coordinating conjunctions (and, but, or), and short prepositions (e.g., in, on, at), unless they begin the subheader.
 
 * **Example** (Markdown, illustrative):
 

--- a/guidelines/contributors/editorial-guidelines.md
+++ b/guidelines/contributors/editorial-guidelines.md
@@ -209,6 +209,14 @@ These guidelines can be modified through a Pull Request (PR), which the members 
 
 * **Consistent Formatting:** This formatting MUST be used consistently across all normative requirements, descriptions, and tables when referencing a specific string value.
 
+### Comparison Terminology
+
+To ensure consistent language when describing relationships and evaluations between values, normative requirements and standard prose MUST use the following terminology:
+
+* **Numeric Values:** Use "equal" or "be equal to" when comparing numeric values, costs, quantities, or mathematical sums (e.g., "ContractedCost MUST be equal to BilledCost"). Do not use "match".
+* **Identifiers and Strings:** Use "match" when comparing strings, IDs, or names (e.g., "HostProviderName MUST match ServiceProviderName"). Do not use "equal".
+* **State and Conditions:** Use "is" when evaluating if a column contains a specific value (e.g., "when ChargeCategory is `Purchase`"). Do not use "equals".
+
 ### Bullet Structure
 
 * **Unordered List Style:** All unordered lists in Markdown MUST use asterisks (`*`) rather than dashes (`-`) or plus signs (`+`). This maintains visual consistency across the specification and aligns with our automated linting standards.

--- a/guidelines/contributors/markdownpp-guidelines.md
+++ b/guidelines/contributors/markdownpp-guidelines.md
@@ -286,6 +286,7 @@ To ensure predictable Table of Contents (TOC) generation, stable internal links,
 * A single space MUST follow the `#` character(s).
 * Headers MUST NOT use Setext-style headers (`=` or `-` underlines), even though they are technically supported.
 * Headers MUST NOT be empty.
+* Headers MUST be denoted in Title Case, with all words capitalized except articles (a, an, the), coordinating conjunctions (and, but, or), and short prepositions (e.g., in, on, at), unless they begin the subheader.
 * Header text SHOULD only contain alphanumeric characters (`A-Z`, `0-9`), spaces (` `), commas (`,`), and the following special characters: hyphens (`-`), apostrophes (`'`), and parentheses (`(`, `)`).
 * Other special characters SHOULD be avoided.
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -85,8 +85,7 @@ The recommended pattern for a normative requirement is:
 ```
 
 * Normative requirements MUST be expressed as individual bullet points.
-* Each bullet MUST represent exactly one normative requirement.
-* Each normative requirement MUST express a single requirement.
+* Each bullet MUST represent exactly one normative requirement expressing a single constraint.
 * Each normative requirement MUST:
   * identify exactly one **normative subject** to which the requirement applies
   * contain exactly one **BCP 14 keyword** (MUST, SHOULD, MAY, MUST NOT, etc.), indicating the obligation level

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -177,6 +177,10 @@ Specifically:
   * a constraint on the resulting dataset state, or
   * a constraint on a schema-defined artifact.
 
+### Tone and Grammar
+
+In order to maintain a formal, professional tone throughout the specification, contractions MUST NOT be used in normative requirements (e.g., use "do not" instead of "don't").
+
 ### Use of BCP 14 Keywords
 
 * Each normative bullet MUST contain exactly one BCP 14 keyword (MUST, SHOULD, MAY, MUST NOT, SHOULD NOT). See [BCP14](https://tools.ietf.org/html/bcp14) [[RFC2119](https://tools.ietf.org/html/rfc2119)][[RFC8174](https://tools.ietf.org/html/rfc8174)].

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -86,11 +86,25 @@ The recommended pattern for a normative requirement is:
 
 * Normative requirements MUST be expressed as individual bullet points.
 * Each bullet MUST represent exactly one normative requirement.
+* Each normative requirement MUST express a single requirement.
 * Each normative requirement MUST:
   * identify exactly one **normative subject** to which the requirement applies
   * contain exactly one **BCP 14 keyword** (MUST, SHOULD, MAY, MUST NOT, etc.), indicating the obligation level
   * express exactly one **verifiable constraint**
+  * be split into multiple bullets if it introduces multiple independent constraints.
 * Each normative requirement SHOULD describe a **verifiable state** of the object rather than behavior
+
+### Explicit Conditions in Normative Requirements
+
+* Normative requirements MUST include an explicit condition unless the rule applies universally.
+* Conditional clauses MUST use standardized patterns such as:
+   * when <condition>
+   * if <condition>
+   * unless <condition>  
+   * only when <condition>  
+   * only if <condition>  
+   * except when <condition>  
+   * except if <condition>
 
 ### Structural Anchor Requirement
 
@@ -118,6 +132,8 @@ For **Attribute Requirements** sections, a different canonical form applies:
 See [Section Structural Anchor Requirement for Attributes](#structural-anchor-requirement-for-attributes) for details.
 
 ### Normative Subject
+
+* Each normative requirement MUST clearly identify the subject being constrained.
 
 #### Terminology Usage in Normative Requirements
 
@@ -200,6 +216,7 @@ A requirement MUST be split into multiple bullets if it:
 
 * contains more than one BCP 14 keyword,
 * combines multiple obligations (e.g., multiple verifiable state descriptors, multiple objects, or multiple conditions that result in distinct constraints),
+* combines multiple independent conditions using “and” or “or” that result in distinct constraints,
 * contains a hidden constraint expressed as a definition (e.g., `ColumnA MUST be Z, where Z is defined as Y`),
 * applies constraints to multiple subjects, even with a single BCP 14 keyword (e.g., `ColumnA and ColumnB MUST be X`).
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -84,6 +84,8 @@ The recommended pattern for a normative requirement is:
 <Subject (+qualifier)> + <BCP 14 Keyword> + <Verifiable State Descriptor> + <Object (+qualifier)> [+ Conditions]
 ```
 
+* Normative requirements MUST be expressed as individual bullet points.
+* Each bullet MUST represent exactly one normative requirement.
 * Each normative requirement MUST:
   * identify exactly one **normative subject** to which the requirement applies
   * contain exactly one **BCP 14 keyword** (MUST, SHOULD, MAY, MUST NOT, etc.), indicating the obligation level
@@ -116,6 +118,12 @@ For **Attribute Requirements** sections, a different canonical form applies:
 See [Section Structural Anchor Requirement for Attributes](#structural-anchor-requirement-for-attributes) for details.
 
 ### Normative Subject
+
+#### Terminology Usage in Normative Requirements
+
+* Column references in normative requirements MUST use the ColumnId.
+* Display Names MUST NOT be used in normative requirements.
+* Display Names MAY be used in non-normative sections for readability.
 
 #### Allowed Subjects
 
@@ -181,6 +189,8 @@ Specifically:
 
 * Each normative bullet MUST contain exactly one BCP 14 keyword (MUST, SHOULD, MAY, MUST NOT, SHOULD NOT). See [BCP14](https://tools.ietf.org/html/bcp14) [[RFC2119](https://tools.ietf.org/html/rfc2119)][[RFC8174](https://tools.ietf.org/html/rfc8174)].
 * A bullet containing more than one normative keyword MUST be split.
+* The term **RECOMMENDED** MUST NOT be used as a normative keyword. The keyword **SHOULD** MUST be used instead.
+* The lowercase word “recommended” MAY be used in non-normative text, provided it does not express a normative requirement.
 
 * **Exception for Composite Requirements:** While each individual bullet (parent or nested) MUST contain only one BCP 14 keyword, a Composite Requirement as a whole MAY contain multiple keywords to express nuanced obligations. In such cases, the logical strength of the requirement is governed by the hierarchy defined in section [Composite Requirements](#composite-requirements).
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -216,7 +216,7 @@ A requirement MUST be split into multiple bullets if it:
 
 * contains more than one BCP 14 keyword,
 * combines multiple obligations (e.g., multiple verifiable state descriptors, multiple objects, or multiple conditions that result in distinct constraints),
-* combines multiple independent conditions using “and” or “or” that result in distinct constraints,
+* combines multiple independent conditions using “and” or “or” that result in distinct constraints
 * contains a hidden constraint expressed as a definition (e.g., `ColumnA MUST be Z, where Z is defined as Y`),
 * applies constraints to multiple subjects, even with a single BCP 14 keyword (e.g., `ColumnA and ColumnB MUST be X`).
 


### PR DESCRIPTION
## Summary

This PR updates the `editorial-guidelines.md` document to establish stricter rules around text formatting, casing, and tone to ensure consistency across the FOCUS specification. 

* **Sentence Spacing:** Mandates the use of a single space between sentences; explicitly forbids double spaces.
* **Formal Tone:** Prohibits the use of contractions (e.g., using "do not" instead of "don't") to maintain a professional voice throughout the documentation.
* **Subheader Casing:** Requires Title Case for all subheaders. It clarifies that articles, coordinating conjunctions, and short prepositions should remain lowercase unless they start the header.
* **Markdown Tables:** Introduces a new `### Tables` section dictating that table cells must only use a single space after values, prohibiting extra padding or justification used purely to align vertical pipes in the raw markdown.

### Type of Change
- [ ] Bug fix
- [ ] New feature / Specification update
- [x] Editorial / Formatting

### Author Checklist
- [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
- [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
- [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
