### PR TITLE
AI #2339: Fix broken internal links in JSON Object Format columns

### DIFF
--- a/specification/datasets/contract_commitment/columns/contractcommitmentapplicability.md
+++ b/specification/datasets/contract_commitment/columns/contractcommitmentapplicability.md
@@ -18,7 +18,7 @@ ContractCommitmentApplicability MUST adhere to the following requirements:
 
 Contract Commitment Applicability consists of a valid JSON object which contains a set of top-level property keys. These keys define entity-based inclusionary and exclusionary logic, as well as the portion of relevant cost and/or usage that is applicable to the *contract commitment*.
 
-The following section details the normative requirements for the ContractCommitmentApplicabilityObject and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datasets.contractcommitment.contractcommitmentapplicability.schemastructure) and [Object Example](#datasets.contractcommitment.contractcommitmentapplicability.objectexample) sections.
+The following section details the normative requirements for the ContractCommitmentApplicabilityObject and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datasets.contractcommitment.contractcommitmentapplicability.contractcommitmentapplicabilityobject.objectschemastructure) and [Object Example](#datasets.contractcommitment.contractcommitmentapplicability.contractcommitmentapplicabilityobject.objectexample) sections.
 
 ### Object Requirements
 

--- a/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedmethoddetails.md
@@ -22,7 +22,7 @@ AllocatedMethodDetails MUST adhere to the following requirements:
 
 Allocated Method Details consists of a valid JSON object with a top level key of Elements containing an Array of entry objects. Each entry object consists of FOCUS-defined property keys but can be extended to provide additional details about the allocation.
 
-The following section details the normative requirements for the AllocatedMethodDetailsObject and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datasets.costandusage.allocatedmethoddetails.schemastructure) and [Object Example](#datasets.costandusage.allocatedmethoddetails.objectexample) sections.
+The following section details the normative requirements for the AllocatedMethodDetailsObject and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datasets.costandusage.allocatedmethoddetails.allocatedmethoddetailsobject.objectschemastructure) and [Object Example](#datasets.costandusage.allocatedmethoddetails.allocatedmethoddetailsobject.objectexample) sections.
 
 ### Object Requirements
 

--- a/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
+++ b/specification/datasets/cost_and_usage/columns/commitmentprogrameligibilitydetails.md
@@ -26,7 +26,7 @@ Commitment Program Eligibility Details consists of a valid JSON object with a to
 
 CommitmentProgramEligibilityDetailsObject MUST adhere to the following requirements:
 
-* CommitmentProgramEligibilityDetailsObject MUST conform to the [CommitmentProgramEligibilityDetailsObjectSchema](#schemas.datasets.costandusage.commitmentprogrameligibilitydetailsobjectschema) JSON Schema.
+* CommitmentProgramEligibilityDetailsObject MUST conform to the [CommitmentProgramEligibilityDetailsObjectSchema](#schemas.costandusage.commitmentprogrameligibilitydetailsobjectschema) JSON Schema.
 * CommitmentProgramEligibilityDetailsObject.CommitmentPrograms[\*].ProgramType MUST correspond to a *commitment program* type supported by the service provider.
 * CommitmentProgramEligibilityDetailsObject.CommitmentPrograms[\*].ProgramType MUST match [CommitmentDiscountType](#datasets.costandusage.commitmentdiscounttype) for one object in CommitmentProgramEligibilityDetailsObject.CommitmentPrograms when CommitmentDiscountType is not null.
 * CommitmentProgramEligibilityDetailsObject.CommitmentPrograms[\*].ProgramType SHOULD correspond to terminology disclosed by the service provider in public documentation.
@@ -58,7 +58,7 @@ To facilitate querying data across allocations and across service providers, a d
 Here is a basic example of the object format.
 
 * For more detailed examples, please see this column's entry in the JSON Object Examples appendix entry [here](#appendix.examples:jsonobject.examples:commitmentprogrameligibilitydetails).
-* For the JSON schema, please see [Commitment Program Eligibility Details Object Schema](#schemas.datasets.costandusage.commitmentprogrameligibilitydetailsobjectschema).
+* For the JSON schema, please see [Commitment Program Eligibility Details Object Schema](#schemas.costandusage.commitmentprogrameligibilitydetailsobjectschema).
 
 ``` json
 {

--- a/specification/datasets/cost_and_usage/columns/contractapplied.md
+++ b/specification/datasets/cost_and_usage/columns/contractapplied.md
@@ -18,7 +18,7 @@ ContractApplied MUST adhere to the following requirements:
 
 Contract Applied Object consists of a valid JSON object which contains an array of key-value objects describing the one or more contract commitments applied to the *charge*. Each object consists of FOCUS-defined property keys but can be extended to provide additional details about the contract application.
 
-The following section details the normative requirements for the ContractAppliedObject and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datasets.costandusage.contractapplied.schemastructure) and [Object Example](#datasets.costandusage.contractapplied.objectexample) sections.
+The following section details the normative requirements for the ContractAppliedObject and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datasets.costandusage.contractapplied.contractappliedobject.objectschemastructure) and [Object Example](#datasets.costandusage.contractapplied.contractappliedobject.objectexample) sections.
 
 ### Object Requirements
 


### PR DESCRIPTION
## Summary

The heading restructuring introduced as part of the 1.4 release renamed and relocated several headings in JSON Object Format columns (Schema Structure → Object Schema Structure, Object Example repositioned under {ColumnName} Object). 

However, six internal links in Allocated Method Details, Contract Applied, and Contract Commitment Applicability still reference the old anchor paths. Additionally, two links in Commitment Program Eligibility Details reference a schema anchor with an extra datasets. segment in the path.

This PR fixes the following broken links:

Allocated Method Details:
- `#datasets.costandusage.allocatedmethoddetails.schemastructure` → `#datasets.costandusage.allocatedmethoddetails.allocatedmethoddetailsobject.objectschemastructure`
- `#datasets.costandusage.allocatedmethoddetails.objectexample` → `#datasets.costandusage.allocatedmethoddetails.allocatedmethoddetailsobject.objectexample`

Contract Applied:
- `#datasets.costandusage.contractapplied.schemastructure` → `#datasets.costandusage.contractapplied.contractappliedobject.objectschemastructure`
- `#datasets.costandusage.contractapplied.objectexample` → `#datasets.costandusage.contractapplied.contractappliedobject.objectexample`

Contract Commitment Applicability:
- `#datasets.contractcommitment.contractcommitmentapplicability.schemastructure` → `#datasets.contractcommitment.contractcommitmentapplicability.contractcommitmentapplicabilityobject.objectschemastructure`
- `#datasets.contractcommitment.contractcommitmentapplicability.objectexample` → `#datasets.contractcommitment.contractcommitmentapplicability.contractcommitmentapplicabilityobject.objectexample`

Commitment Program Eligibility Details (x 2):
- `#schemas.datasets.costandusage.commitmentprogrameligibilitydetailsobjectschema` → `#schemas.costandusage.commitmentprogrameligibilitydetailsobjectschema`

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
