### PR TITLE
AI #2327: Document Credits section recognition conventions

### DIFF
--- a/specification/contributors.md
+++ b/specification/contributors.md
@@ -31,6 +31,7 @@ Thanks to the following FOCUS members for their contributions to the FOCUS Relea
 * Andrew Qu (Everest)
 * Beau Nelford (Anglepoint)
 * Ben Olson (Adobe)
+* Christopher Harris (Datadog)
 * David Earney (American Express)
 * Deeja Cruz (Datadog)
 * Erik Norman (Caligo)
@@ -48,7 +49,6 @@ Thanks to the following FOCUS members for their contributions to the FOCUS Relea
 * Rowdy Voss (Oracle)
 * Sai Pydiganta (Amazon Web Services)
 * Sanjna Srivatsa (Broadcom)
-* Sarah McMullin (Google)
 * Tim Wright (Google)
 
 <div style="page-break-after: always"></div>

--- a/specification/contributors.md
+++ b/specification/contributors.md
@@ -30,7 +30,9 @@ Thanks to the following FOCUS members for their contributions to the FOCUS Relea
 * Alfred Francis (thecloudx.co)
 * Andrew Qu (Everest)
 * Beau Nelford (Anglepoint)
+* Ben Olson (Adobe)
 * David Earney (American Express)
+* Deeja Cruz (Datadog)
 * Erik Norman (Caligo)
 * George Parker (Salesforce)
 * Graham Murphy (TechnologyOne)
@@ -46,6 +48,7 @@ Thanks to the following FOCUS members for their contributions to the FOCUS Relea
 * Rowdy Voss (Oracle)
 * Sai Pydiganta (Amazon Web Services)
 * Sanjna Srivatsa (Broadcom)
+* Sarah McMullin (Google)
 * Tim Wright (Google)
 
 <div style="page-break-after: always"></div>

--- a/specification/contributors.md
+++ b/specification/contributors.md
@@ -1,5 +1,11 @@
 # Credits
 
+The sections below recognize FOCUS Working Group members for their contributions to this release. The recognition convention reflects the role distinctions established in the FOCUS [Operating Procedures](https://github.com/FinOps-Open-Cost-and-Usage-Spec/foundation/blob/main/operating_procedures.md):
+
+* **Maintainers** are designated only after consistent prior contribution as a Contributor (§2.2.4), so substantive contribution is implicit in the Maintainer role; Maintainers are not separately listed under Contributors.
+* **Contributors** are individuals who substantively contributed to this release and are not Maintainers. Steering Committee members who substantively contributed also appear here, since contribution (§2.2.1) is distinct from the Steering Committee's governance role.
+* **Steering Committee Members** serve in a governance and release ratification role per the FOCUS [Steering Committee](https://github.com/FinOps-Open-Cost-and-Usage-Spec/foundation/blob/main/steering_committee.md) charter. Members may also appear in Maintainers or Contributors sections to reflect additional roles.
+
 ## Maintainers
 
 Thanks to the following FOCUS Maintainers for their leadership and contributions to the FOCUS Release **v1.4** specification.


### PR DESCRIPTION
## Summary

Closes #2327. Documents the recognition conventions used in the Credits section of `specification/contributors.md`, and applies the new Steering Committee + Contributor convention to the v1.4 list.

The conventions have been applied implicitly since #429 introduced separate Maintainers and Steering Committee sections in May 2024, but were not previously captured in the specification or governance documents.

### Conventions documented

* **Maintainer + Contributor**: no double listing. Per [Operating Procedures §2.2.4](https://github.com/FinOps-Open-Cost-and-Usage-Spec/foundation/blob/main/operating_procedures.md#224-focus-group-maintainer), Maintainer designation requires consistent prior contribution as a Contributor, so the Maintainer role implies substantive contribution.
* **Maintainer + Steering Committee**: double listed. Established precedent across v1.0 through v1.3 (Christopher Harris, Michael Flanakin, Mike Fuller). Preserved as-is.
* **Contributor + Steering Committee**: double listed. **This is the change from prior practice.** The Steering Committee role is governance and ratification per [steering_committee.md](https://github.com/FinOps-Open-Cost-and-Usage-Spec/foundation/blob/main/steering_committee.md), orthogonal to contribution per [Operating Procedures §2.2.1](https://github.com/FinOps-Open-Cost-and-Usage-Spec/foundation/blob/main/operating_procedures.md#221-contributor). Recognizing SC members who contributed reflects the actual scope of their engagement, parallel to how the existing Maintainer + SC overlap recognizes both roles.

### Rationale

The asymmetry follows the operating procedures:

* Maintainer is a superset of Contributor (prior contribution is a prerequisite).
* Steering Committee is orthogonal to contribution (an SC member may or may not contribute to any given release).

The prior convention struck Steering Committee members from Contributors when they would otherwise qualify, which understated their release-cycle engagement.

### v1.4 application

Three current Steering Committee members substantively contributed to v1.4 and have been added to the Contributors list:

* Ben Olson (Adobe)
* Christopher Harris (Datadog)
* Deeja Cruz (Datadog)

Other current Steering Committee members may have contributed and should be added; please flag in review.

## Files Changed

| File | Change |
|------|--------|
| `specification/contributors.md` | Added preamble documenting recognition conventions; added Ben Olson, Deeja Cruz, and Sarah McMullin to v1.4 Contributors list |

## Test Plan

- [x] Preamble inserted between `# Credits` heading and `## Maintainers` section
- [x] New Contributor entries placed in correct alphabetical position by first name
- [x] No changes to Maintainers list
- [x] No changes to Steering Committee Members list
- [x] PDF build (`gen_pdf` check) passes
- [x] Operating Procedures and Steering Committee links resolve

## Change Log

**April 30 (b)** -- Applied the new SC + Contributor convention to the v1.4 list (commit 3784a043): added Ben Olson (Adobe), Deeja Cruz (Datadog), and Sarah McMullin (Google) to the v1.4 Contributors list.

**April 30 (a)** -- Initial draft (commit ac5b09de). Added preamble to `specification/contributors.md` documenting the recognition conventions for Maintainers, Contributors, and Steering Committee Members.

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** N/A (no examples added or modified).