### PR TITLE
AI #2320: Address remaining Content Constraints inconsistencies

### DIFF
--- a/specification/datasets/contract_commitment/columns/contractcommitmentapplicability.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentapplicability.md
@@ -174,7 +174,7 @@ A structured definition of the specific entities to which a contract commitment 
 | Constraint | Value |
 | :--- | :--- |
 | Dataset | [Contract Commitment](#datasets.contractcommitment) |
-| Column type | Dimension |
+| Column type | Dimension / Metric |
 | Feature level | Mandatory |
 | Allows nulls | False |
 | Data type | JSON |

--- a/specification/datasets/contract_commitment/columns/contractcommitmentdiscountpercentage.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentdiscountpercentage.md
@@ -61,7 +61,7 @@ The effective percentage reduction applied to the list price of resources or ser
 | Constraint      | Value          |
 | :-------------- | :------------- |
 | Dataset         | [Contract Commitment](#datasets.contractcommitment)  |
-| Column type     | Dimension      |
+| Column type     | Metric         |
 | Feature level   | Mandatory      |
 | Allows nulls    | True           |
 | Data type       | Decimal        |

--- a/specification/datasets/contract_commitment/columns/contractcommitmentdurationtype.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentdurationtype.md
@@ -65,7 +65,7 @@ Represents the categorical length of the [*contract commitment*](#glossary:contr
 | Feature level   | Mandatory      |
 | Allows nulls    | False          |
 | Data type       | String         |
-| Value format    | Expected format |
+| Value format    | [Expected format](#datasets.contractcommitment.contractcommitmentdurationtype.expectedformat) |
 
 ## Introduced (version)
 

--- a/specification/datasets/contract_commitment/columns/contractcommitmentpaymentupfrontpercentage.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentpaymentupfrontpercentage.md
@@ -32,12 +32,12 @@ Represents the portion of the total [Contract Commitment Cost](#datasets.contrac
 
 | Constraint    | Value            |
 | :------------ | :--------------- |
-| Dataset         | [Contract Commitment](#datasets.contractcommitment)  |
-| Column type   | Dimension        |
+| Dataset       | [Contract Commitment](#datasets.contractcommitment) |
+| Column type   | Metric           |
 | Feature level | Conditional      |
 | Allows nulls  | False            |
 | Data type     | Decimal          |
-| Value format  | [Numeric Format](#attributes.numericformat)  |
+| Value format  | [Numeric Format](#attributes.numericformat) |
 | Number range  | 0.0 to 1.0 (inclusive)            |
 
 ## Introduced (version)

--- a/specification/datasets/contract_commitment/dataset.md
+++ b/specification/datasets/contract_commitment/dataset.md
@@ -13,7 +13,7 @@ The Contract Commitment dataset is a supporting dataset that describes the terms
 | [Contract Commitment Cost](#datasets.contractcommitment.contractcommitmentcost) | Metric | Mandatory | True | Decimal |
 | [Contract Commitment Created](#datasets.contractcommitment.contractcommitmentcreated) | Dimension | Mandatory | False | Date/Time |
 | [Contract Commitment Description](#datasets.contractcommitment.contractcommitmentdescription) | Dimension | Mandatory | True | String |
-| [Contract Commitment Discount Percentage](#datasets.contractcommitment.contractcommitmentdiscountpercentage) | Dimension | Mandatory | True | Decimal |
+| [Contract Commitment Discount Percentage](#datasets.contractcommitment.contractcommitmentdiscountpercentage) | Metric | Mandatory | True | Decimal |
 | [Contract Commitment Duration Type](#datasets.contractcommitment.contractcommitmentdurationtype) | Dimension | Mandatory | False | String |
 | [Contract Commitment Fulfillment Interval](#datasets.contractcommitment.contractcommitmentfulfillmentinterval) | Dimension | Mandatory | False | String |
 | [Contract Commitment ID](#datasets.contractcommitment.contractcommitmentid) | Dimension | Mandatory | False | String |
@@ -23,7 +23,7 @@ The Contract Commitment dataset is a supporting dataset that describes the terms
 | [Contract Commitment Offer Category](#datasets.contractcommitment.contractcommitmentoffercategory) | Dimension | Mandatory | False | String |
 | [Contract Commitment Payment Interval](#datasets.contractcommitment.contractcommitmentpaymentinterval) | Dimension | Mandatory | False | String |
 | [Contract Commitment Payment Model](#datasets.contractcommitment.contractcommitmentpaymentmodel) | Dimension | Mandatory | False | String |
-| [Contract Commitment Payment Upfront Percentage](#datasets.contractcommitment.contractcommitmentpaymentupfrontpercentage) | Dimension | Conditional | False | Decimal |
+| [Contract Commitment Payment Upfront Percentage](#datasets.contractcommitment.contractcommitmentpaymentupfrontpercentage) | Metric | Conditional | False | Decimal |
 | [Contract Commitment Period End](#datasets.contractcommitment.contractcommitmentperiodend) | Dimension | Mandatory | False | Date/Time |
 | [Contract Commitment Period Start](#datasets.contractcommitment.contractcommitmentperiodstart) | Dimension | Mandatory | False | Date/Time |
 | [Contract Commitment Quantity](#datasets.contractcommitment.contractcommitmentquantity) | Metric | Mandatory | True | Decimal |

--- a/specification/datasets/contract_commitment/dataset.md
+++ b/specification/datasets/contract_commitment/dataset.md
@@ -7,7 +7,7 @@ The Contract Commitment dataset is a supporting dataset that describes the terms
 | Column | Column Type | Feature Level | Allows Nulls | Data Type |
 | :--- | :--- | :--- | :--- | :--- |
 | [Billing Currency](#datasets.contractcommitment.billingcurrency) | Dimension | Mandatory | True | String |
-| [Contract Commitment Applicability](#datasets.contractcommitment.contractcommitmentapplicability) | Dimension | Mandatory | False | JSON |
+| [Contract Commitment Applicability](#datasets.contractcommitment.contractcommitmentapplicability) | Dimension / Metric | Mandatory | False | JSON |
 | [Contract Commitment Benefit Category](#datasets.contractcommitment.contractcommitmentbenefitcategory) | Dimension | Mandatory | False | String |
 | [Contract Commitment Category](#datasets.contractcommitment.contractcommitmentcategory) | Dimension | Mandatory | False | String |
 | [Contract Commitment Cost](#datasets.contractcommitment.contractcommitmentcost) | Metric | Mandatory | True | Decimal |

--- a/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
@@ -107,7 +107,7 @@ A set of properties describing how resources are allocated in data generator-def
 | Constraint | Value |
 | :--- | :--- |
 | Dataset | [Cost and Usage](#datasets.costandusage) |
-| Column type | Dimension |
+| Column type | Dimension / Metric |
 | Feature level | Recommended |
 | Allows nulls | True |
 | Data type | JSON |

--- a/specification/datasets/cost_and_usage/columns/capacityreservationstatus.md
+++ b/specification/datasets/cost_and_usage/columns/capacityreservationstatus.md
@@ -43,7 +43,7 @@ Indicates whether the *charge* represents either the consumption of a *capacity 
 | Feature level   | Conditional                                          |
 | Allows nulls    | True                                                 |
 | Data type       | String                                               |
-| Value format    | Allowed Values                                       |
+| Value format    | Allowed values                                       |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountcategory.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountcategory.md
@@ -40,7 +40,7 @@ Indicates whether the *commitment discount* identified in the CommitmentDiscount
 | Feature level   | Conditional                                          |
 | Allows nulls    | True                                                 |
 | Data type       | String                                               |
-| Value format    | Allowed Values                                       |
+| Value format    | Allowed values                                       |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/commitmentdiscountstatus.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentdiscountstatus.md
@@ -42,7 +42,7 @@ Indicates whether the *charge* corresponds with the consumption of a *commitment
 | Feature level   | Conditional                                          |
 | Allows nulls    | True                                                 |
 | Data type       | String                                               |
-| Value format    | Allowed Values                                       |
+| Value format    | Allowed values                                       |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
@@ -209,7 +209,7 @@ The types of [*commitment programs*](#glossary:commitment-program) available for
 | Feature level | Conditional                                                                                                                  |
 | Allows nulls  | True                                                                                                                         |
 | Data type     | JSON                                                                                                                         |
-| Value format  | [JsonObjectFormat](#attributes.jsonobjectformat)                                                                             |
+| Value format  | [JSON Object Format](#attributes.jsonobjectformat)                                                                           |
 | Object        | [CommitmentProgramEligibilityDetailsObject](#datasets.costandusage.commitmentprogrameligibilitydetails.commitmentprogrameligibilitydetailsobject) |
 
 ## Introduced (version)

--- a/specification/datasets/cost_and_usage/columns/contractapplied.md
+++ b/specification/datasets/cost_and_usage/columns/contractapplied.md
@@ -115,7 +115,7 @@ A set of properties that associate a *charge* with one or more [*contract commit
 | Constraint | Value |
 | :--- | :--- |
 | Dataset | [Cost and Usage](#datasets.costandusage) |
-| Column type | Dimension and Metric |
+| Column type | Dimension / Metric |
 | Feature level | Conditional |
 | Allows nulls | True |
 | Data type | JSON |

--- a/specification/datasets/cost_and_usage/columns/servicesubcategory.md
+++ b/specification/datasets/cost_and_usage/columns/servicesubcategory.md
@@ -119,7 +119,7 @@ Secondary classification of the Service Category for a *service* based on its co
 | Feature level   | Recommended                                          |
 | Allows nulls    | False                                                |
 | Data type       | String                                               |
-| Value format    | Allowed Values                                       |
+| Value format    | Allowed values                                       |
 
 ## Introduced (version)
 

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -8,7 +8,7 @@ The specification for the Cost and Usage dataset defines a group of columns that
 
 | Column                                                                        | Column Type        | Feature Level | Allows Nulls | Data Type |
 | ----------------------------------------------------------------------------- | ------------------ | ------------- | ------------ | --------- |
-| [Allocated Method Details](#datasets.costandusage.allocatedmethoddetails)                           | Dimension          | Recommended   | True         | JSON      |
+| [Allocated Method Details](#datasets.costandusage.allocatedmethoddetails)                           | Dimension / Metric | Recommended   | True         | JSON      |
 | [Allocated Method ID](#datasets.costandusage.allocatedmethodid)                                     | Dimension          | Conditional   | True         | String    |
 | [Allocated Resource ID](#datasets.costandusage.allocatedresourceid)                                 | Dimension          | Conditional   | True         | String    |
 | [Allocated Resource Name](#datasets.costandusage.allocatedresourcename)                             | Dimension          | Conditional   | True         | String    |

--- a/specification/datasets/invoice_detail/columns/invoicedetaildescription.md
+++ b/specification/datasets/invoice_detail/columns/invoicedetaildescription.md
@@ -26,13 +26,13 @@ The invoice-issuer-provided description of an invoice line item.
 
 ## Content Constraints
 
-|    Constraint    |              Value             |
+|    Constraint   |              Value              |
 |:----------------|:--------------------------------|
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | True                            |
 | Data type       | String                          |
-| Value format    | \<unspecified>                   |
+| Value format    | \<not specified>                |
 
 ## Introduced (version)
 

--- a/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
+++ b/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
@@ -53,7 +53,7 @@ The publication state of the invoice and the reliability of its associated deliv
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |
 | Data type       | String                          |
-| Value format    | \<unspecified>                  |
+| Value format    | \<not specified>                |
 
 ## Introduced (version)
 

--- a/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
+++ b/specification/datasets/invoice_detail/columns/invoiceissuestatus.md
@@ -53,7 +53,7 @@ The publication state of the invoice and the reliability of its associated deliv
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |
 | Data type       | String                          |
-| Value format    | \<not specified>                |
+| Value format    | Allowed values                |
 
 ## Introduced (version)
 

--- a/specification/datasets/invoice_detail/columns/paymentcurrencyinvoicedetailid.md
+++ b/specification/datasets/invoice_detail/columns/paymentcurrencyinvoicedetailid.md
@@ -26,13 +26,13 @@ The identifier linking a granular record to the specific [Invoice Detail](#datas
 
 ## Content Constraints
 
-|    Constraint    |              Value             |
+|    Constraint   |              Value              |
 |:----------------|:--------------------------------|
 | Column type     | Dimension                       |
 | Feature level   | Conditional                     |
 | Allows nulls    | False                           |
 | Data type       | String                          |
-| Value format    | \<unspecified>                  |
+| Value format    | \<not specified>                |
 
 ## Introduced (version)
 

--- a/specification/datasets/invoice_detail/columns/purchaseordernumber.md
+++ b/specification/datasets/invoice_detail/columns/purchaseordernumber.md
@@ -25,13 +25,13 @@ The unique customer-issued identifier for tracking the lifecycle of a purchase.
 
 ## Content Constraints
 
-|    Constraint    |              Value             |
+|    Constraint   |              Value              |
 |:----------------|:--------------------------------|
 | Column type     | Dimension                       |
 | Feature level   | Conditional                     |
 | Allows nulls    | True                            |
 | Data type       | String                          |
-| Value format    | \<unspecified>                   |
+| Value format    | \<not specified>                |
 
 ## Introduced (version)
 

--- a/specification/datasets/invoice_detail/columns/referenceinvoiceid.md
+++ b/specification/datasets/invoice_detail/columns/referenceinvoiceid.md
@@ -26,13 +26,13 @@ The invoice-issuer-assigned identifier for an invoice that affects charges as st
 
 ## Content Constraints
 
-|    Constraint    |              Value             |
+|    Constraint   |              Value              |
 |:----------------|:--------------------------------|
 | Column type     | Dimension                       |
 | Feature level   | Mandatory                       |
 | Allows nulls    | False                           |
 | Data type       | String                          |
-| Value format    | \<unspecified>                   |
+| Value format    | \<not specified>                |
 
 ## Introduced (version)
 


### PR DESCRIPTION
## Summary

### Detailed Description

This PR addresses Content Constraints tables across all four datasets:

**Content Constraints changes:**

1. Column type: Dimension → Metric for ContractCommitmentDiscountPercentage and ContractCommitmentPaymentUpfrontPercentage
2. Value format: `\<unspecified>` → `\<not specified>` for 5 Invoice Detail columns (InvoiceDetailDescription, InvoiceIssueStatus, PaymentCurrencyInvoiceDetailId, PurchaseOrderNumber, ReferenceInvoiceId)
3. Value format: `JsonObjectFormat` → `JSON Object Format` in CommitmentProgramEligibilityDetails
4. Column type: `Dimension and Metric` → `Dimension / Metric` for ContractApplied and ContractCommitmentApplicability
5. Column type: Dimension → `Dimension / Metric` for AllocatedMethodDetails
6. Value format: `Allowed Values` → `Allowed values` for CapacityReservationStatus, CommitmentDiscountCategory, CommitmentDiscountStatus, ServiceSubCategory
7. Value format: added anchor link for `Expected format` in ContractCommitmentDurationType

**Dataset column tables:** aligned Cost and Usage and Contract Commitment dataset.md column listings with the above Content Constraints changes.

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
