### PR TITLE
AI #2114: Add JSON data type requirement to Key-Value columns

### DIFF
--- a/specification/datasets/cost_and_usage/columns/allocatedtags.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedtags.md
@@ -6,7 +6,7 @@ The Allocated Tags column represents the set of [*tags*](#glossary:tag) assigned
 
 AllocatedTags MUST adhere to the following requirements:
 
-* InvoiceDetailGrain MUST be of type JSON.
+* AllocatedTags MUST be of type JSON.
 * AllocatedTags MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * AllocatedTags MUST adhere to the following nullability requirements:
   * AllocatedTags MUST be null when a *charge* is not related to a data generator-calculated split cost allocation.

--- a/specification/datasets/cost_and_usage/columns/allocatedtags.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedtags.md
@@ -6,7 +6,8 @@ The Allocated Tags column represents the set of [*tags*](#glossary:tag) assigned
 
 AllocatedTags MUST adhere to the following requirements:
 
-* AllocatedTags MUST be of type JSON.
+* AllocatedTags MUST be of type JSON Object (serialized as a String where necessary).
+* AllocatedTags MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * AllocatedTags MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * AllocatedTags MUST adhere to the following nullability requirements:
   * AllocatedTags MUST be null when a *charge* is not related to a data generator-calculated split cost allocation.

--- a/specification/datasets/cost_and_usage/columns/allocatedtags.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedtags.md
@@ -6,6 +6,7 @@ The Allocated Tags column represents the set of [*tags*](#glossary:tag) assigned
 
 AllocatedTags MUST adhere to the following requirements:
 
+* InvoiceDetailGrain MUST be of type JSON.
 * AllocatedTags MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * AllocatedTags MUST adhere to the following nullability requirements:
   * AllocatedTags MUST be null when a *charge* is not related to a data generator-calculated split cost allocation.

--- a/specification/datasets/cost_and_usage/columns/skupricedetails.md
+++ b/specification/datasets/cost_and_usage/columns/skupricedetails.md
@@ -10,7 +10,7 @@ SKU Price Details helps practitioners understand and distinguish *SKU Prices*, e
 
 SkuPriceDetails MUST adhere to the following requirements:
 
-* InvoiceDetailGrain MUST be of type JSON.
+* SkuPriceDetails MUST be of type JSON.
 * SkuPriceDetails MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * SkuPriceDetails property keys SHOULD conform to [PascalCase](#glossary:pascalcase) format.
 * SkuPriceDetails MUST adhere to the following nullability requirements:

--- a/specification/datasets/cost_and_usage/columns/skupricedetails.md
+++ b/specification/datasets/cost_and_usage/columns/skupricedetails.md
@@ -10,6 +10,7 @@ SKU Price Details helps practitioners understand and distinguish *SKU Prices*, e
 
 SkuPriceDetails MUST adhere to the following requirements:
 
+* InvoiceDetailGrain MUST be of type JSON.
 * SkuPriceDetails MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * SkuPriceDetails property keys SHOULD conform to [PascalCase](#glossary:pascalcase) format.
 * SkuPriceDetails MUST adhere to the following nullability requirements:

--- a/specification/datasets/cost_and_usage/columns/skupricedetails.md
+++ b/specification/datasets/cost_and_usage/columns/skupricedetails.md
@@ -10,7 +10,8 @@ SKU Price Details helps practitioners understand and distinguish *SKU Prices*, e
 
 SkuPriceDetails MUST adhere to the following requirements:
 
-* SkuPriceDetails MUST be of type JSON.
+* SkuPriceDetails MUST be of type JSON Object (serialized as a String where necessary).
+* SkuPriceDetails MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * SkuPriceDetails MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * SkuPriceDetails property keys SHOULD conform to [PascalCase](#glossary:pascalcase) format.
 * SkuPriceDetails MUST adhere to the following nullability requirements:

--- a/specification/datasets/cost_and_usage/columns/tags.md
+++ b/specification/datasets/cost_and_usage/columns/tags.md
@@ -8,7 +8,7 @@ A tag becomes [*finalized*](#glossary:finalized-tag) when a single value is sele
 
 Tags MUST adhere to the following requirements:
 
-* InvoiceDetailGrain MUST be of type JSON.
+* Tags MUST be of type JSON.
 * Tags MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * Tags MAY be null.
 * When Tags is not null, Tags MUST adhere to the following requirements:

--- a/specification/datasets/cost_and_usage/columns/tags.md
+++ b/specification/datasets/cost_and_usage/columns/tags.md
@@ -8,6 +8,7 @@ A tag becomes [*finalized*](#glossary:finalized-tag) when a single value is sele
 
 Tags MUST adhere to the following requirements:
 
+* InvoiceDetailGrain MUST be of type JSON.
 * Tags MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * Tags MAY be null.
 * When Tags is not null, Tags MUST adhere to the following requirements:

--- a/specification/datasets/cost_and_usage/columns/tags.md
+++ b/specification/datasets/cost_and_usage/columns/tags.md
@@ -8,7 +8,8 @@ A tag becomes [*finalized*](#glossary:finalized-tag) when a single value is sele
 
 Tags MUST adhere to the following requirements:
 
-* Tags MUST be of type JSON.
+* Tags MUST be of type JSON Object (serialized as a String where necessary).
+* Tags MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * Tags MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * Tags MAY be null.
 * When Tags is not null, Tags MUST adhere to the following requirements:

--- a/specification/datasets/invoice_detail/columns/invoicedetailgrain.md
+++ b/specification/datasets/invoice_detail/columns/invoicedetailgrain.md
@@ -8,7 +8,8 @@ This gives FinOps practitioners a single point of reference for all possible [In
 
 InvoiceDetailGrain MUST adhere to the following requirements:
 
-* InvoiceDetailGrain MUST be of type JSON.
+* InvoiceDetailGrain MUST be of type JSON Object (serialized as a String where necessary).
+* InvoiceDetailGrain MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * InvoiceDetailGrain MUST conform to [KeyValueFormat](#attributes.key-valueformat) requirements.
 * InvoiceDetailGrain MUST NOT be null when one or more properties uniquely define the granularity of the invoice line item.
 * InvoiceDetailGrain MUST contain the set of all properties that uniquely define the granularity of the invoice line item.


### PR DESCRIPTION
## Summary

Adding JSON as the data type to the normative requirements which specify the key-value format

### Type of Change
* [X] Bug fix
* [ ] New feature / Specification update
* [X] Editorial / Formatting

### Author Checklist
* [ ] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [X] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.

N/A no AI was used in this PR (directly nor indirectly).