### PR TITLE
AI #2129: Replace TinyCloud with LatticeScale in commitment discount flexibility examples

### DIFF
--- a/specification/appendix/examples/commitment_discount_flexibility_examples/one_hundred_percent_utilization_with_commitment_discount_flexibility_with_1_resource.md
+++ b/specification/appendix/examples/commitment_discount_flexibility_examples/one_hundred_percent_utilization_with_commitment_discount_flexibility_with_1_resource.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-For this example, fictitious service provider, *TinyCloud*, offers the following SKU catalog which is used in the scenario below.
+For this example, fictitious service provider, *LatticeScale*, offers the following SKU catalog which is used in the scenario below.
 
 ## SKU Catalog
 

--- a/specification/appendix/examples/commitment_discount_flexibility_examples/one_hundred_percent_utilization_with_commitment_discount_flexibility_with_2_resources.md
+++ b/specification/appendix/examples/commitment_discount_flexibility_examples/one_hundred_percent_utilization_with_commitment_discount_flexibility_with_2_resources.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-For this example, fictitious service provider, *TinyCloud*, offers the following SKU catalog which is used in the scenario below.
+For this example, fictitious service provider, *LatticeScale*, offers the following SKU catalog which is used in the scenario below.
 
 ## SKU Catalog
 

--- a/specification/appendix/examples/commitment_discount_flexibility_examples/one_hundred_percent_utilization_without_commitment_discount_flexibility.md
+++ b/specification/appendix/examples/commitment_discount_flexibility_examples/one_hundred_percent_utilization_without_commitment_discount_flexibility.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-For this example, fictitious service provider, *TinyCloud*, offers the following SKU catalog which is used in the scenario below.
+For this example, fictitious service provider, *LatticeScale*, offers the following SKU catalog which is used in the scenario below.
 
 ## SKU Catalog
 

--- a/specification/appendix/examples/commitment_discount_flexibility_examples/zero_percent_utilization_without_commitment_discount_flexibility.md
+++ b/specification/appendix/examples/commitment_discount_flexibility_examples/zero_percent_utilization_without_commitment_discount_flexibility.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-For this example, fictitious service provider, *TinyCloud*, offers the following SKU catalog which is used in the scenario below.
+For this example, fictitious service provider, *LatticeScale*, offers the following SKU catalog which is used in the scenario below.
 
 ## SKU Catalog
 


### PR DESCRIPTION
## Summary
* Replaces non-approved fictitious name "TinyCloud" with approved Data Generator name "LatticeScale" in all 4 commitment discount flexibility example scenarios
* CSV files were reviewed and require no changes (they use generic placeholders only)
* Minor consistency update to align with the approved fictitious entity names from PR #2115

Closes: Part of #2129

## Test plan
- [ ] Verify "TinyCloud" no longer appears in any commitment discount flexibility example files
- [ ] Verify "LatticeScale" appears correctly in context sections of all 4 scenario files
- [ ] Confirm CSV files remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)