### PR TITLE
AI #2056: Address Node.js 20 action deprecation

### DIFF
--- a/.github/workflows/candidate_release.yml
+++ b/.github/workflows/candidate_release.yml
@@ -12,7 +12,7 @@ jobs:
       image: pandoc/extra:latest-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
       - name: Install prequirements
         shell: bash
         run: |
@@ -33,13 +33,13 @@ jobs:
           /usr/bin/pip3 install --break-system-packages -r requirements.txt
           ./build_json.py
       - name: Upload on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ failure()}}
         with:
           name: spec.md
           path: specification/spec.md
       - name: Upload Spec
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       image: pandoc/extra:latest-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
       - name: Install prequirements
         shell: bash
         run: |
@@ -33,13 +33,13 @@ jobs:
           /usr/bin/pip3 install --break-system-packages -r requirements.txt
           ./build_json.py
       - name: Upload on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ failure()}}
         with:
           name: spec.md
           path: specification/spec.md
       - name: Upload Spec
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: FOCUS_specification
           path: |

--- a/.github/workflows/working_draft.yml
+++ b/.github/workflows/working_draft.yml
@@ -17,8 +17,8 @@ jobs:
       image: pandoc/extra:latest-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4.2.2
-        
+        uses: actions/checkout@v6
+
       - name: Install prequirements
         shell: bash
         run: |
@@ -27,29 +27,29 @@ jobs:
           DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y make zip
           DEBIAN_FRONTEND=noninteractive /usr/bin/apt install -y -f ./wkhtmltox_0.12.6.1-3.jammy_amd64.deb
           /usr/bin/pip3 install --break-system-packages -r requirements.txt
-          
+
       - name: Build PDF
         shell: bash
         working-directory: ./specification
         run: |
           make STYLE=working_draft BRANCH=${GITHUB_REF_NAME}
-          
+
       - name: Build Requirements Model JSON
         shell: bash
         working-directory: ./specification/requirements_model
         run: |
           /usr/bin/pip3 install --break-system-packages -r requirements.txt
           ./build_json.py
-          
+
       - name: Upload on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ failure() }}
         with:
           name: spec.md
           path: specification/spec.md
-          
+
       - name: Upload Spec
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: FOCUS_specification
           path: |
@@ -74,8 +74,11 @@ jobs:
         with:
           tag: "latest-draft"
           name: "Latest Working Draft"
-          body: "Automatically generated artifacts from the `working_draft` branch. For the best offline HTML experience, download the .zip bundle."
-          artifacts: "specification/spec.pdf, specification/spec.md, specification/spec.html, specification/spec_html_with_assets.zip, specification/requirements_model/build/*.json"
+          body: "Automatically generated artifacts from the `working_draft` branch. For
+            the best offline HTML experience, download the .zip bundle."
+          artifacts: "specification/spec.pdf, specification/spec.md,
+            specification/spec.html, specification/spec_html_with_assets.zip,
+            specification/requirements_model/build/*.json"
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: false


### PR DESCRIPTION
Signed-off-by: Mike Fuller <mike@finops.org>

## Summary

Update GitHub workflows to avoid Node.js 20 actions deprecation. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4.2.2, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [ ] Editorial / Formatting
* [X] Repo Maintenance

### Author Checklist
* [X] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [X] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [X] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
