### PR TITLE
AI #2355: Updates to Requirements Model v1.4

### DIFF
--- a/specification/requirements_model/releases/1.4/model_rules/datasets/billing_period/columns/billingperiodstatus.json
+++ b/specification/requirements_model/releases/1.4/model_rules/datasets/billing_period/columns/billingperiodstatus.json
@@ -182,8 +182,8 @@
     "DatasetId": "BillingPeriod",
     "DatasetName": "Billing Period",
     "ValidationCriteria": {
-      "MustSatisfy": "BillingPeriodStatus MUST be \"Open\" following a previous status of \"Closed\", except when explicitly requested or approved by the customer.",
-      "Keyword": "MUST",
+      "MustSatisfy": "BillingPeriodStatus MUST NOT be \"Open\" following a previous status of \"Closed\", except when explicitly requested or approved by the customer.",
+      "Keyword": "MUST NOT",
       "Requirement": {},
       "Condition": {},
       "Dependencies": []

--- a/specification/requirements_model/releases/1.4/model_rules/datasets/cost_and_usage/columns/allocatedmethodid.json
+++ b/specification/requirements_model/releases/1.4/model_rules/datasets/cost_and_usage/columns/allocatedmethodid.json
@@ -202,7 +202,7 @@
     "DatasetId": "CostAndUsage",
     "DatasetName": "Cost and Usage",
     "ValidationCriteria": {
-      "MustSatisfy": "Data generator-calculated split cost allocation method documentation MUST reference to a single AllocatedMethodId value.",
+      "MustSatisfy": "Data generator-calculated split cost allocation method documentation MUST reference a single AllocatedMethodId value.",
       "Keyword": "MUST",
       "Requirement": {},
       "Condition": {},

--- a/specification/requirements_model/releases/1.4/model_rules/datasets/cost_and_usage/columns/allocatedmethodid.json
+++ b/specification/requirements_model/releases/1.4/model_rules/datasets/cost_and_usage/columns/allocatedmethodid.json
@@ -202,7 +202,7 @@
     "DatasetId": "CostAndUsage",
     "DatasetName": "Cost and Usage",
     "ValidationCriteria": {
-      "MustSatisfy": "Data generator-calculated split cost allocation method documentation MUST make reference to a single AllocatedMethodId value.",
+      "MustSatisfy": "Data generator-calculated split cost allocation method documentation MUST reference to a single AllocatedMethodId value.",
       "Keyword": "MUST",
       "Requirement": {},
       "Condition": {},

--- a/specification/requirements_model/releases/1.4/model_rules/datasets/cost_and_usage/columns/tags.json
+++ b/specification/requirements_model/releases/1.4/model_rules/datasets/cost_and_usage/columns/tags.json
@@ -615,7 +615,7 @@
     "ModelVersionIntroduced": "1.4",
     "Status": "Active",
     "ApplicabilityCriteria": [],
-    "Order": 190,
+    "Order": 100,
     "DatasetType": "CAU",
     "DatasetId": "CostAndUsage",
     "DatasetName": "Cost and Usage",


### PR DESCRIPTION
## Summary

This PR addresses the difference between the current requirements-model `MustSatisfy` statements and the normative statements in the Release v1.4 in the `working_draft` branch.

### Type of Change
* [x] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [ ] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
