### PR TITLE
AI #2097: Add missing Dataset row to Content Constraints tables for Invoice Detail, Billing Period, and Cost and Usage

### DIFF
--- a/specification/datasets/billing_period/columns/billingperiodcreated.md
+++ b/specification/datasets/billing_period/columns/billingperiodcreated.md
@@ -27,6 +27,7 @@ The timestamp when the *Billing Period* record was first created.
 
 |    Constraint   |              Value              |
 |:----------------|:--------------------------------|
+| Dataset         | [Billing Period](#datasets.billingperiod)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |

--- a/specification/datasets/billing_period/columns/billingperiodend.md
+++ b/specification/datasets/billing_period/columns/billingperiodend.md
@@ -27,6 +27,7 @@ The *exclusive end bound* of a *billing period*.
 
 | Constraint      | Value                                |
 |:----------------|:-------------------------------------|
+| Dataset         | [Billing Period](#datasets.billingperiod)             |
 | Column type     | Dimension                            |
 | Feature level   | Mandatory                            |
 | Allows nulls    | False                                |

--- a/specification/datasets/billing_period/columns/billingperiodlastupdated.md
+++ b/specification/datasets/billing_period/columns/billingperiodlastupdated.md
@@ -28,6 +28,7 @@ The timestamp when the Billing Period record was last updated.
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Billing Period](#datasets.billingperiod)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |

--- a/specification/datasets/billing_period/columns/billingperiodstart.md
+++ b/specification/datasets/billing_period/columns/billingperiodstart.md
@@ -27,6 +27,7 @@ The *inclusive start bound* of a *billing period*.
 
 | Constraint      | Value                                |
 |:----------------|:-------------------------------------|
+| Dataset         | [Billing Period](#datasets.billingperiod)             |
 | Column type     | Dimension                            |
 | Feature level   | Mandatory                            |
 | Allows nulls    | False                                |

--- a/specification/datasets/billing_period/columns/billingperiodstatus.md
+++ b/specification/datasets/billing_period/columns/billingperiodstatus.md
@@ -51,6 +51,7 @@ The state of the billing period (i.e., "Open" or "Closed"), indicating whether t
 
 | Constraint    | Value                               |
 | :------------ | :---------------------------------- |
+| Dataset         | [Billing Period](#datasets.billingperiod)             |
 | Column type   | Dimension                           |
 | Feature level | Mandatory                           |
 | Allows nulls  | False                               |

--- a/specification/datasets/billing_period/columns/invoiceissuername.md
+++ b/specification/datasets/billing_period/columns/invoiceissuername.md
@@ -29,6 +29,7 @@ The name of the entity responsible for invoicing for the *resources* or *service
 
 | Constraint      | Value           |
 |:----------------|:----------------|
+| Dataset         | [Billing Period](#datasets.billingperiod)             |
 | Column type     | Dimension       |
 | Feature level   | Mandatory       |
 | Allows nulls    | False           |

--- a/specification/datasets/cost_and_usage/columns/invoicedetailid.md
+++ b/specification/datasets/cost_and_usage/columns/invoicedetailid.md
@@ -30,6 +30,7 @@ The invoice-issuer-assigned identifier for an Invoice Detail record encapsulatin
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Cost and Usage](#datasets.costandusage)             |
 | Column type     | Dimension                       |
 | Feature level   | Conditional                     |
 | Allows nulls    | True                            |

--- a/specification/datasets/invoice_detail/columns/billedcost.md
+++ b/specification/datasets/invoice_detail/columns/billedcost.md
@@ -47,6 +47,7 @@ Cost of a *charge* as invoiced by the [*invoice issuer*](#glossary:invoice-issue
 
 | Constraint | Value |
 | :--- | :--- |
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type | Metric |
 | Feature level | Mandatory |
 | Allows nulls | False |

--- a/specification/datasets/invoice_detail/columns/billingaccountid.md
+++ b/specification/datasets/invoice_detail/columns/billingaccountid.md
@@ -30,6 +30,7 @@ The identifier assigned to a *billing account* by the invoice issuer.
 
 |    Constraint   |      Value       |
 |:----------------|:-----------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension        |
 | Feature level   | Mandatory        |
 | Allows nulls    | False            |

--- a/specification/datasets/invoice_detail/columns/billingcurrency.md
+++ b/specification/datasets/invoice_detail/columns/billingcurrency.md
@@ -29,6 +29,7 @@ Represents the currency that a *charge* was billed in.
 
 | Constraint      | Value                               |
 |:----------------|:------------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                           |
 | Feature level   | Mandatory                           |
 | Allows nulls    | False                               |

--- a/specification/datasets/invoice_detail/columns/billingperiodend.md
+++ b/specification/datasets/invoice_detail/columns/billingperiodend.md
@@ -28,6 +28,7 @@ The *exclusive end bound* of a *billing period*.
 
 | Constraint      | Value                                |
 |:----------------|:-------------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                            |
 | Feature level   | Mandatory                            |
 | Allows nulls    | False                                |

--- a/specification/datasets/invoice_detail/columns/billingperiodstart.md
+++ b/specification/datasets/invoice_detail/columns/billingperiodstart.md
@@ -28,6 +28,7 @@ The *inclusive start bound* of a *billing period*.
 
 | Constraint      | Value                                |
 |:----------------|:-------------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                            |
 | Feature level   | Mandatory                            |
 | Allows nulls    | False                                |

--- a/specification/datasets/invoice_detail/columns/chargecategory.md
+++ b/specification/datasets/invoice_detail/columns/chargecategory.md
@@ -37,6 +37,7 @@ Represents the highest-level classification of a *charge* based on the nature of
 
 | Constraint      | Value          |
 | :-------------- | :------------- |
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension      |
 | Feature level   | Mandatory      |
 | Allows nulls    | False          |

--- a/specification/datasets/invoice_detail/columns/invoicedetailcreated.md
+++ b/specification/datasets/invoice_detail/columns/invoicedetailcreated.md
@@ -28,6 +28,7 @@ The timestamp when the Invoice Detail record was first created.
 
 |    Constraint    |              Value              |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |

--- a/specification/datasets/invoice_detail/columns/invoicedetaildescription.md
+++ b/specification/datasets/invoice_detail/columns/invoicedetaildescription.md
@@ -28,6 +28,7 @@ The invoice-issuer-provided description of an invoice line item.
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | True                            |

--- a/specification/datasets/invoice_detail/columns/invoicedetailgrain.md
+++ b/specification/datasets/invoice_detail/columns/invoicedetailgrain.md
@@ -46,6 +46,7 @@ The set of key-value pairs that defines the granularity of the invoice line item
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | True                            |

--- a/specification/datasets/invoice_detail/columns/invoicedetailid.md
+++ b/specification/datasets/invoice_detail/columns/invoicedetailid.md
@@ -27,6 +27,7 @@ The invoice-issuer-assigned identifier for an Invoice Detail record encapsulatin
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |

--- a/specification/datasets/invoice_detail/columns/invoicedetaillastupdated.md
+++ b/specification/datasets/invoice_detail/columns/invoicedetaillastupdated.md
@@ -28,6 +28,7 @@ The timestamp when the Invoice Detail record was last updated.
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |

--- a/specification/datasets/invoice_detail/columns/invoiceid.md
+++ b/specification/datasets/invoice_detail/columns/invoiceid.md
@@ -28,6 +28,7 @@ The invoice-issuer-assigned identifier for an invoice encapsulating *charges* in
 
 |    Constraint   |      Value       |
 |:----------------|:-----------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension        |
 | Feature level   | Mandatory        |
 | Allows nulls    | False            |

--- a/specification/datasets/invoice_detail/columns/invoiceissuedate.md
+++ b/specification/datasets/invoice_detail/columns/invoiceissuedate.md
@@ -27,6 +27,7 @@ The date the invoice was issued by the invoice issuer.
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | True                            |

--- a/specification/datasets/invoice_detail/columns/invoiceissuername.md
+++ b/specification/datasets/invoice_detail/columns/invoiceissuername.md
@@ -29,6 +29,7 @@ The name of the entity responsible for invoicing for the *resources* or *service
 
 | Constraint      | Value           |
 |:----------------|:----------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension       |
 | Feature level   | Mandatory       |
 | Allows nulls    | False           |

--- a/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
+++ b/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
@@ -49,6 +49,7 @@ The publication state of the invoice and the reliability of its associated deliv
 
 |    Constraint   |              Value              |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |

--- a/specification/datasets/invoice_detail/columns/paymentcurrency.md
+++ b/specification/datasets/invoice_detail/columns/paymentcurrency.md
@@ -28,6 +28,7 @@ The currency in which the invoice is paid.
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Conditional                     |
 | Allows nulls    | False                           |

--- a/specification/datasets/invoice_detail/columns/paymentcurrencybilledcost.md
+++ b/specification/datasets/invoice_detail/columns/paymentcurrencybilledcost.md
@@ -74,6 +74,7 @@ The [Billed Cost](#datasets.invoicedetail.billedcost) as expressed in [Payment C
 
 |    Constraint   |      Value              |
 |:----------------|:------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Metric                  |
 | Feature level   | Conditional             |
 | Allows nulls    | False                   |

--- a/specification/datasets/invoice_detail/columns/paymentcurrencyinvoicedetailid.md
+++ b/specification/datasets/invoice_detail/columns/paymentcurrencyinvoicedetailid.md
@@ -28,6 +28,7 @@ The identifier linking a granular record to the specific [Invoice Detail](#datas
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Conditional                     |
 | Allows nulls    | False                           |

--- a/specification/datasets/invoice_detail/columns/paymentduedate.md
+++ b/specification/datasets/invoice_detail/columns/paymentduedate.md
@@ -27,6 +27,7 @@ The date by which the payment for an invoice is expected to be received by the i
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | True                            |

--- a/specification/datasets/invoice_detail/columns/paymentterms.md
+++ b/specification/datasets/invoice_detail/columns/paymentterms.md
@@ -27,6 +27,7 @@ The terms (typically focused on timeframe) by which the invoice issuer expects t
 
 |    Constraint   |              Value              |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |

--- a/specification/datasets/invoice_detail/columns/purchaseordernumber.md
+++ b/specification/datasets/invoice_detail/columns/purchaseordernumber.md
@@ -27,6 +27,7 @@ The unique customer-issued identifier for tracking the lifecycle of a purchase.
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Conditional                     |
 | Allows nulls    | True                            |

--- a/specification/datasets/invoice_detail/columns/referenceinvoiceid.md
+++ b/specification/datasets/invoice_detail/columns/referenceinvoiceid.md
@@ -28,6 +28,7 @@ The invoice-issuer-assigned identifier for an invoice that affects charges as st
 
 |    Constraint    |              Value             |
 |:----------------|:--------------------------------|
+| Dataset         | [Invoice Detail](#datasets.invoicedetail)             |
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |


### PR DESCRIPTION
## Summary

Closes #2097.

Adds the missing `Dataset` row as the first entry in the `## Content Constraints` table for all column files in the **Billing Period** and **Invoice Detail** datasets. This matches the pattern already established in Cost and Usage and Contract Commitment column files.

**No other content changes.**

### Affected files (29)

**Billing Period (6):**
* `billingperiodcreated.md`
* `billingperiodend.md`
* `billingperiodlastupdated.md`
* `billingperiodstart.md`
* `billingperiodstatus.md`
* `invoiceissuername.md`

**Invoice Detail (22):**
* `billedcost.md`
* `billingaccountid.md`
* `billingcurrency.md`
* `billingperiodend.md`
* `billingperiodstart.md`
* `chargecategory.md`
* `invoicedetailcreated.md`
* `invoicedetaildescription.md`
* `invoicedetailgrain.md`
* `invoicedetailid.md`
* `invoicedetaillastupdated.md`
* `invoiceid.md`
* `invoiceissuedate.md`
* `invoiceissuername.md`
* `invoiceissuestatus.md`
* `paymentcurrency.md`
* `paymentcurrencybilledcost.md`
* `paymentcurrencyinvoicedetailid.md`
* `paymentduedate.md`
* `paymentterms.md`
* `purchaseordernumber.md`
* `referenceinvoiceid.md`

**Cost and Usage (1):**
* `invoicedetailid.md`

### Type of Change
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.

## Test plan

* [x] All 29 files have `Dataset` as the first row in `## Content Constraints`
* [x] Billing Period files link to `[Billing Period](#datasets.billingperiod)`
* [x] Invoice Detail files link to `[Invoice Detail](#datasets.invoicedetail)`
* [x] No other content modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)