### PR TITLE
AI #2140: Pivot scaled-down tables from horizontal to vertical

### DIFF
--- a/specification/datasets/invoice_detail/columns/paymentcurrencybilledcost.md
+++ b/specification/datasets/invoice_detail/columns/paymentcurrencybilledcost.md
@@ -24,13 +24,15 @@ In this scenario, the invoice issuer performs currency conversion at the individ
 * **Payment Currency:** EUR
 * **Exchange Rate:** 1.00 USD = 0.92 EUR
 
-<div class="small-table">
-
-| InvoiceDetailId | ChargeCategory | BillingCurrency | BilledCost | PaymentCurrency | PaymentCurrencyBilledCost | PaymentCurrencyInvoiceDetailId |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| ID-001 | Usage | USD | 100.00 | EUR | 92.00 | ID-001 |
-
-</div>
+| Column | Value |
+| :--- | :--- |
+| InvoiceDetailId | ID-001 |
+| ChargeCategory | Usage |
+| BillingCurrency | USD |
+| BilledCost | 100.00 |
+| PaymentCurrency | EUR |
+| PaymentCurrencyBilledCost | 92.00 |
+| PaymentCurrencyInvoiceDetailId | ID-001 |
 
 > **Note:** Because the conversion is 1:1, the `PaymentCurrencyInvoiceDetailId` points to the record's own `InvoiceDetailId`.
 
@@ -42,15 +44,13 @@ In this scenario, the invoice issuer tracks usage in the billing currency at a g
 * **Payment Currency:** EUR
 * **Effective Exchange Rate:** 1.00 USD = 0.92 EUR
 
-<div class="small-table">
-
-| InvoiceDetailId | InvoiceDetailDescription | BilledCost | PaymentCurrencyBilledCost | PaymentCurrencyInvoiceDetailId |
-| :--- | :--- | :--- | :--- | :--- |
-| A-101 | Compute Instance A | 45.00 | 0.00 | Z-999 |
-| A-102 | Compute Instance B | 55.00 | 0.00 | Z-999 |
-| Z-999 | Usage in Payment Currency | 0.00 | 92.00 | Z-999 |
-
-</div>
+| Column | A-101 | A-102 | Z-999 |
+| :--- | :--- | :--- | :--- |
+| InvoiceDetailId | A-101 | A-102 | Z-999 |
+| InvoiceDetailDescription | Compute Instance A | Compute Instance B | Usage in Payment Currency |
+| BilledCost | 45.00 | 55.00 | 0.00 |
+| PaymentCurrencyBilledCost | 0.00 | 0.00 | 92.00 |
+| PaymentCurrencyInvoiceDetailId | Z-999 | Z-999 | Z-999 |
 
 **Logic Breakdown:**
 

--- a/specification/datasets/invoice_detail/columns/paymentcurrencybilledcost.md
+++ b/specification/datasets/invoice_detail/columns/paymentcurrencybilledcost.md
@@ -24,14 +24,14 @@ In this scenario, the invoice issuer performs currency conversion at the individ
 * **Payment Currency:** EUR
 * **Exchange Rate:** 1.00 USD = 0.92 EUR
 
-| Column | Value |
-| :--- | :--- |
-| InvoiceDetailId | ID-001 |
-| ChargeCategory | Usage |
-| BillingCurrency | USD |
-| BilledCost | 100.00 |
-| PaymentCurrency | EUR |
-| PaymentCurrencyBilledCost | 92.00 |
+| Column                         | Value  |
+| :----------------------------- | :----- |
+| InvoiceDetailId                | ID-001 |
+| ChargeCategory                 | Usage  |
+| BillingCurrency                | USD    |
+| BilledCost                     | 100.00 |
+| PaymentCurrency                | EUR    |
+| PaymentCurrencyBilledCost      | 92.00  |
 | PaymentCurrencyInvoiceDetailId | ID-001 |
 
 > **Note:** Because the conversion is 1:1, the `PaymentCurrencyInvoiceDetailId` points to the record's own `InvoiceDetailId`.
@@ -44,13 +44,13 @@ In this scenario, the invoice issuer tracks usage in the billing currency at a g
 * **Payment Currency:** EUR
 * **Effective Exchange Rate:** 1.00 USD = 0.92 EUR
 
-| Column | A-101 | A-102 | Z-999 |
-| :--- | :--- | :--- | :--- |
-| InvoiceDetailId | A-101 | A-102 | Z-999 |
-| InvoiceDetailDescription | Compute Instance A | Compute Instance B | Usage in Payment Currency |
-| BilledCost | 45.00 | 55.00 | 0.00 |
-| PaymentCurrencyBilledCost | 0.00 | 0.00 | 92.00 |
-| PaymentCurrencyInvoiceDetailId | Z-999 | Z-999 | Z-999 |
+| Column                         | A-101              | A-102              | Z-999                     |
+| :----------------------------- | :----------------- | :----------------- | :------------------------ |
+| InvoiceDetailId                | A-101              | A-102              | Z-999                     |
+| InvoiceDetailDescription       | Compute Instance A | Compute Instance B | Usage in Payment Currency |
+| BilledCost                     | 45.00              | 55.00              | 0.00                      |
+| PaymentCurrencyBilledCost      | 0.00               | 0.00               | 92.00                     |
+| PaymentCurrencyInvoiceDetailId | Z-999              | Z-999              | Z-999                     |
 
 **Logic Breakdown:**
 


### PR DESCRIPTION
## Summary

Pivots the two tables in `paymentcurrencybilledcost.md` from horizontal to vertical, removing the `<div class="small-table">` wrappers added in #2038. The `.small-table` CSS class in `base.css` is retained per the #2140 directive.

The horizontal + scaled-down approach in #2038 forced the PDF renderer to downscale the entire document. Pivoting these tables vertical eliminates the need for the scaling wrapper on these two tables while leaving the CSS hook available for future use.

Addresses AI #2140. Supersedes #2038's scaling workaround for these two tables.

## Reviewer Attention

Example 2 illustrates a parent-child relationship (A-101 and A-102 roll up to Z-999). The horizontal layout let readers compare records row-by-row; the vertical pivot uses `InvoiceDetailId` values as column headers. Please confirm this still reads cleanly. Alternatives if it does not:

- Keeping Example 2 horizontal with shortened column headers
- Splitting the narrative so the `Logic Breakdown` bullets carry more of the relationship explanation

## Files Changed

| File | Change |
|------|--------|
| `specification/datasets/invoice_detail/columns/paymentcurrencybilledcost.md` | Pivoted two example tables from horizontal to vertical; padded cells to align pipes per #2236 |

## Test Plan

- [x] Data values preserved from original horizontal tables (verified cell-by-cell)
- [x] Row widths under 120 characters; pipes aligned per #2236
- [ ] PDF build renders without document-wide scaling
- [ ] GitHub Markdown render verified

## Change Log

**April 15** -- Applied table spacing guidance from #2236: both pivoted tables now use aligned vertical pipes (row widths under 120 characters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)