### PR TITLE
Feedback #2418: Correct CommitmentDiscountStatus allowed values in 1.4 requirements model

### DIFF
--- a/specification/requirements_model/releases/1.4/model_rules/datasets/cost_and_usage/columns/commitmentdiscountstatus.json
+++ b/specification/requirements_model/releases/1.4/model_rules/datasets/cost_and_usage/columns/commitmentdiscountstatus.json
@@ -220,17 +220,12 @@
           {
             "CheckFunction": "CheckValue",
             "ColumnName": "CommitmentDiscountStatus",
-            "Value": "Active"
+            "Value": "Used"
           },
           {
             "CheckFunction": "CheckValue",
             "ColumnName": "CommitmentDiscountStatus",
-            "Value": "Expired"
-          },
-          {
-            "CheckFunction": "CheckValue",
-            "ColumnName": "CommitmentDiscountStatus",
-            "Value": "Pending"
+            "Value": "Unused"
           }
         ]
       },


### PR DESCRIPTION
## Summary

The Requirements Model rule `CAU-CommitmentDiscountStatus-C-005-M` defines the allowed values for `CommitmentDiscountStatus` as `Active`, `Expired`, and `Pending`. None of these values appear in the FOCUS specification.

`CommitmentDiscountStatus` is a utilization field with exactly two allowed values, `Used` and `Unused`:

* The column "Allowed Values" table and normative requirements in `specification/datasets/cost_and_usage/columns/commitmentdiscountstatus.md` ("MUST be 'Used' when the charge utilizes a specific amount...", "MUST be 'Unused' when the charge represents the unused portion...")
* The canonical commitment-discount SQL in `spec.md` filters `WHERE CommitmentDiscountStatus = 'Unused'`

This changes `CAU-CommitmentDiscountStatus-C-005-M` to allow `Used` and `Unused`, matching the spec text and the sibling `CapacityReservationStatus` rule, which already encodes `Used` / `Unused`.

The 1.4 specification and Requirements Model are not yet ratified, so this is a correction to the draft model and is not positioned as errata. The same defect persists in the published 1.2 and 1.3 Requirements Models and is addressed as errata in a separate PR.

Refs #2418

### Type of Change
* [x] Bug fix
* [ ] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** N/A (no example data in this PR).
