### PR TITLE
AI #2089: Update contributor guidelines to reflect branch-based workflow for CLA members

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,12 +57,13 @@ For complete guidance, see [AI Usage Guidelines](guidelines/contributors/ai-usag
 
 ## 4. Contribution Process
 
-1. **Fork this repository** and create a branch for your work:
+1. **Create a branch** in this repository for your work. CLA-signed members have write access and should commit directly to a branch here, not a fork. This ensures GitHub Actions checks (PDF builds, PR status syncs) run on your PR, since repository secrets are not exposed to workflows triggered from forks.
+
 ```bash
-git checkout -b feature/your-change-description
+git checkout -b <issue-number>-<short-description>
 ```
 
-> For further details on how to work with Git and GitHub, refer to the [GitHub Guidelines](guidelines/contributors/github-guidelines.md).
+> External contributors without write access may fork the repository instead. For branch naming conventions and further details on working with Git and GitHub, refer to the [GitHub Guidelines](guidelines/contributors/github-guidelines.md).
 
 2. **Reference existing issues** or create a new one to track your change. Include the issue number in your PR title or description (e.g., Fixes #845).
 

--- a/guidelines/contributors/development-processes.md
+++ b/guidelines/contributors/development-processes.md
@@ -211,17 +211,14 @@ Each Task Force (TF) group in the FOCUS Working Group is able to have a Maintain
 
 ### Branch Management
 
-Members of the FOCUS project need to be aware that all branches in the [FOCUS\_Spec](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec) repository are owned by the project and that frequent cleanups of stale branches will be performed by the \`Admins\`. This means that any scratch/WIP/ideation work which is not part of any open Action Items/Feature Requests should be moved out to a [fork of the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) in the individual members own GitHub repository.
+Members of the FOCUS project need to be aware that all branches in the [FOCUS\_Spec](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec) repository are owned by the project and that frequent cleanups of stale branches will be performed by the \`Admins\`. This means that any scratch/WIP/ideation work which is not part of any open Action Items/Feature Requests should be moved out to a [fork of the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) in the individual members own GitHub repository. Work tied to an open Action Item or Feature Request should use an internal branch, since GitHub Actions workflows triggered by forks do not have access to repository secrets (required for PDF builds and PR status syncs).
 
 When Pull Requests are merged the option to delete the working branch should always be used, with a preference for a new branch to be created for further work.
 
 
 ### Branch Naming
 
-As members of FOCUS you are able to open branches in the GitHub repository. The naming convention of branches must follow one of the following patterns:
-
-1. Start with your name (e.g., flanakin/skuterm)
-2. Start with the Feature Request number (e.g., 636-clarify-guidance-around-refunds)
+As members of FOCUS you are able to open branches in the GitHub repository. Branch names must start with the issue number followed by a short description (e.g., \`636-clarify-guidance-around-refunds\`).
 
 Branches not following this naming convention may be closed without notice.
 

--- a/guidelines/contributors/github-guidelines.md
+++ b/guidelines/contributors/github-guidelines.md
@@ -697,7 +697,7 @@ Here's a comprehensive guide for submitting a Pull Request using GitHub Desktop 
 2. Select your repository from the dropdown
 3. Click "Current branch" at the top
 4. Click "New branch"
-5. Name your branch descriptively (e.g., Start with your name (e.g., `flanakin/skuterm`);  Start with the Work Item number (e.g., `636-clarify-guidance-around-refunds`)
+5. Name your branch starting with the issue number followed by a short description (e.g., `636-clarify-guidance-around-refunds`)
 6. Click "Create branch"
 
 ### 2. Make Your Changes (VSCode)


### PR DESCRIPTION
## Summary

Updates `CONTRIBUTING.md` section 4 to make the branch-based workflow the primary contribution path for CLA-signed members, with forking noted as the alternative for external contributors without write access. Also aligns `guidelines/contributors/development-processes.md` and `guidelines/contributors/github-guidelines.md` so the three documents are consistent.

The fork-based instruction at CONTRIBUTING.md line 60 was a holdover from before CLA-signed members had write access. It also causes functional problems: GitHub Actions does not expose repository secrets to workflows triggered by fork PRs, so automation checks (PDF builds, PR status syncs) fail on fork-based PRs.

## Files Changed

| File | Change |
|------|--------|
| `CONTRIBUTING.md` | Section 4 inverted from fork-based to branch-based workflow; branch naming example updated; external-contributor path preserved. |
| `guidelines/contributors/development-processes.md` | Branch Naming: removed `flanakin/skuterm` pattern. Branch Management: added CI-secrets rationale for PR-tied work. |
| `guidelines/contributors/github-guidelines.md` | Step-by-step branch creation walkthrough updated to use the issue-number pattern. |

Closes #2089.

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.

## Change Log

**April 21 (c)** -- Closed the loop on `github-guidelines.md:700` (commit 9f5b24b6): removed the `flanakin/skuterm` personal-name pattern from the step-by-step branch creation walkthrough so the example matches the new single-pattern convention.

**April 21 (b)** -- Addressed @shawnalpay review feedback by aligning `development-processes.md` with CONTRIBUTING.md (commit 434cf3f5): removed the `flanakin/skuterm` personal-name pattern from Branch Naming, and added a sentence in Branch Management stating that PR-tied work should use an internal branch since fork-triggered workflows do not have access to repository secrets. Consolidated Shawn's Branch Management and Pull Requests asks into a single sentence rather than repeating the rationale in both sections.

**April 21 (a)** -- Initial draft (commit 15ae722a). Inverted CONTRIBUTING.md section 4 from fork-based to branch-based workflow for CLA-signed members, with the GitHub Actions rationale inline. Updated the branch name example from `feature/your-change-description` to `<issue-number>-<short-description>`. Preserved forking as the documented alternative for external contributors without write access.
