### PR TITLE
AI #2431: Fix incorrect Allows Nulls value for HostProviderName in CostAndUsage column table

### DIFF
--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -43,7 +43,7 @@ The specification for the Cost and Usage dataset defines a group of columns that
 | [Contracted Cost](#datasets.costandusage.contractedcost)                                            | Metric             | Mandatory     | False        | Decimal   |
 | [Contracted Unit Price](#datasets.costandusage.contractedunitprice)                                 | Metric             | Conditional   | True         | Decimal   |
 | [Effective Cost](#datasets.costandusage.effectivecost)                                              | Metric             | Mandatory     | False        | Decimal   |
-| [Host Provider Name](#datasets.costandusage.hostprovidername)                                       | Dimension          | Mandatory     | False        | String    |
+| [Host Provider Name](#datasets.costandusage.hostprovidername)                                       | Dimension          | Mandatory     | True         | String    |
 | [Invoice Detail ID](#datasets.costandusage.invoicedetailid)                                         | Dimension          | Conditional   | True         | String    |
 | [Invoice ID](#datasets.costandusage.invoiceid)                                                      | Dimension          | Conditional   | True         | String    |
 | [Invoice Issuer Name](#datasets.costandusage.invoiceissuername)                                     | Dimension          | Mandatory     | False        | String    |


### PR DESCRIPTION
## Summary

This PR fixes the incorrect Allows Nulls property value for HostProviderName in the CostAndUsage dataset column table overview and aligns it with the normative requirements and Content Constraints.

### Type of Change
* [x] Bug fix
* [ ] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
