### PR TITLE
Feedback #2408: Fix invalid SQL in the invoice reconciliation example

### DIFF
--- a/specification/supported_features/invoice_reconciliation.md
+++ b/specification/supported_features/invoice_reconciliation.md
@@ -43,7 +43,7 @@ SELECT
   COALESCE(ID.InvoiceId, CU.InvoiceId) AS InvoiceId,
   ID.TotalBilledCost_InvoiceDetail,
   CU.TotalBilledCost_CostAndUsage,
-  (ID.TotalBilledCost_InvoiceDetail - CU.TotalBilledCost_CostAndUsage) AS Variance
+  (COALESCE(ID.TotalBilledCost_InvoiceDetail, 0) - COALESCE(CU.TotalBilledCost_CostAndUsage, 0)) AS Variance
 FROM (
   SELECT
     InvoiceId,
@@ -57,8 +57,10 @@ FULL OUTER JOIN (
     InvoiceId,
     SUM(BilledCost) AS TotalBilledCost_CostAndUsage
   FROM CostAndUsage
+  WHERE ChargeCategory != 'Tax'
+  GROUP BY InvoiceId
 ) CU ON ID.InvoiceId = CU.InvoiceId
-WHERE ID.InvoiceId = ?
+WHERE COALESCE(ID.InvoiceId, CU.InvoiceId) = ?
 ```
 
 ### Reconcile Multi-Currency Settlement Using Lineage IDs


### PR DESCRIPTION
## Summary

The first SQL example in `specification/supported_features/invoice_reconciliation.md` ("Reconcile Cost and Usage to Invoice Detail by Invoice ID") did not execute, and once made runnable, mishandled invoices present on only one side of the join. Four changes:

1. **`GROUP BY InvoiceId`** on the `CostAndUsage` subquery. As published it selected an ungrouped `InvoiceId` beside `SUM(BilledCost)` — invalid under BigQuery (the spec's canonical dialect) and the other targeted engines (Snowflake, Redshift, Trino, Athena, Postgres, DuckDB). Verified: transpiling the published query to DuckDB raises `Binder Error: column "InvoiceId" must appear in the GROUP BY clause`.
2. **`COALESCE(..., 0)` in the `Variance`** so an invoice present on only one side yields a number, not `NULL`.
3. **`WHERE COALESCE(ID.InvoiceId, CU.InvoiceId) = ?`** so the filter matches invoices on either side. The old `WHERE ID.InvoiceId = ?` dropped invoices present only in `CostAndUsage` — the reconciliation gaps the query is meant to surface.
4. **Symmetric `!= 'Tax'` filter** on the `CostAndUsage` subquery so the variance is not contaminated by tax, matching the example's stated intent ("the total non-tax charges").

Verified by transpiling the fixed query to DuckDB and executing against tables built from the FOCUS column definitions: a two-sided invoice now reconciles to 0, and a `CostAndUsage`-only invoice surfaces with its variance (previously dropped).

SQL revision proposed by @shawnalpay.

Fixes #2407.

### Type of Change
* [x] Bug fix
* [ ] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.