### PR TITLE
Feedback #2418: Errata for CommitmentDiscountStatus allowed values in 1.2 and 1.3 requirements model

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -10,7 +10,7 @@ These updates serve as the basis for revising FOCUS enablement artifacts, such a
 
 This section outlines minor discrepancies found in the 1.3 release of the FOCUS specification. 
 
-All issues are considered clarifications to intended language and are not meant to represent material changes. The working group has implemented checks going forward that will prevent the introduction of similar issues. Most issues were introduced in version 1.3 and addressed in version 1.4; where a discrepancy originated in an earlier release or was addressed later, the individual entry notes this.
+All issues are considered clarifications to intended language and are not meant to represent material changes. The working group has implemented checks going forward that will prevent the introduction of similar issues. These issues have been addressed in version 1.4.
 
 ### A. Schema & Validation Logic Corrections
 *The following corrections address schema definitions and validation rules to ensure automated tooling and JSON parsers function correctly.*

--- a/ERRATA.md
+++ b/ERRATA.md
@@ -10,7 +10,7 @@ These updates serve as the basis for revising FOCUS enablement artifacts, such a
 
 This section outlines minor discrepancies found in the 1.3 release of the FOCUS specification. 
 
-All issues are considered clarifications to intended language and are not meant to represent material changes. The working group has implemented checks going forward that will prevent the introduction of similar issues. All issues were introduced in version 1.3 of the specification and have been addressed in version 1.4.
+All issues are considered clarifications to intended language and are not meant to represent material changes. The working group has implemented checks going forward that will prevent the introduction of similar issues. Most issues were introduced in version 1.3 and addressed in version 1.4; where a discrepancy originated in an earlier release or was addressed later, the individual entry notes this.
 
 ### A. Schema & Validation Logic Corrections
 *The following corrections address schema definitions and validation rules to ensure automated tooling and JSON parsers function correctly.*
@@ -45,6 +45,7 @@ All issues are considered clarifications to intended language and are not meant 
 | :--- | :--- | :--- | :--- | :--- |
 | **#7: Missing Ignored Key** | `contractappliedobject.json` | The `IgnoreKeys` array omitted `"ContractId"`, causing valid custom key checks to fail. | `"ContractId"` was added to the `IgnoreKeys` array. | Issue: [#2048](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/2048)<br>PR: [#2052](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/2052) |
 | **#8: Incorrect JSON Path targets** | `contractappliedobject.json` | The `Path` targeted `"$.Elements[*].ContractCommitmentId"` for all three metric presence checks. | The `Path` was corrected to target the respective `Cost`, `Quantity`, and `Unit` JSON properties. | Issue: [#2048](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/2048)<br>PR: [#2052](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/2052) |
+| **#11: Incorrect CommitmentDiscountStatus allowed values**<br><br>*(Defect carried over from the 1.2 Requirements Model)* | `commitmentdiscountstatus.json` | `CAU-CommitmentDiscountStatus-C-005-M` listed the allowed values as `Active`, `Expired`, and `Pending`, none of which appear in the specification. | Corrected to the spec-defined values `Used` and `Unused` (matching the column's Allowed Values table and the sibling `CapacityReservationStatus` rule). | Issue: [#2418](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/2418)<br>PR: [#2422](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/2422) |
 
 ---
 
