### PR TITLE
AI #2142: Remove redundant "more granular" wording in split cost allocation handling

### DIFF
--- a/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
+++ b/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
@@ -1,6 +1,6 @@
 # Data Generator-Calculated Split Cost Allocation Handling
 
-The data generator-calculated split cost allocation for data generator-defined services is a capability that can be offered by data generators which allocates (or in some cases provides more granular detail about) a charge to a more granular level. This is accomplished by taking a charge record present in a FOCUS dataset ([*origin charge*](#glossary:origin-charge)) and splitting it into multiple charge records ([*allocated charges*](#glossary:allocated-charge)) to reflect the more granular detail, while ensuring the origin charge can be derived from the combination of *allocated charges*. This feature is used by practitioners to conduct chargebacks and better understand the usage of resources.
+The data generator-calculated split cost allocation for data generator-defined services is a capability that can be offered by data generators which allocates a charge to a more granular level. This is accomplished by taking a charge record present in a FOCUS dataset ([*origin charge*](#glossary:origin-charge)) and splitting it into multiple charge records ([*allocated charges*](#glossary:allocated-charge)) to reflect the more granular detail, while ensuring the origin charge can be derived from the combination of *allocated charges*. This feature is used by practitioners to conduct chargebacks and better understand the usage of resources.
 
 ## Requirements
 

--- a/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
+++ b/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
@@ -1,6 +1,6 @@
 # Data Generator-Calculated Split Cost Allocation Handling
 
-The data generator-calculated split cost allocation for data generator-defined services is a capability that can be offered by data generators which allocates a charge to a more granular level or, in some cases, surfaces detail not visible in the origin charge (such as unused capacity). This is accomplished by taking a charge record present in a FOCUS dataset ([*origin charge*](#glossary:origin-charge)) and splitting it into multiple charge records ([*allocated charges*](#glossary:allocated-charge)) to reflect the more granular detail, while ensuring the origin charge can be derived from the combination of *allocated charges*. This feature is used by practitioners to conduct chargebacks and better understand the usage of resources.
+The data generator-calculated split cost allocation for data generator-defined services is a capability that can be offered by data generators which allocate a charge to a more granular level or, in some cases, surfaces detail not visible in the origin charge (such as unused capacity). This is accomplished by taking a charge record present in a FOCUS dataset ([*origin charge*](#glossary:origin-charge)) and splitting it into multiple charge records ([*allocated charges*](#glossary:allocated-charge)) to reflect the more granular detail, while ensuring the origin charge can be derived from the combination of *allocated charges*. This feature is used by practitioners to conduct chargebacks and better understand the usage of resources.
 
 ## Requirements
 

--- a/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
+++ b/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
@@ -1,6 +1,6 @@
 # Data Generator-Calculated Split Cost Allocation Handling
 
-The data generator-calculated split cost allocation for data generator-defined services is a capability that can be offered by data generators which allocates a charge to a more granular level. This is accomplished by taking a charge record present in a FOCUS dataset ([*origin charge*](#glossary:origin-charge)) and splitting it into multiple charge records ([*allocated charges*](#glossary:allocated-charge)) to reflect the more granular detail, while ensuring the origin charge can be derived from the combination of *allocated charges*. This feature is used by practitioners to conduct chargebacks and better understand the usage of resources.
+The data generator-calculated split cost allocation for data generator-defined services is a capability that can be offered by data generators which allocates a charge to a more granular level or, in some cases, surfaces detail not visible in the origin charge (such as unused capacity). This is accomplished by taking a charge record present in a FOCUS dataset ([*origin charge*](#glossary:origin-charge)) and splitting it into multiple charge records ([*allocated charges*](#glossary:allocated-charge)) to reflect the more granular detail, while ensuring the origin charge can be derived from the combination of *allocated charges*. This feature is used by practitioners to conduct chargebacks and better understand the usage of resources.
 
 ## Requirements
 

--- a/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
+++ b/specification/attributes/data_generator_calculated_split_cost_allocation_handling.md
@@ -1,6 +1,6 @@
 # Data Generator-Calculated Split Cost Allocation Handling
 
-The data generator-calculated split cost allocation for data generator-defined services is a capability that can be offered by data generators which allocate a charge to a more granular level or, in some cases, surfaces detail not visible in the origin charge (such as unused capacity). This is accomplished by taking a charge record present in a FOCUS dataset ([*origin charge*](#glossary:origin-charge)) and splitting it into multiple charge records ([*allocated charges*](#glossary:allocated-charge)) to reflect the more granular detail, while ensuring the origin charge can be derived from the combination of *allocated charges*. This feature is used by practitioners to conduct chargebacks and better understand the usage of resources.
+The data generator-calculated split cost allocation for data generator-defined services is a capability that can be offered by data generators which allocates a charge to a more granular level or, in some cases, surfaces detail not visible in the origin charge (such as unused capacity). This is accomplished by taking a charge record present in a FOCUS dataset ([*origin charge*](#glossary:origin-charge)) and splitting it into multiple charge records ([*allocated charges*](#glossary:allocated-charge)) to reflect the more granular detail, while ensuring the origin charge can be derived from the combination of *allocated charges*. This feature is used by practitioners to conduct chargebacks and better understand the usage of resources.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Resolves #2142.

Removes the parenthetical aside "(or in some cases provides more granular detail about)" from the opening paragraph of `specification/attributes/data_generator_calculated_split_cost_allocation_handling.md`. The original sentence used variants of "more granular" three times, making it harder to read than necessary. The remaining two occurrences are meaningful (one describes the *action*, the other describes the *outcome*).

**Before:**

> ...which allocates (or in some cases provides **more granular detail** about) a charge to **a more granular level**. This is accomplished by...to reflect **the more granular detail**...

**After:**

> ...which allocates a charge to **a more granular level**. This is accomplished by...to reflect **the more granular detail**...

Part of #1878 (1.4 consistency review).

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
