### PR TITLE
AI #2264: Sync issue template title prefixes with AGENTS.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: "Feature Request"
 description: "Propose a new feature or enhancement to the FOCUS specification"
-title: "[FR]: "
+title: "[FR] "
 labels: ["feature", "needs triage"]
 assignees: ["matt-cowsert"]
 body:

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,6 +1,6 @@
 name: Maintenance Task
 description: Create tasks related to work on the GitHub Repository or GitHub Actions.
-title: "[MAINTENANCE]: "
+title: "[Maintenance] "
 labels: ["repo maintenance"]
 type: "Maintenance"
 assignees: ["shawnalpay"]


### PR DESCRIPTION
## Summary

Syncs the title prefixes in two issue template yml files with the Issue Templates table in AGENTS.md (introduced in PR #2172).

* `.github/ISSUE_TEMPLATE/feature-request.yml`: `"[FR]: "` to `"[FR] "` (drop colon)
* `.github/ISSUE_TEMPLATE/maintenance.yml`: `"[MAINTENANCE]: "` to `"[Maintenance] "` (case change, drop colon)

Resolves the inconsistency where UI-created and API-created issues would follow different title formats.

Closes #2264.

> Merge after PR #2172 to keep the history readable. This PR references the Issue Templates table introduced there.

### Type of Change
- [ ] Bug fix
- [ ] New feature / Specification update
- [x] Editorial / Formatting

### Author Checklist
- [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](guidelines/contributors/ai-usage-guidelines.md).
- [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
- [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