@@ -68,3 +69,4 @@ This section outlines discrepancies found in the enablement artifacts (Requireme
 | :--- | :--- | :--- | :--- | :--- |
 | **#1: Incorrect argument name** | `resourcetype.json` | The condition function incorrectly used the argument `"CheckCondition": "ResourceId"`. | The argument was corrected to the standard `"ColumnName": "ResourceId"`. | Issue: [#1824](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/1824)<br>PR: [#1956](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/1956) |
 | **#2: Incorrect nullability function** | `commitmentdiscountstatus.json` | The requirement used `CheckNotValue` to ensure the status was null, which caused valid nulls to fail. | The function was corrected to `CheckValue` to properly enforce the `MUST be null` requirement. | Issue: [#1825](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/1825)<br>PR: [#1956](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/1956) |
+| **#3: Incorrect CommitmentDiscountStatus allowed values** | `commitmentdiscountstatus.json` | `CommitmentDiscountStatus-C-005-M` listed the allowed values as `Active`, `Expired`, and `Pending`, none of which appear in the specification. | Corrected to the spec-defined values `Used` and `Unused` (matching the column's Allowed Values table and the sibling `CapacityReservationStatus` rule). | Issue: [#2418](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/2418)<br>PR: [#2422](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/2422) |

--- a/specification/requirements_model/releases/1.2/model_details.json
+++ b/specification/requirements_model/releases/1.2/model_details.json
@@ -1,6 +1,6 @@
 {
   "Details": {
-    "ModelVersion": "1.2.0.2",
+    "ModelVersion": "1.2.0.3",
     "FOCUSVersion": "1.2"
   }
 }

--- a/specification/requirements_model/releases/1.2/model_rules/columns/commitmentdiscountstatus.json
+++ b/specification/requirements_model/releases/1.2/model_rules/columns/commitmentdiscountstatus.json
@@ -163,17 +163,12 @@
           {
             "CheckFunction": "CheckValue",
             "ColumnName": "CommitmentDiscountStatus",
-            "Value": "Active"
+            "Value": "Used"
           },
           {
             "CheckFunction": "CheckValue",
             "ColumnName": "CommitmentDiscountStatus",
-            "Value": "Expired"
-          },
-          {
-            "CheckFunction": "CheckValue",
-            "ColumnName": "CommitmentDiscountStatus",
-            "Value": "Pending"
+            "Value": "Unused"
           }
         ]
       },

--- a/specification/requirements_model/releases/1.3/model_details.json
+++ b/specification/requirements_model/releases/1.3/model_details.json
@@ -1,6 +1,6 @@
 {
   "Details": {
-    "ModelVersion": "1.3.0.2",
+    "ModelVersion": "1.3.0.3",
     "FOCUSVersion": "1.3"
   }
 }

--- a/specification/requirements_model/releases/1.3/model_rules/datasets/cost_and_usage/columns/commitmentdiscountstatus.json
+++ b/specification/requirements_model/releases/1.3/model_rules/datasets/cost_and_usage/columns/commitmentdiscountstatus.json
@@ -199,17 +199,12 @@
           {
             "CheckFunction": "CheckValue",
             "ColumnName": "CommitmentDiscountStatus",
-            "Value": "Active"
+            "Value": "Used"
           },
           {
             "CheckFunction": "CheckValue",
             "ColumnName": "CommitmentDiscountStatus",
-            "Value": "Expired"
-          },
-          {
-            "CheckFunction": "CheckValue",
-            "ColumnName": "CommitmentDiscountStatus",
-            "Value": "Pending"
+            "Value": "Unused"
           }
         ]
       },


### PR DESCRIPTION
## Summary

The Requirements Model rule for `CommitmentDiscountStatus` allowed values (`CommitmentDiscountStatus-C-005-M` in 1.2, `CAU-CommitmentDiscountStatus-C-005-M` in 1.3) lists `Active`, `Expired`, and `Pending`. None of these values appear in the FOCUS specification.

`CommitmentDiscountStatus` is a utilization field with exactly two allowed values, `Used` and `Unused`:

* The column "Allowed Values" table and normative requirements in `commitmentdiscountstatus.md` ("MUST be 'Used' when...", "MUST be 'Unused' when...")
* The canonical commitment-discount SQL in `spec.md` filters `WHERE CommitmentDiscountStatus = 'Unused'`

The specification text for both 1.2 and 1.3 is correct; only the Requirements Model is wrong. This is a Requirements Model Correction (`ERRATA.md` category D), the same class as the existing 1.2 `#2` and 1.3 `#7`/`#8` entries. The defect originated in the 1.2 model (`ModelVersionIntroduced: 1.2`) and persists in 1.3.

This PR:

* Corrects `C-005-M` allowed values to `Used` / `Unused` in the 1.2 and 1.3 Requirements Models, matching the spec text and the sibling `CapacityReservationStatus` rule
* Bumps the Requirements Model versions: 1.2 `1.2.0.2 -> 1.2.0.3`, 1.3 `1.3.0.2 -> 1.3.0.3`
* Documents the correction in `ERRATA.md` (Version 1.2 `#3`, Version 1.3 `#11`), noting the 1.2 origin on the 1.3 entry and revising the 1.3 section preamble to drop the claim that every issue originated in 1.3

The same defect in the unratified 1.4 / `latest` model is corrected as a non-errata draft fix in #2421.

Refs #2418

### Type of Change
* [x] Bug fix
* [ ] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** N/A (no example data in this PR).
