### PR TITLE
AI #2127: Fix attribute linking, enforce Attribute IDs, and correct anchor generation description in MarkdownPP Guidelines

### DIFF
--- a/guidelines/contributors/markdownpp-guidelines.md
+++ b/guidelines/contributors/markdownpp-guidelines.md
@@ -183,9 +183,9 @@ This feature automatically:
 All headers appearing after the !TOC directive automatically receive an HTML anchor generated from the header text whereby the following applies:
 
 * Anchor text is normalized to lowercase.
-* Whitespace and the following characters are removed: `,` `-` `(` `)`.
+* Whitespace and the following characters are removed: `,` `(` `)`.
 * Other special characters are preserved.
-* Dots (.) are inserted between header levels to represent the full hierarchy of document sections.
+* Dots (`.`) are inserted between header levels to represent the full hierarchy of document sections.
 * Headers marked with `<!--SkipTOC-->` will appear in the document but will not be included in the Table of Contents, and no anchor will be created.
 
 ***Note:*** *These anchors are generated for the HTML and PDF builds of the specification and differ from how GitHub natively generates anchors for markdown files. Links using these anchors will work in the built specification output but not when viewing the source markdown on GitHub.*

--- a/specification/attributes/attributes_overview.md
+++ b/specification/attributes/attributes_overview.md
@@ -6,14 +6,15 @@ Attributes serve as reusable containers for requirements that enforce consistenc
 
 | Attribute | Description |
 | :--- | :--- |
