### PR TITLE
AI #2106: Standardize Allowed Values subheaders across datasets

### DIFF
--- a/specification/datasets/billing_period/columns/billingperiodstatus.md
+++ b/specification/datasets/billing_period/columns/billingperiodstatus.md
@@ -12,6 +12,13 @@ BillingPeriodStatus MUST adhere to the following requirements:
 * BillingPeriodStatus MUST represent the state of the billing period identified by [BillingPeriodStart](#datasets.billingperiod.billingperiodstart) and [BillingPeriodEnd](#datasets.billingperiod.billingperiodend).
 * BillingPeriodStatus MUST NOT transition from "Closed" to "Open" unless explicitly requested or approved by the customer.
 
+## Allowed Values
+
+| Value  | Description                                                                                                   |
+| :----- | :------------------------------------------------------------------------------------------------------------ |
+| Open   | The billing period is currently active or still being processed. Records may continue to be added or revised. |
+| Closed | The billing period has ended, all anticipated invoices have been issued, and the delivered data is finalized. |
+
 ## Implementation Context
 
 While the transition from "Open" to "Closed" typically signifies the end of a billing cycle, in scenarios such as the following, it may be necessary to provide corrections to closed billing periods:
@@ -49,13 +56,6 @@ The state of the billing period (i.e., "Open" or "Closed"), indicating whether t
 | Allows nulls  | False                               |
 | Data type     | String                              |
 | Value format  | Allowed values                      |
-
-## Allowed Values
-
-| Value  | Description                                                                                                   |
-| :----- | :------------------------------------------------------------------------------------------------------------ |
-| Open   | The billing period is currently active or still being processed. Records may continue to be added or revised. |
-| Closed | The billing period has ended, all anticipated invoices have been issued, and the delivered data is finalized. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentbenefitcategory.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentbenefitcategory.md
@@ -24,6 +24,15 @@ ContractCommitmentBenefitCategory MUST adhere to the following requirements:
 * ContractCommitmentBenefitCategory MUST NOT be null.
 * ContractCommitmentBenefitCategory MUST be one of the allowed values.
 
+## Allowed Values
+
+| Value | Sort Order | Description | Typical Use Case |
+| :--- | :--- | :--- | :--- |
+| Discount | 10 | A financial reduction in the unit price or list rate, whether applied immediately or conditionally upon meeting usage or spend thresholds. | Flat rate negotiated reductions, Savings Plans, growth rebates, or volume-tier discounts. |
+| Entitlement | 20 | The contractual right to access and consume specific products, features, or software tiers that would otherwise be unavailable. | Marketplace SaaS purchases, Enterprise Agreements (e.g., Snowflake), or paid Proof of Concepts. |
+| Availability | 30 | A contractual assurance of resource access and physical capacity. | Capacity reservations or dedicated host guarantees. |
+| Other | 40 | Benefits not captured by standard categories. | Support access, training, or professional services. |
+
 ## Column ID
 
 ContractCommitmentBenefitCategory
@@ -46,15 +55,6 @@ Defines the primary value or advantage received for a [*contract commitment*](#g
 | Allows nulls    | False          |
 | Data type       | String         |
 | Value format    | Allowed values |
-
-Allowed values:
-
-| Value | Sort Order | Description | Typical Use Case |
-| :--- | :--- | :--- | :--- |
-| Discount | 10 | A financial reduction in the unit price or list rate, whether applied immediately or conditionally upon meeting usage or spend thresholds. | Flat rate negotiated reductions, Savings Plans, growth rebates, or volume-tier discounts. |
-| Entitlement | 20 | The contractual right to access and consume specific products, features, or software tiers that would otherwise be unavailable. | Marketplace SaaS purchases, Enterprise Agreements (e.g., Snowflake), or paid Proof of Concepts. |
-| Availability | 30 | A contractual assurance of resource access and physical capacity. | Capacity reservations or dedicated host guarantees. |
-| Other | 40 | Benefits not captured by standard categories. | Support access, training, or professional services. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentcategory.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentcategory.md
@@ -10,6 +10,13 @@ ContractCommitmentCategory MUST adhere to the following requirements:
 * ContractCommitmentCategory MUST NOT be null.
 * ContractCommitmentCategory MUST be one of the allowed values.
 
+## Allowed Values
+
+| Value   | Description                                                              |
+|:--------|:-------------------------------------------------------------------------|
+| Spend   | Contract commitments that require a predetermined amount of spend. |
+| Usage   | Contract commitments that require a predetermined amount of usage. |
+
 ## Column ID
 
 ContractCommitmentCategory
@@ -32,13 +39,6 @@ Represents the highest-level classification of a *contract commitment* based on 
 | Allows nulls    | False                                                |
 | Data type       | String                                               |
 | Value format    | Allowed values                                       |
-
-Allowed values:
-
-| Value   | Description                                                              |
-|:--------|:-------------------------------------------------------------------------|
-| Spend   | Contract commitments that require a predetermined amount of spend. |
-| Usage   | Contract commitments that require a predetermined amount of usage. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentdurationtype.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentdurationtype.md
@@ -23,6 +23,27 @@ ContractCommitmentDurationType MUST adhere to the following requirements:
 * ContractCommitmentDurationType SHOULD correspond to the standard duration of the purchased offering (e.g., "1 Year", "3 Years") rather than a precise calculation of days or hours.
 * ContractCommitmentDurationType MAY differ from the actual duration calculated between [ContractCommitmentPeriodStart](#datasets.contractcommitment.contractcommitmentperiodstart) and [ContractCommitmentPeriodEnd](#datasets.contractcommitment.contractcommitmentperiodend) (e.g., if a 3-year commitment is exchanged in its final month, the resulting record may have a short lifespan but retains a value of "3 Years").
 
+## Allowed Values
+
+The following units should be used for the representation of time:
+
+| Time Unit |
+| :--- |
+| Minute |
+| Minutes |
+| Hour |
+| Hours |
+| Day |
+| Days |
+| Week |
+| Weeks |
+| Month |
+| Months |
+| Quarter |
+| Quarters |
+| Year |
+| Years |
+
 ## Column ID
 
 ContractCommitmentDurationType
@@ -45,27 +66,6 @@ Represents the categorical length of the [*contract commitment*](#glossary:contr
 | Allows nulls    | False          |
 | Data type       | String         |
 | Value format    | Expected format |
-
-Allowed values:
-
-The following units should be used for the representation of time:
-
-| Time Unit |
-| :--- |
-| Minute |
-| Minutes |
-| Hour |
-| Hours |
-| Day |
-| Days |
-| Week |
-| Weeks |
-| Month |
-| Months |
-| Quarter |
-| Quarters |
-| Year |
-| Years |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentfulfillmentinterval.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentfulfillmentinterval.md
@@ -13,6 +13,23 @@ ContractCommitmentFulfillmentInterval MUST adhere to the following requirements:
 * ContractCommitmentFulfillmentInterval MUST be one of the allowed values.
 * ContractCommitmentFulfillmentInterval MUST NOT be "Total Term" if [ContractCommitmentModel](#datasets.contractcommitment.contractcommitmentmodel) is "Continuous".
 
+## Allowed Values
+
+| Value         | Sort Order | Description                                                                            | Typical Use Case                                                           |
+| ------------- | ---------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Hourly        | 10         | Measured over a 60-minute period. | Continuous Model: Cloud-native RIs and Savings Plans. |
+| Daily         | 20         | Measured over a calendar day. | Daily active user (DAU) caps or daily license minimums. |
+| Weekly        | 30         | Measured over a rolling or fixed 7-day period. | Burstable bandwidth or weekly sprint-based SaaS usage. |
+| Monthly       | 40         | Measured over a calendar month. | Discontinuous Model: SaaS MRR minimums or tiered discounts. |
+| Quarterly     | 50         | Measured over a 3-month fiscal period. | Enterprise true-ups or volume-based rebate targets. |
+| Semi-Annual   | 60         | Measured over a 6-month period. | Mid-year budget alignments or review cycles. |
+| Annual        | 70         | Measured over a 12-month period. | Discontinuous Model: Cloud EAs (Enterprise Agreements). |
+| Total Term    | 80         | The commitment applies to the entire duration of the contract with no internal resets. | Multi-year "Pool of Funds" or total contract value (TCV) commits. |
+| Transactional | 90         | No time-based reset; based purely on event volume or credit consumption. | API call bundles or "Credit Packs" with no expiration date. |
+| Custom        | 100        | A bespoke interval that does not fit standard calendar units. | Bridge contracts, unique POCs, or non-standard durations (e.g., 100 days). |
+
+Note: the sort orders and use cases presented above are included for convenience and are not defined as separate FOCUS columns.
+
 ## Column ID
 
 ContractCommitmentFulfillmentInterval
@@ -35,23 +52,6 @@ Represents the specific [*period*](#glossary:period) used to measure and reset t
 | Allows nulls    | False          |
 | Data type       | String         |
 | Value format    | Allowed values |
-
-Allowed values:
-
-| Value         | Sort Order | Description                                                                            | Typical Use Case                                                           |
-| ------------- | ---------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| Hourly        | 10         | Measured over a 60-minute period. | Continuous Model: Cloud-native RIs and Savings Plans. |
-| Daily         | 20         | Measured over a calendar day. | Daily active user (DAU) caps or daily license minimums. |
-| Weekly        | 30         | Measured over a rolling or fixed 7-day period. | Burstable bandwidth or weekly sprint-based SaaS usage. |
-| Monthly       | 40         | Measured over a calendar month. | Discontinuous Model: SaaS MRR minimums or tiered discounts. |
-| Quarterly     | 50         | Measured over a 3-month fiscal period. | Enterprise true-ups or volume-based rebate targets. |
-| Semi-Annual   | 60         | Measured over a 6-month period. | Mid-year budget alignments or review cycles. |
-| Annual        | 70         | Measured over a 12-month period. | Discontinuous Model: Cloud EAs (Enterprise Agreements). |
-| Total Term    | 80         | The commitment applies to the entire duration of the contract with no internal resets. | Multi-year "Pool of Funds" or total contract value (TCV) commits. |
-| Transactional | 90         | No time-based reset; based purely on event volume or credit consumption. | API call bundles or "Credit Packs" with no expiration date. |
-| Custom        | 100        | A bespoke interval that does not fit standard calendar units. | Bridge contracts, unique POCs, or non-standard durations (e.g., 100 days). |
-
-Note: the sort orders and use cases presented above are included for convenience and are not defined as separate FOCUS columns.
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentlifecyclestatus.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentlifecyclestatus.md
@@ -11,6 +11,18 @@ ContractCommitmentLifecycleStatus MUST adhere to the following requirements:
 * ContractCommitmentLifecycleStatus MUST be one of the allowed values.
 * When a contract commitment record is modified in a way that requires a new [ContractCommitmentID](#datasets.contractcommitment.contractcommitmentid), ContractCommitmentLifecycleStatus for the previous record MUST be "Superseded".
 
+## Allowed Values
+
+| Value | Sort Order | Description |
+| :--- | :--- | :--- |
+| Proposed | 10 | The commitment is being negotiated or modeled; it has no legal or financial impact on current data. |
+| Pending | 20 | The commitment is finalized or signed, but the effective start date is in the future. |
+| Active | 30 | The commitment is currently in effect, and it has remaining value. |
+| Exhausted | 40 | The commitment is currently in effect, but its value has been fully consumed. |
+| Expired | 50 | The commitment is no longer active because it reached its scheduled end date. |
+| Canceled | 60 | The commitment is no longer active because it was terminated by either party prior to its scheduled end date. |
+| Superseded | 70 | The commitment is no longer active because it was replaced by a newer version prior to its scheduled end date. |
+
 ## Column ID
 
 ContractCommitmentLifecycleStatus
@@ -33,18 +45,6 @@ The current lifecycle state of a [*contract commitment*](#glossary:contract-comm
 | Allows nulls    | False          |
 | Data type       | String         |
 | Value format    | Allowed values |
-
-## Allowed Values
-
-| Value | Sort Order | Description |
-| :--- | :--- | :--- |
-| Proposed | 10 | The commitment is being negotiated or modeled; it has no legal or financial impact on current data. |
-| Pending | 20 | The commitment is finalized or signed, but the effective start date is in the future. |
-| Active | 30 | The commitment is currently in effect, and it has remaining value. |
-| Exhausted | 40 | The commitment is currently in effect, but its value has been fully consumed. |
-| Expired | 50 | The commitment is no longer active because it reached its scheduled end date. |
-| Canceled | 60 | The commitment is no longer active because it was terminated by either party prior to its scheduled end date. |
-| Superseded | 70 | The commitment is no longer active because it was replaced by a newer version prior to its scheduled end date. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentmodel.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentmodel.md
@@ -24,6 +24,13 @@ ContractCommitmentModel MUST adhere to the following requirements:
 * ContractCommitmentModel MUST be one of the allowed values.
 * ContractCommitmentModel MUST be "Discontinuous" if [ContractCommitmentFulfillmentInterval](#datasets.contractcommitment.contractcommitmentfulfillmentinterval) is "Total Term".
 
+## Allowed Values
+
+| Value         | Description                                                                                                                                                     |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Continuous    | A flat, constant "floor" of commitment (e.g., RIs, Savings Plans). Coverage is applied at a fixed rate per [Contract Commitment Fulfillment Interval](#datasets.contractcommitment.contractcommitmentfulfillmentinterval) (usually hourly), and benefits are not carried over to subsequent intervals. |
+| Discontinuous | A flexible, aggregate commitment (e.g., Enterprise Agreements, SaaS Minimum Spend). Coverage is measured over a broad window or against a total monetary value. |
+
 ## Column ID
 
 ContractCommitmentModel
@@ -46,13 +53,6 @@ Represents the operational behavior and consumption flexibility of a [*contract 
 | Allows nulls    | False          |
 | Data type       | String         |
 | Value format    | Allowed values |
-
-Allowed values:
-
-| Value         | Description                                                                                                                                                     |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Continuous    | A flat, constant "floor" of commitment (e.g., RIs, Savings Plans). Coverage is applied at a fixed rate per [Contract Commitment Fulfillment Interval](#datasets.contractcommitment.contractcommitmentfulfillmentinterval) (usually hourly), and benefits are not carried over to subsequent intervals. |
-| Discontinuous | A flexible, aggregate commitment (e.g., Enterprise Agreements, SaaS Minimum Spend). Coverage is measured over a broad window or against a total monetary value. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentoffercategory.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentoffercategory.md
@@ -19,6 +19,13 @@ ContractCommitmentOfferCategory MUST adhere to the following requirements:
 * ContractCommitmentOfferCategory MUST NOT be null.
 * ContractCommitmentOfferCategory MUST be one of the allowed values.
 
+## Allowed Values
+
+| Value      | Description                                                                                                        | Typical Use Case                                                                                                |
+| ---------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| Public     | Terms that are generally available to all customers via a service provider's standard rate card or portal. | Standard Savings Plans or Reserved Instances purchased via the cloud console without a custom discount. |
+| Negotiated | Terms and pricing that have been specifically modified through an agreement between the customer and the service provider. | Enterprise Agreements (EA), private marketplace offers, or custom SaaS contracts with volume-based discounting. |
+
 ## Column ID
 
 ContractCommitmentOfferCategory
@@ -41,13 +48,6 @@ Indicates whether the pricing and terms of a [*contract commitment*](#glossary:c
 | Allows nulls    | False          |
 | Data type       | String         |
 | Value format    | Allowed values |
-
-Allowed values:
-
-| Value      | Description                                                                                                        | Typical Use Case                                                                                                |
-| ---------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| Public     | Terms that are generally available to all customers via a service provider's standard rate card or portal. | Standard Savings Plans or Reserved Instances purchased via the cloud console without a custom discount. |
-| Negotiated | Terms and pricing that have been specifically modified through an agreement between the customer and the service provider. | Enterprise Agreements (EA), private marketplace offers, or custom SaaS contracts with volume-based discounting. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentpaymentinterval.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentpaymentinterval.md
@@ -14,6 +14,17 @@ ContractCommitmentPaymentInterval MUST adhere to the following requirements:
 * ContractCommitmentPaymentInterval MUST be "One-Time" if [ContractCommitmentPaymentModel](#datasets.contractcommitment.contractcommitmentpaymentmodel) is "All Upfront".
 * ContractCommitmentPaymentInterval SHOULD represent a time granularity equal to or lesser than the time granularity represented by [ContractCommitmentDurationType](#datasets.contractcommitment.contractcommitmentdurationtype).
 
+## Allowed Values
+
+| Value       | Sort Order | Description                                                         | Typical Use Case                                  |
+| ----------- | ---------- | ------------------------------------------------------------------- | ------------------------------------------------- |
+| One-Time    | 10         | A single invoice is generated for the entire obligation. | All Upfront models (e.g., 3yr All-Upfront RI) or single-invoice arrears paid at the end of a term. |
+| Monthly     | 20         | Invoices for the deferred balance are generated once per month. | No Upfront Savings Plans or Monthly SaaS. |
+| Quarterly   | 30         | Invoices for the deferred balance are generated every three months. | Partial Upfront deals with 90-day true-ups. |
+| Semi-Annual | 40         | Invoices for the deferred balance are generated every six months. | Split-payment agreements. |
+| Annual      | 50         | Invoices for the deferred balance are generated once per year. | Partial Upfront EAs billed yearly. |
+| Custom      | 60         | Hourly/Daily or other irregular cycles. | Irregular bridge contracts or non-standard terms. |
+
 ## Column ID
 
 ContractCommitmentPaymentInterval
@@ -36,17 +47,6 @@ Represents the frequency by which a [*contract commitment*](#glossary:contract-c
 | Allows nulls    | False          |
 | Data type       | String         |
 | Value format    | Allowed values |
-
-Allowed values:
-
-| Value       | Sort Order | Description                                                         | Typical Use Case                                  |
-| ----------- | ---------- | ------------------------------------------------------------------- | ------------------------------------------------- |
-| One-Time    | 10         | A single invoice is generated for the entire obligation. | All Upfront models (e.g., 3yr All-Upfront RI) or single-invoice arrears paid at the end of a term. |
-| Monthly     | 20         | Invoices for the deferred balance are generated once per month. | No Upfront Savings Plans or Monthly SaaS. |
-| Quarterly   | 30         | Invoices for the deferred balance are generated every three months. | Partial Upfront deals with 90-day true-ups. |
-| Semi-Annual | 40         | Invoices for the deferred balance are generated every six months. | Split-payment agreements. |
-| Annual      | 50         | Invoices for the deferred balance are generated once per year. | Partial Upfront EAs billed yearly. |
-| Custom      | 60         | Hourly/Daily or other irregular cycles. | Irregular bridge contracts or non-standard terms. |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentpaymentmodel.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentpaymentmodel.md
@@ -21,6 +21,14 @@ ContractCommitmentPaymentModel MUST adhere to the following requirements:
 * ContractCommitmentPaymentModel MUST NOT be null.
 * ContractCommitmentPaymentModel MUST be one of the allowed values.
 
+## Allowed Values
+
+| Value           | Sort Order | Description                                                                                  | Typical Use Case                                              |
+| --------------- | ---------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| No Upfront      | 10         | The obligation is settled entirely through deferred payment(s) (typically multiple recurring charges) with no initial payment. | Pay-as-you-go Savings Plans or monthly-billed SaaS. |
+| Partial Upfront | 20         | The obligation is settled through a combination of an initial payment and deferred payment(s) (typically multiple recurring charges). | Hybrid RIs or EAs with a "Year 1" deposit plus installments. |
+| All Upfront     | 30         | The total obligation is settled via a single payment at the start of the duration. | High-discount RIs or multi-year contracts paid in full Day 1. |
+
 ## Column ID
 
 ContractCommitmentPaymentModel
@@ -43,14 +51,6 @@ Defines the financial settlement structure of a [*contract commitment*](#glossar
 | Allows nulls    | False          |
 | Data type       | String         |
 | Value format    | Allowed values |
-
-Allowed values:
-
-| Value           | Sort Order | Description                                                                                  | Typical Use Case                                              |
-| --------------- | ---------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| No Upfront      | 10         | The obligation is settled entirely through deferred payment(s) (typically multiple recurring charges) with no initial payment. | Pay-as-you-go Savings Plans or monthly-billed SaaS. |
-| Partial Upfront | 20         | The obligation is settled through a combination of an initial payment and deferred payment(s) (typically multiple recurring charges). | Hybrid RIs or EAs with a "Year 1" deposit plus installments. |
-| All Upfront     | 30         | The total obligation is settled via a single payment at the start of the duration. | High-discount RIs or multi-year contracts paid in full Day 1. |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/capacityreservationstatus.md
+++ b/specification/datasets/cost_and_usage/columns/capacityreservationstatus.md
@@ -15,6 +15,13 @@ CapacityReservationStatus MUST adhere to the following requirements:
   * CapacityReservationStatus MUST be "Unused" when the *charge* represents the unused portion of a *capacity reservation*.
   * CapacityReservationStatus MUST be "Used" when the *charge* represents the used portion of a *capacity reservation*.
 
+## Allowed Values
+
+| Value  | Description                                                                 |
+| :----- | :-------------------------------------------------------------------------- |
+| Used   | *Charges* that utilized a specific amount of a *capacity reservation*. |
+| Unused | *Charges* that represent the unused portion of a *capacity reservation*. |
+
 ## Column ID
 
 CapacityReservationStatus
@@ -37,13 +44,6 @@ Indicates whether the *charge* represents either the consumption of a *capacity 
 | Allows nulls    | True                                                 |
 | Data type       | String                                               |
 | Value format    | Allowed Values                                       |
-
-Allowed values:
-
-| Value  | Description                                                                 |
-| :----- | :-------------------------------------------------------------------------- |
-| Used   | *Charges* that utilized a specific amount of a *capacity reservation*. |
-| Unused | *Charges* that represent the unused portion of a *capacity reservation*. |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/chargecategory.md
+++ b/specification/datasets/cost_and_usage/columns/chargecategory.md
@@ -15,6 +15,16 @@ ChargeCategory MUST adhere to the following requirements:
 * ChargeCategory MUST be "Credit" when the *charge* represents a financial incentive or allowance unrelated to other charges.
 * ChargeCategory MUST be "Adjustment" when the *charge* represents a billing modification that does not fall into other ChargeCategories.
 
+## Allowed Values
+
+| Value      | Description                                                                                                                                    |
+| :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------|
+| Usage      | Positive or negative *charges* based on the quantity of a service or resource that was consumed over a given period of time including refunds. |
+| Purchase   | Positive or negative *charges* for the acquisition of a service or resource bought upfront or on a recurring basis including refunds.          |
+| Tax        | Positive or negative applicable taxes that are levied by the relevant authorities including refunds. Tax *charges* may vary depending on factors such as the location, jurisdiction, and local or federal regulations. |
+| Credit     | Positive or negative *charges* granted by the service provider for various scenarios e.g., promotional credits or corrections to promotional credits.    |
+| Adjustment | Positive or negative *charges* the service provider applies that do not fall into other category values.                                               |
+
 ## Column ID
 
 ChargeCategory
@@ -37,16 +47,6 @@ Represents the highest-level classification of a *charge* based on the nature of
 | Allows nulls    | False                                                |
 | Data type       | String                                               |
 | Value format    | Allowed values                                       |
-
-Allowed values:
-
-| Value      | Description                                                                                                                                    |
-| :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------|
-| Usage      | Positive or negative *charges* based on the quantity of a service or resource that was consumed over a given period of time including refunds. |
-| Purchase   | Positive or negative *charges* for the acquisition of a service or resource bought upfront or on a recurring basis including refunds.          |
-| Tax        | Positive or negative applicable taxes that are levied by the relevant authorities including refunds. Tax *charges* may vary depending on factors such as the location, jurisdiction, and local or federal regulations. |
-| Credit     | Positive or negative *charges* granted by the service provider for various scenarios e.g., promotional credits or corrections to promotional credits.    |
-| Adjustment | Positive or negative *charges* the service provider applies that do not fall into other category values.                                               |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/chargeclass.md
+++ b/specification/datasets/cost_and_usage/columns/chargeclass.md
@@ -12,6 +12,12 @@ ChargeClass MUST adhere to the following requirements:
   * ChargeClass MUST NOT be null when the *charge* represents a correction to a previously *closed billing period*.
 * ChargeClass MUST be "Correction" when ChargeClass is not null.
 
+## Allowed Values
+
+| Value      | Description                                                                                    |
+| :--------- | :----------------------------------------------------------------------------------------------|
+| Correction | Correction to a previously *closed billing period* (e.g., refunds and credit modifications). |
+
 ## Column ID
 
 ChargeClass
@@ -34,12 +40,6 @@ Indicates whether a *charge* represents a correction to a previously *closed bil
 | Allows nulls    | True                                                 |
 | Data type       | String                                               |
 | Value format    | Allowed values                                       |
-
-Allowed values:
-
-| Value      | Description                                                                                    |
-| :--------- | :----------------------------------------------------------------------------------------------|
-| Correction | Correction to a previously *closed billing period* (e.g., refunds and credit modifications). |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/chargefrequency.md
+++ b/specification/datasets/cost_and_usage/columns/chargefrequency.md
@@ -11,6 +11,14 @@ ChargeFrequency MUST adhere to the following requirements:
 * ChargeFrequency MUST be one of the allowed values.
 * ChargeFrequency MUST NOT be "Usage-Based" when [ChargeCategory](#datasets.costandusage.chargecategory) is "Purchase".
 
+## Allowed Values
+
+| Value       | Description                   |
+|:------------|:------------------------------|
+| One-Time    | *Charges* that only happen once and will not repeat. One-time *charges* are typically recorded on the hour or day when the cost was incurred.  |
+| Recurring   | *Charges* that repeat on a periodic cadence (e.g., weekly, monthly) regardless of whether the product or [*service*](#glossary:service) was used. Recurring *charges* typically happen on the same day or point within every period. The charge date does not change based on how or when the *service* is used. |
+| Usage-Based | *Charges* that repeat every time the *service* is used. Usage-based *charges* are typically recorded hourly or daily, based on the granularity of the cost data for the period when the *service* was used (referred to as *charge period*). Usage-based *charges* are not recorded when the *service* is not used.                    |
+
 ## Column ID
 
 ChargeFrequency
@@ -33,14 +41,6 @@ Indicates how often a *charge* will occur.
 | Allows nulls    | False                                                |
 | Data type       | String                                               |
 | Value format    | Allowed values                                       |
-
-Allowed values:
-
-| Value       | Description                   |
-|:------------|:------------------------------|
-| One-Time    | *Charges* that only happen once and will not repeat. One-time *charges* are typically recorded on the hour or day when the cost was incurred.  |
-| Recurring   | *Charges* that repeat on a periodic cadence (e.g., weekly, monthly) regardless of whether the product or [*service*](#glossary:service) was used. Recurring *charges* typically happen on the same day or point within every period. The charge date does not change based on how or when the *service* is used. |
-| Usage-Based | *Charges* that repeat every time the *service* is used. Usage-based *charges* are typically recorded hourly or daily, based on the granularity of the cost data for the period when the *service* was used (referred to as *charge period*). Usage-based *charges* are not recorded when the *service* is not used.                    |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountcategory.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountcategory.md
@@ -12,6 +12,13 @@ CommitmentDiscountCategory MUST adhere to the following requirements:
   * CommitmentDiscountCategory MUST NOT be null when CommitmentDiscountId is not null.
 * CommitmentDiscountCategory MUST be one of the allowed values.
 
+## Allowed Values
+
+| Value   | Description                                                              |
+|:--------|:-------------------------------------------------------------------------|
+| Spend   | Commitment discounts that require a predetermined amount of spend. |
+| Usage   | Commitment discounts that require a predetermined amount of usage. |
+
 ## Column ID
 
 CommitmentDiscountCategory
@@ -34,13 +41,6 @@ Indicates whether the *commitment discount* identified in the CommitmentDiscount
 | Allows nulls    | True                                                 |
 | Data type       | String                                               |
 | Value format    | Allowed Values                                       |
-
-Allowed values:
-
-| Value   | Description                                                              |
-|:--------|:-------------------------------------------------------------------------|
-| Spend   | Commitment discounts that require a predetermined amount of spend. |
-| Usage   | Commitment discounts that require a predetermined amount of usage. |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountstatus.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountstatus.md
@@ -14,6 +14,13 @@ CommitmentDiscountStatus MUST adhere to the following requirements:
 * CommitmentDiscountStatus MUST be "Used" when the *charge* utilizes a specific amount of a given CommitmentDiscountId.
 * CommitmentDiscountStatus MUST be "Unused" when the *charge* represents the unused portion of the given CommitmentDiscountId.
 
+## Allowed Values
+
+| Value  | Description                                                             |
+| :----- | :---------------------------------------------------------------------- |
+| Used   | *Charges* that utilized a specific amount of a commitment discount. |
+| Unused | *Charges* that represent the unused portion of the commitment discount. |
+
 ## Column ID
 
 CommitmentDiscountStatus
@@ -36,13 +43,6 @@ Indicates whether the *charge* corresponds with the consumption of a *commitment
 | Allows nulls    | True                                                 |
 | Data type       | String                                               |
 | Value format    | Allowed Values                                       |
-
-Allowed values:
-
-| Value  | Description                                                             |
-| :----- | :---------------------------------------------------------------------- |
-| Used   | *Charges* that utilized a specific amount of a commitment discount. |
-| Unused | *Charges* that represent the unused portion of the commitment discount. |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/pricingcategory.md
+++ b/specification/datasets/cost_and_usage/columns/pricingcategory.md
@@ -19,6 +19,15 @@ PricingCategory MUST adhere to the following requirements:
   * PricingCategory MUST be "Dynamic" when pricing is determined by the service provider and may change over time, regardless of predetermined agreement pricing.
   * PricingCategory MUST be "Other" when there is a pricing model but none of the allowed values apply.
 
+## Allowed Values
+
+| Value     | Description                                                                                                                                                                                                                          |
+| :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Standard  | *Charges* priced at the agreed upon rate for the billing account, including [*negotiated discounts*](#glossary:negotiated-discount). This pricing includes any flat rate and volume/tiered pricing but does not include dynamic pricing or reduced pricing due to the application of a *commitment discount*. This does include the purchase of a commitment discount at agreed upon rates. |
+| Dynamic   | *Charges* priced at a variable rate determined by the service provider. This includes any product or service with a unit price the service provider can change without notice, like interruptible or low priority [*resources*](#glossary:resource). |
+| Committed | *Charges* with reduced pricing due to the application of the *commitment discount* specified by the Commitment Discount ID. |
+| Other     | *Charges* priced in a way not covered by another pricing category. |
+
 ## Column ID
 
 PricingCategory
@@ -41,15 +50,6 @@ Describes the pricing model used for a *charge* at the time of use or purchase.
 | Allows nulls    | True                                                 |
 | Data type       | String                                               |
 | Value format    | Allowed values                                       |
-
-Allowed values:
-
-| Value     | Description                                                                                                                                                                                                                          |
-| :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Standard  | *Charges* priced at the agreed upon rate for the billing account, including [*negotiated discounts*](#glossary:negotiated-discount). This pricing includes any flat rate and volume/tiered pricing but does not include dynamic pricing or reduced pricing due to the application of a *commitment discount*. This does include the purchase of a commitment discount at agreed upon rates. |
-| Dynamic   | *Charges* priced at a variable rate determined by the service provider. This includes any product or service with a unit price the service provider can change without notice, like interruptible or low priority [*resources*](#glossary:resource). |
-| Committed | *Charges* with reduced pricing due to the application of the *commitment discount* specified by the Commitment Discount ID. |
-| Other     | *Charges* priced in a way not covered by another pricing category. |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/servicecategory.md
+++ b/specification/datasets/cost_and_usage/columns/servicecategory.md
@@ -10,30 +10,7 @@ ServiceCategory MUST adhere to the following requirements:
 * ServiceCategory MUST NOT be null.
 * ServiceCategory MUST be one of the allowed values.
 
-## Column ID
-
-ServiceCategory
-
-## Display Name
-
-Service Category
-
-## Description
-
-Highest-level classification of a *service* based on the core function of the *service*.
-
-## Content Constraints
-
-| Constraint      | Value                                                |
-| :-------------- | :--------------------------------------------------- |
-| Dataset         | [Cost and Usage](#datasets.costandusage)             |
-| Column type     | Dimension                                            |
-| Feature level   | Mandatory                                            |
-| Allows nulls    | False                                                |
-| Data type       | String                                               |
-| Value format    | Allowed values                                       |
-
-Allowed values:
+## Allowed Values
 
 | Service Category          | Description                                                                                    |
 | :------------------------ | :--------------------------------------------------------------------------------------------- |
@@ -56,6 +33,29 @@ Allowed values:
 | Storage                   | Storage services for structured or unstructured data.                                          |
 | Web                       | Services enabling cloud applications to interact via the Internet.                             |
 | Other                     | New or emerging services that do not align with an existing category.                          |
+
+## Column ID
+
+ServiceCategory
+
+## Display Name
+
+Service Category
+
+## Description
+
+Highest-level classification of a *service* based on the core function of the *service*.
+
+## Content Constraints
+
+| Constraint      | Value                                                |
+| :-------------- | :--------------------------------------------------- |
+| Dataset         | [Cost and Usage](#datasets.costandusage)             |
+| Column type     | Dimension                                            |
+| Feature level   | Mandatory                                            |
+| Allows nulls    | False                                                |
+| Data type       | String                                               |
+| Value format    | Allowed values                                       |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/servicesubcategory.md
+++ b/specification/datasets/cost_and_usage/columns/servicesubcategory.md
@@ -11,30 +11,7 @@ ServiceSubcategory MUST adhere to the following requirements:
 * ServiceSubcategory MUST be one of the allowed values.
 * ServiceSubcategory MUST have one and only one parent ServiceCategory as specified in the allowed values below.
 
-## Column ID
-
-ServiceSubcategory
-
-## Display Name
-
-Service Subcategory
-
-## Description
-
-Secondary classification of the Service Category for a *service* based on its core function.
-
-## Content Constraints
-
-| Constraint      | Value                                                |
-| :-------------- | :--------------------------------------------------- |
-| Dataset         | [Cost and Usage](#datasets.costandusage)             |
-| Column type     | Dimension                                            |
-| Feature level   | Recommended                                          |
-| Allows nulls    | False                                                |
-| Data type       | String                                               |
-| Value format    | Allowed Values                                       |
-
-Allowed values:
+## Allowed Values
 
 | Service Category          | Service Subcategory                   | Service Subcategory Description                                                                               |
 | ------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
@@ -120,6 +97,29 @@ Allowed values:
 | Web                       | Application Platforms                 | Integrated environments that run web applications. |
 | Web                       | Other (Web)                           | Web services that do not fall into one of the defined subcategories. |
 | Other                     | Other (Other)                         | Services that do not fall into one of the defined categories. |
+
+## Column ID
+
+ServiceSubcategory
+
+## Display Name
+
+Service Subcategory
+
+## Description
+
+Secondary classification of the Service Category for a *service* based on its core function.
+
+## Content Constraints
+
+| Constraint      | Value                                                |
+| :-------------- | :--------------------------------------------------- |
+| Dataset         | [Cost and Usage](#datasets.costandusage)             |
+| Column type     | Dimension                                            |
+| Feature level   | Recommended                                          |
+| Allows nulls    | False                                                |
+| Data type       | String                                               |
+| Value format    | Allowed Values                                       |
 
 ## Introduced (version)
 

--- a/specification/datasets/invoice_detail/columns/chargecategory.md
+++ b/specification/datasets/invoice_detail/columns/chargecategory.md
@@ -11,6 +11,16 @@ ChargeCategory MUST adhere to the following requirements:
 * ChargeCategory MUST be one of the allowed values.
 * ChargeCategory MAY equal "Usage" when the record aggregates *charges* across multiple allowed values other than "Tax" (for example, aggregation of "Usage" and "Credit" is allowed, but not "Usage" and "Tax").
 
+## Allowed Values
+
+| Value      | Description                                                                                                                                    |
+| :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------|
+| Usage      | Positive or negative *charges* based on the quantity of a service or resource that was consumed over a given period of time including refunds. |
+| Purchase   | Positive or negative *charges* for the acquisition of a service or resource bought upfront or on a recurring basis including refunds. |
+| Tax        | Positive or negative applicable taxes that are levied by the relevant authorities including refunds. Tax *charges* may vary depending on factors such as the location, jurisdiction, and local or federal regulations. |
+| Credit     | Positive or negative *charges* granted by the service provider for various scenarios (e.g., promotional credits, corrections to promotional credits). |
+| Adjustment | Positive or negative *charges* the service provider applies that do not fall into other category values. |
+
 ## Column ID
 
 ChargeCategory
@@ -32,16 +42,6 @@ Represents the highest-level classification of a *charge* based on the nature of
 | Allows nulls    | False          |
 | Data type       | String         |
 | Value format    | Allowed values |
-
-## Allowed Values
-
-| Value      | Description                                                                                                                                    |
-| :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------|
-| Usage      | Positive or negative *charges* based on the quantity of a service or resource that was consumed over a given period of time including refunds. |
-| Purchase   | Positive or negative *charges* for the acquisition of a service or resource bought upfront or on a recurring basis including refunds. |
-| Tax        | Positive or negative applicable taxes that are levied by the relevant authorities including refunds. Tax *charges* may vary depending on factors such as the location, jurisdiction, and local or federal regulations. |
-| Credit     | Positive or negative *charges* granted by the service provider for various scenarios (e.g., promotional credits, corrections to promotional credits). |
-| Adjustment | Positive or negative *charges* the service provider applies that do not fall into other category values. |
 
 ## Introduced (version)
 

--- a/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
+++ b/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
@@ -13,6 +13,14 @@ InvoiceIssueStatus MUST adhere to the following requirements:
 * InvoiceIssueStatus MUST represent the current publication state of the invoice.
 * InvoiceIssueStatus MUST NOT transition from "Issued" to "Open" unless explicitly requested or approved by the customer.
 
+## Allowed Values
+
+| Value  | Description |
+| :---   | :---        |
+| Open   | The invoice is provisional and subject to change. It is not a valid financial obligation and the associated delivered data is preliminary. |
+| Issued | The invoice has been formally issued by the provider. It represents a valid financial obligation with finalized associated data. |
+| Voided | The invoice was previously issued but has been retracted or nullified. It is not a valid financial obligation. |
+
 ## Implementation Context
 
 The transition from "Open" to "Issued" typically signifies that an invoice has been finalized, invoice reconciliation has been performed, and the delivered data is accurate. However, when the delivered data is found to be inaccurate or incomplete, it may be necessary to apply corrections to records associated with the issued invoice.
@@ -46,14 +54,6 @@ The publication state of the invoice and the reliability of its associated deliv
 | Allows nulls    | False                           |
 | Data type       | String                          |
 | Value format    | \<unspecified>                  |
-
-## Allowed Values
-
-| Value  | Description |
-| :---   | :---        |
-| Open   | The invoice is provisional and subject to change. It is not a valid financial obligation and the associated delivered data is preliminary. |
-| Issued | The invoice has been formally issued by the provider. It represents a valid financial obligation with finalized associated data. |
-| Voided | The invoice was previously issued but has been retracted or nullified. It is not a valid financial obligation. |
 
 ## Introduced (version)
 


### PR DESCRIPTION
## Summary

Closes #2106.

Converts bare \`Allowed values:\` text labels to proper \`## Allowed Values\` markdown headings and moves the section to appear immediately after \`## Requirements\` in all 21 columns that define allowed values.

**No other content changes.**

### Affected files (21)

**Billing Period (1):**
* \`billingperiodstatus.md\`

**Contract Commitment (9):**
* \`contractcommitmentbenefitcategory.md\`
* \`contractcommitmentcategory.md\`
* \`contractcommitmentdurationtype.md\`
* \`contractcommitmentfulfillmentinterval.md\`
* \`contractcommitmentlifecyclestatus.md\`
* \`contractcommitmentmodel.md\`
* \`contractcommitmentoffercategory.md\`
* \`contractcommitmentpaymentinterval.md\`
* \`contractcommitmentpaymentmodel.md\`

**Cost and Usage (9):**
* \`capacityreservationstatus.md\`
* \`chargecategory.md\`
* \`chargeclass.md\`
* \`chargefrequency.md\`
* \`commitmentdiscountcategory.md\`
* \`commitmentdiscountstatus.md\`
* \`pricingcategory.md\`
* \`servicecategory.md\`
* \`servicesubcategory.md\`

**Invoice Detail (2):**
* \`chargecategory.md\`
* \`invoiceissuestatus.md\`

### Note

\`contractcommitmentdurationtype.md\` has an introductory sentence between \`## Allowed Values\` and its time-units table. This exception is tracked in #2262 for team discussion.

### Type of Change
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.

## Test plan

* [x] All 21 files use \`## Allowed Values\` as a proper markdown heading
* [x] \`## Allowed Values\` appears immediately after \`## Requirements\` in all 21 files
* [x] No other content modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)