### PR TITLE
AI #2397: Address Spec-only issues identified during Spec–RM (v.1.4) comparison

### DIFF
--- a/specification/attributes/custom_column_handling.md
+++ b/specification/attributes/custom_column_handling.md
@@ -24,7 +24,6 @@ Column conforming to CustomColumnHandling attribute MUST adhere to the following
   * *Custom column* SHOULD use [*Pascal case*](#glossary:pascalcase) in the portion of the Column ID following the required `x_` prefix.
   * *Custom column* SHOULD use only alphanumeric characters in the portion of the Column ID following the required `x_` prefix.
   * *Custom column* SHOULD NOT include special characters other than the underscore in the required `x_` prefix.
-
   * *Custom column* SHOULD NOT use abbreviations other than `Id` in the Column ID.
   * *Custom column* SHOULD NOT use acronyms other than `Sku` in the Column ID.
   * *Custom column* SHOULD NOT exceed 50 characters in the Column ID to accommodate column length restrictions of various data repositories.

--- a/specification/supported_features/contract_commitments.md
+++ b/specification/supported_features/contract_commitments.md
@@ -36,14 +36,14 @@ Because ANSI SQL does not inherently support the parsing of JSON, the following 
 
 ### Report on Initial Contract Commitment
 
-This query takes inputs of a time range via ChargePeriodStart and ChargePeriodEnd, then presents the aggregation of initial contract commitments from the CostAndUsage dataset per ServiceProviderName and ContractCommitmentID by filtering on the specified time range, along with ChargeCategory of `Purchase`.
+This query takes inputs of a time range via ChargePeriodStart and ChargePeriodEnd, then presents the aggregation of initial contract commitments from the CostAndUsage dataset per ServiceProviderName and ContractCommitmentId by filtering on the specified time range, along with ChargeCategory of `Purchase`.
 
 ```sql
 SELECT
   MIN(CU.ChargePeriodStart) AS ChargePeriodStart,
   MAX(CU.ChargePeriodEnd) AS ChargePeriodEnd,
   CU.ServiceProviderName,
-  JSON_VALUE(CA, '$.ContractCommitmentID') AS ContractCommitmentId,
+  JSON_VALUE(CA, '$.ContractCommitmentId') AS ContractCommitmentId,
   SUM(CAST(JSON_VALUE(CA, '$.ContractCommitmentAppliedCost') AS FLOAT64)) AS ContractCommitmentAppliedCost
 FROM CostAndUsage CU
 CROSS JOIN
@@ -57,14 +57,14 @@ ORDER BY ServiceProviderName, ContractCommitmentId
 
 ### Report on Usage Against Contract Commitment
 
-This query takes inputs of a time range via ChargePeriodStart and ChargePeriodEnd, then presents the aggregation of the application of contract commitments from the CostAndUsage dataset per ServiceProviderName and ContractCommitmentID by filtering on the specified time range, along with ChargeCategory of `Usage`.
+This query takes inputs of a time range via ChargePeriodStart and ChargePeriodEnd, then presents the aggregation of the application of contract commitments from the CostAndUsage dataset per ServiceProviderName and ContractCommitmentId by filtering on the specified time range, along with ChargeCategory of `Usage`.
 
 ```sql
 SELECT
   MIN(CU.ChargePeriodStart) AS ChargePeriodStart,
   MAX(CU.ChargePeriodEnd) AS ChargePeriodEnd,
   CU.ServiceProviderName,
-  JSON_VALUE(CA, '$.ContractCommitmentID') AS ContractCommitmentId,
+  JSON_VALUE(CA, '$.ContractCommitmentId') AS ContractCommitmentId,
   SUM(CAST(JSON_VALUE(CA, '$.ContractCommitmentAppliedCost') AS FLOAT64)) AS ContractCommitmentAppliedCost
 FROM CostAndUsage CU
 CROSS JOIN
@@ -78,14 +78,14 @@ ORDER BY ServiceProviderName, ContractCommitmentId
 
 ### Report on Usage Against Contract Commitment by Category
 
-This query takes inputs of a time range via ChargePeriodStart and ChargePeriodEnd, then presents the aggregation of the application of contract commitments from the CostAndUsage dataset per ServiceProviderName and ContractCommitmentID by filtering on the specified time range, along with ChargeCategory of `Usage`. It also joins in the ContractCommitment dataset to provide further information about each contract commitment (in this case, the start and end date/time).
+This query takes inputs of a time range via ChargePeriodStart and ChargePeriodEnd, then presents the aggregation of the application of contract commitments from the CostAndUsage dataset per ServiceProviderName and ContractCommitmentId by filtering on the specified time range, along with ChargeCategory of `Usage`. It also joins in the ContractCommitment dataset to provide further information about each contract commitment (in this case, the start and end date/time).
 
 ```sql
 SELECT
   MIN(CU.ChargePeriodStart) AS ChargePeriodStart,
   MAX(CU.ChargePeriodEnd) AS ChargePeriodEnd,
   CU.ServiceProviderName,
-  JSON_VALUE(CA, '$.ContractCommitmentID') AS ContractCommitmentId,
+  JSON_VALUE(CA, '$.ContractCommitmentId') AS ContractCommitmentId,
   CC.ContractCommitmentPeriodStart,
   CC.ContractCommitmentPeriodEnd,
   SUM(CAST(JSON_VALUE(CA, '$.ContractCommitmentAppliedCost') AS FLOAT64)) AS ContractCommitmentAppliedCost
@@ -95,7 +95,7 @@ CROSS JOIN
 INNER JOIN
   ContractCommitment CC
 ON
-  JSON_VALUE(CA, '$.ContractCommitmentID') = CC.ContractCommitmentID
+  JSON_VALUE(CA, '$.ContractCommitmentId') = CC.ContractCommitmentId
 WHERE JSON_VALUE(CA, '$.ContractCommitmentAppliedCost') IS NOT NULL
   AND ChargePeriodStart >= ? AND ChargePeriodEnd < ?
   AND ChargeCategory = 'Usage'


### PR DESCRIPTION
## Summary

This PR performs Spec-only cleanup addressing minor issues identified during the Spec–RM comparison, with no impact on RM.

#### Changes:

- Removed extra blank line in custom_column_handling.md under `CustomColumnHandling` rules
- Standardized `ContractCommitmentID` → `ContractCommitmentId `within supported feature examples in contract_commitments.md
  - Updated related SQL examples, JSON field references, and joins to consistently use `ContractCommitmentId`

***Note:** Intentionally left the remaining `ContractCommitmentID `reference in the `ContractCommitmentLifecycleStatus` requirement unchanged, since updating it to `ContractCommitmentId` would also require a corresponding RM update*

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