+| [Correction Handling](#attributes.correctionhandling) | Defines how corrections to previously delivered dataset artifacts are represented in subsequent deliveries. |
 | [Currency Format](#attributes.currencyformat) | Specifies rules and formatting requirements for currency columns. |
 | [Custom Column Handling](#attributes.customcolumnhandling) | Defines column ID naming, formatting, and value requirements for [*custom columns*](#glossary:custom-column) appearing in a [*FOCUS dataset*](#glossary:FOCUS-dataset). |
 | [Data Generator-Calculated Split Cost Allocation Handling](#attributes.datagenerator-calculatedsplitcostallocationhandling) | Allows data generators to provide granular cost information based on specific documented methods. |
 | [Dataset Completeness](#attributes.datasetcompleteness) | Defines requirements for a *FOCUS dataset* to include *custom columns* not represented in [*FOCUS columns*](#glossary:FOCUS-column). |
 | [Dataset Configuration](#attributes.datasetconfiguration) | Defines the rules for customizing a dataset's schema. |
 | [Date/Time Format](#attributes.date/timeformat) | Outlines rules and ISO 8601 formatting requirements for date and time information. |
+| [Delivery Handling](#attributes.deliveryhandling) | Defines how a data generator delivers a FOCUS dataset to a customer. |
 | [FOCUS Column Handling](#attributes.focuscolumnhandling) | Defines naming conventions for *FOCUS columns* appearing in a *FOCUS dataset*. |
-| [Invoice Handling](#attributes.invoicehandling) | Ensures all monetary charges on an invoice are represented in the dataset for reconciliation. |
 | [JSON Object Format](#attributes.jsonobjectformat) | Defines rules for columns that convey data as complex, hierarchical serialized JSON strings. |
 | [Key-Value Format](#attributes.key-valueformat) | Provides formatting requirements for columns conveying data as simple key-value pairs. |
 | [Null Handling](#attributes.nullhandling) | Standardizes how to represent columns that do not have a value using NULL. |

--- a/specification/attributes/custom_column_handling.md
+++ b/specification/attributes/custom_column_handling.md
@@ -32,7 +32,7 @@ Column conforming to CustomColumnHandling attribute MUST adhere to the following
   * *Custom column* SHOULD include the `Name` suffix in the Column ID when the *custom column* represents a name.
 * *Custom column* SHOULD conform to [DataGeneratorCalculatedSplitCostAllocationHandling](#attributes.datagenerator-calculatedsplitcostallocationhandling) requirements when the data generator supports data generator-calculated split cost allocation.
 * *Custom column* SHOULD conform to [NullHandling](#attributes.nullhandling) requirements.
-* *Custom column* containing date/time values SHOULD conform to [DateTimeFormat](#attributes.datetimeformat) requirements.
+* *Custom column* containing date/time values SHOULD conform to [DateTimeFormat](#attributes.date/timeformat) requirements.
 * *Custom column* containing JSON objects MUST have its object schema documented by the data generator and accessible to practitioners.
 * *Custom column* containing numeric values MUST contain a single numeric value.
 * *Custom column* containing numeric values SHOULD conform to [NumericFormat](#attributes.numericformat) requirements.

--- a/specification/attributes/dataset_completeness.md
+++ b/specification/attributes/dataset_completeness.md
@@ -24,11 +24,11 @@ A service provider's native cost dataset includes a column `internal_project_id`
 
 The native dataset also includes a native billing event reference (`billing_event_id`) that does not directly support analysis but allows practitioners to trace *FOCUS dataset* records back to native records. The *FOCUS dataset* includes this as `x_BillingEventId` to enable correlation between the two datasets.
 
-Even when [Discount Handling](#attributes.discounthandling) splits a single native charge into two FOCUS rows (e.g., separating a commitment discount), *custom columns* like `x_InternalProjectId` and `x_BillingEventId` are preserved on both rows and cost metrics like `BilledCost` are split accurately, maintaining data integrity.
+Even when a single native record results in multiple FOCUS records (e.g., separating discounted and non-discounted portions of a charge in a [Cost and Usage](#datasets.costandusage) [*dataset artifact*](#glossary:dataset-artifact)), *custom columns* like `x_InternalProjectId` and `x_BillingEventId` are preserved in all resulting records and cost metrics like `BilledCost` are split accurately, maintaining data integrity.
 
 *Custom columns* that duplicate newly introduced *FOCUS columns* may be preserved during a documented transitional period to enable migration without breaking changes.
 
-This attribute ensures *custom columns* are fully represented in the *FOCUS dataset* schema. Data generators may require FOCUS consumers to explicitly select these columns when generating a [*dataset artifact*](#glossary:dataset-artifact) (see [Dataset Configuration](#attributes.datasetconfiguration)).
+This attribute ensures *custom columns* are fully represented in the *FOCUS dataset* schema. Data generators may require FOCUS consumers to explicitly select these columns when generating a *dataset artifact* (see [Dataset Configuration](#attributes.datasetconfiguration)).
 
 ## Attribute ID
 

--- a/specification/attributes/unit_format.md
+++ b/specification/attributes/unit_format.md
@@ -6,7 +6,7 @@ Billing data frequently captures data measured in units related to data size, co
 
 Column conforming to UnitFormat attribute MUST adhere to the following requirements:
 
-* [*FOCUS dataset column*](#glossary:FOCUS-dataset-column) MUST adhere to the following [base unit](#attributes.definitions.baseunit) requirements:
+* [*FOCUS dataset column*](#glossary:FOCUS-dataset-column) MUST adhere to the following [base unit](#attributes.unitformat.definitions.baseunit) requirements:
   * *FOCUS dataset column* MUST include at least one base unit.
   * *FOCUS dataset column* MUST use one of the allowed data size unit abbreviations listed below for data size base units.
   * *FOCUS dataset column* MUST use the allowed data size unit abbreviations in the same form for both singular and plural units.
@@ -16,15 +16,15 @@ Column conforming to UnitFormat attribute MUST adhere to the following requireme
   * *FOCUS dataset column* SHOULD use one of the recommended count-based unit names listed below for count-based base units.
   * *FOCUS dataset column* SHOULD use capitalized nouns for base units that do not correspond to any of the allowed base unit names listed below.
   * *FOCUS dataset column* MAY include a count-based base unit that is not listed as one of the allowed values.
-* *FOCUS dataset column* MAY include a [unit quantity](#attributes.definitions.unitquantity) expressed as a positive integer.
-* *FOCUS dataset column* expressing a compound unit MUST use a hyphen (`-`) to separate base units (e.g., `GB-Hours`).
+* *FOCUS dataset column* MAY include a [unit quantity](#attributes.unitformat.definitions.unitquantity) expressed as a positive integer.
+* *FOCUS dataset column* expressing a [compound unit](#attributes.unitformat.definitions.compoundunit) MUST use a hyphen (`-`) to separate base units (e.g., `GB-Hours`).
 * *FOCUS dataset column* expressing a compound unit SHOULD use the `<singular-base-unit>-<plural-base-unit>` format (e.g., `GB-Hours`, `MB-Days`, `Request-Tokens`).
-* *FOCUS dataset column* expressing a ratio unit MUST use a slash (`/`) to separate the numerator and denominator (e.g., `GB/Hour` to signify gigabytes per hour).
-* *FOCUS dataset column* expressing a ratio unit MAY include a [denominator quantity](#attributes.definitions.denominatorquantity) expressed as a positive integer.
+* *FOCUS dataset column* expressing a [ratio unit](#attributes.unitformat.definitions.ratiounit) MUST use a slash (`/`) to separate the numerator and denominator (e.g., `GB/Hour` to signify gigabytes per hour).
+* *FOCUS dataset column* expressing a ratio unit MAY include a [denominator quantity](#attributes.unitformat.definitions.denominatorquantity) expressed as a positive integer.
 * *FOCUS dataset column* expressing a ratio unit and including a denominator quantity SHOULD use the `<plural-units>/<denominator-quantity> <plural-time-units>` format (e.g., `Units/3 Months`).
 * *FOCUS dataset column* expressing a ratio unit with a compound unit numerator SHOULD use the `<compound-unit>/<singular-time-unit>` format (e.g., `Core-Hours/Day`).
 * *FOCUS dataset column* expressing a ratio unit with a time denominator SHOULD use the `<plural-units>/<singular-time-unit>` format (e.g., `GB/Hour`, `PB/Day`).
-* *FOCUS dataset column* expressing a simple unit SHOULD use the `<plural-units>` format (e.g., `GB`, `Seconds`).
+* *FOCUS dataset column* expressing a [simple unit](#attributes.unitformat.definitions.simpleunit) SHOULD use the `<plural-units>` format (e.g., `GB`, `Seconds`).
 * *FOCUS dataset column* including a unit quantity SHOULD use the `<unit-quantity> <plural-units>` format (e.g., `1000 Tokens`, `1000 Characters`).
 
 ## Definitions
@@ -37,27 +37,27 @@ A standardized expression that describes how quantities in a *FOCUS dataset* are
 
 ### Base Unit
 
-An atomic unit that serves as a building block for all [measurement units](#attributes.definitions.measurementunit); can be a data size unit, time-based unit, or count-based unit (e.g., `GB`, `Hour`, `Token`).
+An atomic unit that serves as a building block for all [measurement units](#attributes.unitformat.definitions.measurementunit); can be a data size unit, time-based unit, or count-based unit (e.g., `GB`, `Hour`, `Token`).
 
 ### Simple Unit
 
-A [measurement unit](#attributes.definitions.measurementunit) that contains exactly one [base unit](#attributes.definitions.baseunit), optionally preceded by a [unit quantity](#attributes.definitions.unitquantity) (e.g., `GB`, `Seconds`, `1000 Tokens`).
+A [measurement unit](#attributes.unitformat.definitions.measurementunit) that contains exactly one [base unit](#attributes.unitformat.definitions.baseunit), optionally preceded by a [unit quantity](#attributes.unitformat.definitions.unitquantity) (e.g., `GB`, `Seconds`, `1000 Tokens`).
 
 ### Compound Unit
 
-A [measurement unit](#attributes.definitions.measurementunit) that combines two [base units](#attributes.definitions.baseunit) using a hyphen (`-`), optionally preceded by a [unit quantity](#attributes.definitions.unitquantity) (e.g., `GB-Hours`, `MB-Days`, `Request-Tokens`).
+A [measurement unit](#attributes.unitformat.definitions.measurementunit) that combines two [base units](#attributes.unitformat.definitions.baseunit) using a hyphen (`-`), optionally preceded by a [unit quantity](#attributes.unitformat.definitions.unitquantity) (e.g., `GB-Hours`, `MB-Days`, `Request-Tokens`).
 
 ### Ratio Unit
 
-A [measurement unit](#attributes.definitions.measurementunit) that expresses one [base unit](#attributes.definitions.baseunit) or [compound unit](#attributes.definitions.compoundunit) per another using a slash (`/`), optionally including a [denominator quantity](#attributes.definitions.denominatorquantity) (e.g., `GB/Hour`, `Units/3 Months`, `Core-Hours/Day`).
+A [measurement unit](#attributes.unitformat.definitions.measurementunit) that expresses one [base unit](#attributes.unitformat.definitions.baseunit) or [compound unit](#attributes.unitformat.definitions.compoundunit) per another using a slash (`/`), optionally including a [denominator quantity](#attributes.unitformat.definitions.denominatorquantity) (e.g., `GB/Hour`, `Units/3 Months`, `Core-Hours/Day`).
 
 ### Unit Quantity
 
-A positive integer included in a [measurement unit](#attributes.definitions.measurementunit), indicating the granularity (e.g., `1000` in `1000 Tokens`).
+A positive integer included in a [measurement unit](#attributes.unitformat.definitions.measurementunit), indicating the granularity (e.g., `1000` in `1000 Tokens`).
 
 ### Denominator Quantity
 
-A positive integer included in the denominator of a [ratio unit](#attributes.definitions.ratiounit), indicating the granularity of the denominator (e.g., `3` in `Units/3 Months`).
+A positive integer included in the denominator of a [ratio unit](#attributes.unitformat.definitions.ratiounit), indicating the granularity of the denominator (e.g., `3` in `Units/3 Months`).
 
 ## Base Unit Names
 

--- a/specification/datasets/cost_and_usage/columns/skupriceid.md
+++ b/specification/datasets/cost_and_usage/columns/skupriceid.md
@@ -9,7 +9,7 @@ The composition of properties associated with the SKU Price ID may differ across
 SkuPriceId MUST adhere to the following requirements:
 
 * SkuPriceId MUST be of type String.
-* SkuPriceId MUST conform to [String Handling](#attributes.stringhandling) requirements.
+* SkuPriceId MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * SkuPriceId MUST adhere to the following nullability requirements:
   * SkuPriceId MUST be null when [ChargeCategory](#datasets.costandusage.chargecategory) is "Tax".
   * SkuPriceId MUST NOT be null when ChargeCategory is "Usage" or "Purchase" and [ChargeClass](#datasets.costandusage.chargeclass) is not "Correction".


### PR DESCRIPTION
## Summary

This PR fixes internal link structures to use full `#attributes.<attributeid>` paths, replaces display name references with Attribute IDs in normative requirements, and corrects the anchor generation guidelines to accurately document that hyphens are preserved (not removed) during anchor generation.

### Changes

#### Link Structures Corrected

- Fixed `#attributes.datetimeformat` → `#attributes.date/timeformat` in `custom_column_handling.md`. The anchor generated by `TableOfContents.py` preserves the `/` from the header "Date/Time Format", so the link must include it.
- Fixed 16 links in `unit_format.md` using the incomplete path `#attributes.definitions.*` -> `#attributes.unitformat.definitions.*` to include the full parent section prefix.
- Other broken attribute links reported in the original issue (e.g., `#datagenerator-calculatedsplitcostallocationhandling` missing the `#attributes.` prefix) were verified to have been fixed in a prior PR. No further changes needed.

#### CostAndUsage Links Fixed

- All instances of `[Data Generator-Calculated Split Cost Allocation]` within CostAndUsage requirements were verified to correctly point to `#attributes.datagenerator-calculatedsplitcostallocationhandling`. This was fixed in a prior PR. No further changes needed.

#### Attribute IDs Enforced

- Fixed the single remaining case where a display name was used instead of an Attribute ID in a normative requirement: `[String Handling]` -> `[StringHandling]` in `skupriceid.md`.

#### Attributes Overview Corrected

- Added missing attributes (Correction Handling, Delivery Handling) and removed non-existent Invoice Handling from the Attribute List table in `attributes_overview.md`. The table now includes all 15 defined attributes in alphabetical order.

#### Stale Attribute Reference Removed

- Rephrased sentence in `dataset_completeness.md` that referenced the non-existent `#attributes.discounthandling`. The sentence now describes the charge-splitting scenario directly, without attributing it to a removed attribute.

#### Anchors Sanitized

- Investigation of the `TableOfContents.py` script revealed that the anchor generation regex (`[\s,-,\(,\)]+`) does **not** strip hyphens, i.e., hyphens are preserved in generated anchors by design (e.g., `Key-Value Format` → `key-valueformat`).
- The contributor guidelines incorrectly documented that hyphens are removed. This PR corrects the **MarkdownPP Guidelines for FOCUS Specification** guidelines to match the actual script behavior rather than modifying anchors or the script, since the entire specification already relies on hyphen-preserving anchors.

#### Validation

- Check and verify that markdown builds successfully without broken internal links to attributes — in progress.
Verified the following within the Attributes section (Section 4):
  - All internal links to attributes resolve to valid anchors — no broken attribute links remain after this PR.
  - Normative content (Requirements sections) consistently references Attribute IDs (e.g., `[StringHandling]`), not Display Names.
  - Non-normative content (Overview, Implementation Context, Definitions) consistently references Attribute Display Names (e.g., `[String Handling]`).
  - The Attribute List table includes all 15 defined attributes in alphabetical order, with no references to removed or non-existent attributes.
  - The anchor generation guidelines accurately reflect the behavior of `TableOfContents.py`.

*Note: A full link audit identified additional pre-existing broken links outside the Attributes section. These are unrelated to this PR's scope and should/will be addressed separately.*

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
