### PR TITLE
AI #2348: Graduate dataset presence requirements to data model level

### DIFF
--- a/specification/datasets/billing_period/dataset.md
+++ b/specification/datasets/billing_period/dataset.md
@@ -26,8 +26,7 @@ The Billing Period dataset is primarily used to provide context for the [Cost an
 
 BillingPeriod MUST adhere to the following requirements:
 
-* BillingPeriod MUST be present when the invoice issuer supports payable invoices.
-* The presence of columns in BillingPeriod MUST adhere to the following requirements:
+* BillingPeriod column presence MUST adhere to the following requirements:
   * BillingPeriod MUST include [BillingPeriodCreated](#datasets.billingperiod.billingperiodcreated).
   * BillingPeriod MUST include [BillingPeriodEnd](#datasets.billingperiod.billingperiodend).
   * BillingPeriod MUST include [BillingPeriodLastUpdated](#datasets.billingperiod.billingperiodlastupdated).

--- a/specification/datasets/contract_commitment/dataset.md
+++ b/specification/datasets/contract_commitment/dataset.md
@@ -52,7 +52,6 @@ The Contract Commitment dataset can be joined to the Cost and Usage dataset thro
 
 ContractCommitment MUST adhere to the following requirements:
 
-* ContractCommitment MUST be present when the service provider supports *contract commitments*.
 * ContractCommitment column presence MUST adhere to the following requirements:
   * ContractCommitment MUST include [BillingCurrency](#datasets.contractcommitment.billingcurrency).
   * ContractCommitment MUST include [ContractCommitmentApplicability](#datasets.contractcommitment.contractcommitmentapplicability).

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -89,7 +89,6 @@ The Cost and Usage dataset can be joined to the Contract Commitment dataset thro
 
 CostAndUsage MUST adhere to the following requirements:
 
-* CostAndUsage MUST be present.
 * CostAndUsage column presence MUST adhere to the following requirements:
   * CostAndUsage SHOULD include [AllocatedMethodDetails](#datasets.costandusage.allocatedmethoddetails) when the data generator supports data generator-calculated split cost allocation.
   * CostAndUsage MUST include [AllocatedMethodId](#datasets.costandusage.allocatedmethodid) when the data generator supports data generator-calculated split cost allocation.

--- a/specification/datasets/data_model.md
+++ b/specification/datasets/data_model.md
@@ -22,7 +22,7 @@ DataModel MUST adhere to the following requirements:
 * DataModel MUST include [ContractCommitment](#datasets.contractcommitment) when the service provider supports [*contract commitments*](#glossary:contract-commitment).
 * DataModel MUST include [InvoiceDetail](#datasets.invoicedetail) when the invoice issuer supports payable invoices.
 
-## Dataset ID<!--SkipTOC-->
+## Data Model ID<!--SkipTOC-->
 
 DataModel
 
@@ -37,4 +37,3 @@ The datasets that comprise the FOCUS schema.
 ## Version Introduced<!--SkipTOC-->
 
 0.5
-

--- a/specification/datasets/data_model.md
+++ b/specification/datasets/data_model.md
@@ -13,9 +13,11 @@ Datasets are sorted first by Feature Level (i.e., Mandatory, then Conditional), 
 | [Contract Commitment](#datasets.contractcommitment) | Reference    | Conditional   | Describes the terms of contracts agreed between a service provider and a customer. |
 | [Invoice Detail](#datasets.invoicedetail)           | Transaction  | Conditional   | Describes the cost and usage issued on invoices. |
 
+## Requirements<!--SkipTOC-->
+
 FOCUS data model MUST adhere to the following requirements:
 
 * FOCUS data model MUST include [CostAndUsage](#datasets.costandusage).
 * FOCUS data model MUST include [BillingPeriod](#datasets.billingperiod) when the invoice issuer supports payable invoices.
-* FOCUS data model MUST include [ContractCommitment](#datasets.contractcommitment) when the service provider supports *contract commitments*.
+* FOCUS data model MUST include [ContractCommitment](#datasets.contractcommitment) when the service provider supports [*contract commitments*](#glossary:contract-commitment).
 * FOCUS data model MUST include [InvoiceDetail](#datasets.invoicedetail) when the invoice issuer supports payable invoices.

--- a/specification/datasets/data_model.md
+++ b/specification/datasets/data_model.md
@@ -12,3 +12,10 @@ Datasets are sorted first by Feature Level (i.e., Mandatory, then Conditional), 
 | [Billing Period](#datasets.billingperiod)           | Reference    | Conditional   | Describes the billing periods by which cost and usage is invoiced. |
 | [Contract Commitment](#datasets.contractcommitment) | Reference    | Conditional   | Describes the terms of contracts agreed between a service provider and a customer. |
 | [Invoice Detail](#datasets.invoicedetail)           | Transaction  | Conditional   | Describes the cost and usage issued on invoices. |
+
+FOCUS data model MUST adhere to the following requirements:
+
+* [CostAndUsage](#datasets.costandusage) MUST be present.
+* [BillingPeriod](#datasets.billingperiod) MUST be present when the invoice issuer supports payable invoices.
+* [ContractCommitment](#datasets.contractcommitment) MUST be present when the service provider supports *contract commitments*.
+* [InvoiceDetail](#datasets.invoicedetail) MUST be present when the invoice issuer supports payable invoices.

--- a/specification/datasets/data_model.md
+++ b/specification/datasets/data_model.md
@@ -1,8 +1,8 @@
-# Datasets
+# Data Model
 
-FOCUS defines many individual datasets made up of a selected set of columns which abide by the attributes outlined in this FOCUS Specification.
+The FOCUS data model defines many individual datasets, each comprised of a set of columns, which abide by the attributes outlined in this FOCUS Specification.
 
-## Dataset List<!--SkipTOC-->
+## Datasets<!--SkipTOC-->
 
 Datasets are sorted first by Feature Level (i.e., Mandatory, then Conditional), then alphabetically by name.
 
@@ -15,9 +15,26 @@ Datasets are sorted first by Feature Level (i.e., Mandatory, then Conditional), 
 
 ## Requirements<!--SkipTOC-->
 
-FOCUS data model MUST adhere to the following requirements:
+DataModel MUST adhere to the following requirements:
 
-* FOCUS data model MUST include [CostAndUsage](#datasets.costandusage).
-* FOCUS data model MUST include [BillingPeriod](#datasets.billingperiod) when the invoice issuer supports payable invoices.
-* FOCUS data model MUST include [ContractCommitment](#datasets.contractcommitment) when the service provider supports [*contract commitments*](#glossary:contract-commitment).
-* FOCUS data model MUST include [InvoiceDetail](#datasets.invoicedetail) when the invoice issuer supports payable invoices.
+* DataModel MUST include [CostAndUsage](#datasets.costandusage).
+* DataModel MUST include [BillingPeriod](#datasets.billingperiod) when the invoice issuer supports payable invoices.
+* DataModel MUST include [ContractCommitment](#datasets.contractcommitment) when the service provider supports [*contract commitments*](#glossary:contract-commitment).
+* DataModel MUST include [InvoiceDetail](#datasets.invoicedetail) when the invoice issuer supports payable invoices.
+
+## Dataset ID<!--SkipTOC-->
+
+DataModel
+
+## Display Name<!--SkipTOC-->
+
+Data Model
+
+## Description<!--SkipTOC-->
+
+The datasets that comprise the FOCUS schema.
+
+## Version Introduced<!--SkipTOC-->
+
+0.5
+

--- a/specification/datasets/data_model.md
+++ b/specification/datasets/data_model.md
@@ -15,7 +15,7 @@ Datasets are sorted first by Feature Level (i.e., Mandatory, then Conditional), 
 
 FOCUS data model MUST adhere to the following requirements:
 
-* [CostAndUsage](#datasets.costandusage) MUST be present.
-* [BillingPeriod](#datasets.billingperiod) MUST be present when the invoice issuer supports payable invoices.
-* [ContractCommitment](#datasets.contractcommitment) MUST be present when the service provider supports *contract commitments*.
-* [InvoiceDetail](#datasets.invoicedetail) MUST be present when the invoice issuer supports payable invoices.
+* FOCUS data model MUST include [CostAndUsage](#datasets.costandusage).
+* FOCUS data model MUST include [BillingPeriod](#datasets.billingperiod) when the invoice issuer supports payable invoices.
+* FOCUS data model MUST include [ContractCommitment](#datasets.contractcommitment) when the service provider supports *contract commitments*.
+* FOCUS data model MUST include [InvoiceDetail](#datasets.invoicedetail) when the invoice issuer supports payable invoices.

--- a/specification/datasets/invoice_detail/dataset.md
+++ b/specification/datasets/invoice_detail/dataset.md
@@ -46,8 +46,7 @@ For more information, see the [Invoice Reconciliation](#supportedfeatures.invoic
 
 InvoiceDetail MUST adhere to the following requirements:
 
-* InvoiceDetail MUST be present when the invoice issuer supports payable invoices.
-* The presence of columns in InvoiceDetail MUST adhere to the following requirements:
+* InvoiceDetail column presence MUST adhere to the following requirements:
   * InvoiceDetail MUST include [BilledCost](#datasets.invoicedetail.billedcost).
   * InvoiceDetail MUST include [BillingAccountId](#datasets.invoicedetail.billingaccountid).
   * InvoiceDetail MUST include [BillingCurrency](#datasets.invoicedetail.billingcurrency).


### PR DESCRIPTION
## Summary

This pull request centralizes the dataset presence requirements into the primary `data_model.md` file. 

Previously, the normative requirements dictating when specific datasets MUST be present were scattered across individual dataset definition files (`billing_period/dataset.md`, `contract_commitment/dataset.md`, `cost_and_usage/dataset.md`, and `invoice_detail/dataset.md`). Moving these dataset-level constraints into a unified section in `data_model.md` improves specification organization and makes the overarching data model requirements easier to discover.

Additionally, this PR applies minor editorial cleanups to standardize the phrasing of the column presence introductory clauses in the Billing Period and Invoice Detail datasets (changing "The presence of columns in [Dataset] MUST adhere to..." to "[Dataset] column presence MUST adhere to...").

### Type of Change
* [ ] Bug fix
* [x] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
