### PR TITLE
AI #2316: Add h7-nonindex support to stylesheet

### DIFF
--- a/specification/styles/base.css
+++ b/specification/styles/base.css
@@ -120,6 +120,7 @@ ul.toc.tocdepth2 li.toc.item a {
   color: #111;
   line-height: 125%;
   margin-top: 2em;
+  margin-bottom: 1em;
 }
 
 .h3-nonindex {
@@ -128,6 +129,7 @@ ul.toc.tocdepth2 li.toc.item a {
   color: #111;
   line-height: 125%;
   margin-top: 2em;
+  margin-bottom: 1em;
 }
 
 .h4-nonindex {
@@ -136,6 +138,7 @@ ul.toc.tocdepth2 li.toc.item a {
   color: #111;
   line-height: 125%;
   margin-top: 2em;
+  margin-bottom: 1em;
 }
 
 .h5-nonindex {
@@ -144,6 +147,7 @@ ul.toc.tocdepth2 li.toc.item a {
   color: #111;
   line-height: 125%;
   margin-top: 2em;
+  margin-bottom: 1em;
 }
 
 .h6-nonindex {
@@ -152,6 +156,16 @@ ul.toc.tocdepth2 li.toc.item a {
   color: #111;
   line-height: 125%;
   margin-top: 2em;
+  margin-bottom: 1em;
+}
+
+.h7-nonindex {
+  font-size: 1em;
+  font-weight: bold;
+  color: #111;
+  line-height: 125%;
+  margin-top: 2em;
+  margin-bottom: 1em;
 }
 
 /* Code styling with explicit font family for cross-platform consistency */


### PR DESCRIPTION
Signed-off-by: Mike Fuller <mike@finops.org>

## Summary

Added h7-noindex support and some bottom padding to the no index styles to allow for better document structure. 

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [X] Editorial / Formatting

### Author Checklist
* [X] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [X] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [X] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
