### PR TITLE
AI #2309 (ext. 2283): Improve column heading structure and ordering in CommitmentProgramEligibilityDetails

### DIFF
--- a/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
@@ -4,8 +4,6 @@ Commitment Program Eligibility Details identifies the [*commitment programs*](#g
 
 ## Requirements
 
-### Column Requirements
-
 CommitmentProgramEligibilityDetails MUST adhere to the following requirements:
 
 * CommitmentProgramEligibilityDetails MUST be of type JSON Object (serialized as a String where necessary).
@@ -22,7 +20,7 @@ CommitmentProgramEligibilityDetails MUST adhere to the following requirements:
 
 Commitment Program Eligibility Details consists of a valid JSON object with a top-level property key `CommitmentPrograms` containing an array of objects describing the specific [*commitment programs*](#glossary:commitment-program) available for the usage charge.
 
-### Object Requirements
+## Object Requirements
 
 CommitmentProgramEligibilityDetailsObject MUST adhere to the following requirements:
 
@@ -31,7 +29,7 @@ CommitmentProgramEligibilityDetailsObject MUST adhere to the following requireme
 * CommitmentProgramEligibilityDetailsObject.CommitmentPrograms[\*].ProgramType MUST equal [CommitmentDiscountType](#datasets.costandusage.commitmentdiscounttype) for one object in CommitmentProgramEligibilityDetailsObject.CommitmentPrograms when CommitmentDiscountType is not null.
 * CommitmentProgramEligibilityDetailsObject.CommitmentPrograms[\*].ProgramType SHOULD correspond to terminology disclosed by the service provider in public documentation.
 
-## Schema Structure
+## Object Schema Structure
 
 ### Top-Level Properties
 
@@ -46,6 +44,12 @@ The `CommitmentPrograms` array contains one or more objects, each of which conta
 | Key         | ValueType                            | Required | Description                                                                                                |
 |:-------------|:-------------|:-------------|:------------------------------|
 | ProgramType | [String](#attributes.stringhandling) | True     | The specific type of commitment program (e.g., discount or capacity reservation) available for this usage. |
+
+## Object Implementation Guidance
+
+### Custom Properties
+
+To facilitate querying data across allocations and across service providers, a data generator may include one or more custom properties. These may be placed at the top level of the object (alongside `CommitmentPrograms`) or nested within the individual `CommitmentPrograms` objects. Custom keys must be prefixed with "x_" followed by PascalCase format (e.g., `x_MyCustomKey`) to make them easy to identify as well as prevent collisions with FOCUS-defined keys.
 
 ## Object Example
 
@@ -65,17 +69,11 @@ Here is a basic example of the object format.
 }
 ```
 
-## Implementation Guidance
-
-### Custom Properties
-
-To facilitate querying data across allocations and across service providers, a data generator may include one or more custom properties. These may be placed at the top level of the object (alongside `CommitmentPrograms`) or nested within the individual `CommitmentPrograms` objects. Custom keys must be prefixed with "x_" followed by PascalCase format (e.g., `x_MyCustomKey`) to make them easy to identify as well as prevent collisions with FOCUS-defined keys.
-
-### Object ID
+## Object ID
 
 CommitmentProgramEligibilityDetailsObject
 
-### Object Display Name
+## Object Display Name
 
 Commitment Program Eligibility Details Object
 

--- a/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
@@ -33,13 +33,13 @@ CommitmentProgramEligibilityDetailsObject MUST adhere to the following requireme
 
 ### Object Schema Structure
 
-<div class="h6-nonindex">Top-Level Properties</div>
+<div class="h7-nonindex">Top-Level Properties</div>
 
 | Property             | Type  | Required | Description                                                                         |
 |:----------|:----------|:----------|:---------------------------------------|
 | `CommitmentPrograms` | Array | True     | Array of objects identifying *commitment programs* for which the usage is eligible. |
 
-<div class="h6-nonindex">CommitmentPrograms Object</div>
+<div class="h7-nonindex">CommitmentPrograms Object</div>
 
 The `CommitmentPrograms` array contains one or more objects, each of which contains the following entries:
 
@@ -49,7 +49,7 @@ The `CommitmentPrograms` array contains one or more objects, each of which conta
 
 ### Object Implementation Guidance
 
-<div class="h6-nonindex">Custom Properties</div>
+<div class="h7-nonindex">Custom Properties</div>
 
 To facilitate querying data across allocations and across service providers, a data generator may include one or more custom properties. These may be placed at the top level of the object (alongside `CommitmentPrograms`) or nested within the individual `CommitmentPrograms` objects. Custom keys must be prefixed with "x_" followed by PascalCase format (e.g., `x_MyCustomKey`) to make them easy to identify as well as prevent collisions with FOCUS-defined keys.
 

--- a/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
@@ -4,6 +4,8 @@ Commitment Program Eligibility Details identifies the [*commitment programs*](#g
 
 ## Requirements
 
+### Column Requirements
+
 CommitmentProgramEligibilityDetails MUST adhere to the following requirements:
 
 * CommitmentProgramEligibilityDetails MUST be of type JSON Object (serialized as a String where necessary).
@@ -20,7 +22,7 @@ CommitmentProgramEligibilityDetails MUST adhere to the following requirements:
 
 Commitment Program Eligibility Details consists of a valid JSON object with a top-level property key `CommitmentPrograms` containing an array of objects describing the specific [*commitment programs*](#glossary:commitment-program) available for the usage charge.
 
-## Object Requirements
+### Object Requirements
 
 CommitmentProgramEligibilityDetailsObject MUST adhere to the following requirements:
 
@@ -29,15 +31,15 @@ CommitmentProgramEligibilityDetailsObject MUST adhere to the following requireme
 * CommitmentProgramEligibilityDetailsObject.CommitmentPrograms[\*].ProgramType MUST equal [CommitmentDiscountType](#datasets.costandusage.commitmentdiscounttype) for one object in CommitmentProgramEligibilityDetailsObject.CommitmentPrograms when CommitmentDiscountType is not null.
 * CommitmentProgramEligibilityDetailsObject.CommitmentPrograms[\*].ProgramType SHOULD correspond to terminology disclosed by the service provider in public documentation.
 
-## Object Schema Structure
+### Object Schema Structure
 
-### Top-Level Properties
+<div class="h6-nonindex">Top-Level Properties</div>
 
 | Property             | Type  | Required | Description                                                                         |
 |:----------|:----------|:----------|:---------------------------------------|
 | `CommitmentPrograms` | Array | True     | Array of objects identifying *commitment programs* for which the usage is eligible. |
 
-### CommitmentPrograms Object
+<div class="h6-nonindex">CommitmentPrograms Object</div>
 
 The `CommitmentPrograms` array contains one or more objects, each of which contains the following entries:
 
@@ -45,13 +47,13 @@ The `CommitmentPrograms` array contains one or more objects, each of which conta
 |:-------------|:-------------|:-------------|:------------------------------|
 | ProgramType | [String](#attributes.stringhandling) | True     | The specific type of commitment program (e.g., discount or capacity reservation) available for this usage. |
 
-## Object Implementation Guidance
+### Object Implementation Guidance
 
-### Custom Properties
+<div class="h6-nonindex">Custom Properties</div>
 
 To facilitate querying data across allocations and across service providers, a data generator may include one or more custom properties. These may be placed at the top level of the object (alongside `CommitmentPrograms`) or nested within the individual `CommitmentPrograms` objects. Custom keys must be prefixed with "x_" followed by PascalCase format (e.g., `x_MyCustomKey`) to make them easy to identify as well as prevent collisions with FOCUS-defined keys.
 
-## Object Example
+### Object Example
 
 Here is a basic example of the object format.
 
@@ -69,11 +71,11 @@ Here is a basic example of the object format.
 }
 ```
 
-## Object ID
+### Object ID
 
 CommitmentProgramEligibilityDetailsObject
 
-## Object Display Name
+### Object Display Name
 
 Commitment Program Eligibility Details Object
 


### PR DESCRIPTION
## Summary

This PR extends #2283 by applying the column heading structure standardization introduced in #2309. CommitmentProgramEligibilityDetails was intentionally excluded from #2309, as the column refactoring performed in #2283 was a prerequisite.

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
