### PR TITLE
AI #2313: Sync supported features overview with 1.4 features and alphabetize INCLUDEs

### DIFF
--- a/specification/supported_features/supported_features.mdpp
+++ b/specification/supported_features/supported_features.mdpp
@@ -15,10 +15,10 @@
 !INCLUDE "invoice_reconciliation.md",1
 !INCLUDE "location.md",1
 !INCLUDE "marketplace_purchases.md",1
+!INCLUDE "participating_entity_identification.md",1
 !INCLUDE "recency_metadata.md",1
 !INCLUDE "resource_usage.md",1
 !INCLUDE "schema_metadata.md",1
-!INCLUDE "service_provider_services.md",1
 !INCLUDE "service_categorization.md",1
-!INCLUDE "participating_entity_identification.md",1
+!INCLUDE "service_provider_services.md",1
 !INCLUDE "verify_compare_track_unit_prices.md",1

--- a/specification/supported_features/supported_features_overview.md
+++ b/specification/supported_features/supported_features_overview.md
@@ -10,6 +10,7 @@ The FOCUS specification is designed to meet the needs of FinOps practitioners in
 | [Billed Cost and Invoice Alignment](#supportedfeatures.billedcostandinvoicealignment) | Ensures data is consistent with payable invoices regarding total cost and the period of time covered. |
 | [Charge Categorization](#supportedfeatures.chargecategorization) | Supports classification of charges including purchases, usage, tax, credits, and adjustments. |
 | [Commit Usage and Under Usage](#supportedfeatures.commitusageandunderusage) | Tracks the usage and under-usage of commitment discounts and capacity reservations. |
+| [Commitment Program Eligibility Details](#supportedfeatures.commitmentprogrameligibilitydetails) | Identifies which commitment programs each charge qualifies for, supporting coverage rate analysis and uncovered savings identification. |
 | [Contract Commitments](#supportedfeatures.contractcommitments) | Tracks commitments made via contractual agreements using identifiers joined between Cost and Usage and Contract Commitment datasets. |
 | [Cost and Usage Attribution](#supportedfeatures.costandusageattribution) | Facilitates the inclusion of provider-defined or user-defined metadata (tags) at a row level for organizational analysis. |
 | [Cost Comparison](#supportedfeatures.costcomparison) | Supports comparing Billed, Contracted, Effective, and List cost columns to identify savings or amortization. |
@@ -18,6 +19,7 @@ The FOCUS specification is designed to meet the needs of FinOps practitioners in
 | [Data Granularity](#supportedfeatures.datagranularity) | Supports multiple levels of granularity, from high-level account charges down to individual resource-level data. |
 | [Dataset Instance Metadata](#supportedfeatures.datasetinstancemetadata) | Provides metadata describing dataset artifacts, unique identifiers, and alignment with specific FOCUS datasets. |
 | [Effective Cost Analysis](#supportedfeatures.effectivecostanalysis) | Enables analysis of costs after discounts and the amortization of upfront fees to track spending trends. |
+| [Invoice Reconciliation](#supportedfeatures.invoicereconciliation) | Reconciles Cost and Usage records with Invoice Detail line items to validate that usage costs map back to invoiced amounts. |
 | [Location](#supportedfeatures.location) | Provides structured data for regions and availability zones to analyze costs based on deployment geography. |
 | [Marketplace Purchases](#supportedfeatures.marketplacepurchases) | Supports analysis of marketplace purchase data and reporting Effective Cost for service provider usage. |
 | [Participating Entity Identification](#supportedfeatures.participatingentityidentification) | Allows identification of entities involved in hosting, invoicing, and data generation (e.g., Service Provider vs. Host Provider). |


### PR DESCRIPTION
## Summary

Closes #2313. Two editorial consistency fixes in `specification/supported_features/`, surfaced during the 1.4 consistency review (#1878):

* Add rows for **Commitment Program Eligibility Details** and **Invoice Reconciliation** to the Supported Feature List table in `supported_features_overview.md`. Both features were added in 1.4 and already render in the spec body via `supported_features.mdpp`, but were missing from the overview index. Both anchor IDs (`#supportedfeatures.commitmentprogrameligibilitydetails`, `#supportedfeatures.invoicereconciliation`) are already referenced from elsewhere in the spec.
* Re-sort `supported_features.mdpp` lines 17–24 into alphabetical order. `participating_entity_identification.md` was at the bottom of the file rather than after `marketplace_purchases.md`, and `service_provider_services.md` preceded `service_categorization.md`. Lines 1–16 were already correct.

No normative content changes — purely table additions and INCLUDE reordering.

### Related

* Closes #2313
* Sub-issue of #1878 (1.4 consistency review)

### Test Plan

* `grep -c '^| \[' specification/supported_features/supported_features_overview.md` returned 23, matching the 23 feature `!INCLUDE` lines in `supported_features.mdpp`.
* Lines 2–24 of `supported_features.mdpp` confirmed alphabetical (verified via `diff` against `sort`-ed output, no diff).
* `python3 specification/validate_includes.py supported_features` passed.
* `pymarkdownlnt --config markdownlnt.cfg scan supported_features/supported_features_overview.md` (from `specification/`) returned no findings.

`make` was not run locally (`markdown-pp` not installed in this environment); GitHub Actions exercises the full build.

### Type of Change

* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist

* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** N/A (no examples added or modified).
