### PR TITLE
Feedback #2419: Correct Payment Currency Feature Level in Invoice Detail overview table

### DIFF
--- a/specification/datasets/invoice_detail/dataset.md
+++ b/specification/datasets/invoice_detail/dataset.md
@@ -21,7 +21,7 @@ The Invoice Detail dataset is a transactional dataset that represents the financ
 | [Invoice Issue Date](#datasets.invoicedetail.invoiceissuedate)                   | Dimension   | Mandatory     | True        | Date/Time |
 | [Invoice Issue Status](#datasets.invoicedetail.invoiceissuestatus)             | Dimension   | Mandatory     | False        | String    |
 | [Invoice Issuer Name](#datasets.invoicedetail.invoiceissuername)                 | Dimension   | Mandatory     | False        | String    |
-| [Payment Currency](#datasets.invoicedetail.paymentcurrency)                     | Dimension   | Mandatory     | False        | String    |
+| [Payment Currency](#datasets.invoicedetail.paymentcurrency)                     | Dimension   | Conditional   | False        | String    |
 | [Payment Currency Billed Cost](#datasets.invoicedetail.paymentcurrencybilledcost) | Metric      | Conditional   | False        | Decimal   |
 | [Payment Currency Invoice Detail ID](#datasets.invoicedetail.paymentcurrencyinvoicedetailid) | Dimension | Conditional | False | String |
 | [Payment Due Date](#datasets.invoicedetail.paymentduedate)               | Dimension   | Mandatory     | True         | Date/Time |


### PR DESCRIPTION
## Summary

The Invoice Detail dataset columns overview table lists the Payment Currency Feature Level as **Mandatory**, which contradicts the rest of the spec, where Payment Currency is **Conditional**:

* Payment Currency column definition Content Constraints: `Feature level: Conditional`
* Invoice Detail presence requirement: "InvoiceDetail MUST include PaymentCurrency when the invoice issuer supports billing and payment in different currencies."
* Requirements Model rule `IND-PaymentCurrency-C-000-C` (Conditional, applicability criterion `BILLING_PAYMENT_CURRENCY_DIFFERENCES_SUPPORTED`)

The overview table is the only place listing it as Mandatory. This corrects the table to match the column definition, the normative requirement, and the Requirements Model. The required Feature Level is unchanged.

### Changes
* `specification/datasets/invoice_detail/dataset.md`: overview table Payment Currency Feature Level `Mandatory` to `Conditional`.

Resolves #2419. The corresponding 1.5 working draft change is handled in #2351.

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.