### PR TITLE
AI #2522: Decouple Cost Definitions from Unit Price and Formalize Tiering and Contracted Defaults

### DIFF
--- a/specification/datasets/cost_and_usage/columns/listcost.md
+++ b/specification/datasets/cost_and_usage/columns/listcost.md
@@ -1,6 +1,12 @@
 # List Cost
 
-List Cost represents the cost calculated by multiplying the [*list unit price*](#glossary:list-unit-price) and the corresponding [Pricing Quantity](#datasets.costandusage.pricingquantity). List Cost is denominated in the [Billing Currency](#datasets.costandusage.billingcurrency) and is commonly used for calculating savings based on various rate optimization activities by comparing it with [Contracted Cost](#datasets.costandusage.contractedcost), [Billed Cost](#datasets.costandusage.billedcost) and [Effective Cost](#datasets.costandusage.effectivecost).
+List Cost represents the cost of a [*charge*](#glossary:charge) prior to the application of any discounts.
+
+When [List Unit Price](##datasets.costandusage.listunitprice) and [Pricing Quantity](#datasets.costandusage.pricingquantity) are provided for the *charge*, List Cost is calculated by multiplying the List Unit Price by the corresponding Pricing Quantity.
+
+For *charges* associated with [*SKUs*](#glossary:sku) with [threshold-based tiered pricing](#appendix.thresholdbasedtieredpricing), it reflects the applicable cost per pricing tier, which may be based on quantity, duration, or spend within a defined aggregation scope and aggregation interval.
+
+List Cost is denominated in the [Billing Currency](#datasets.costandusage.billingcurrency). List Cost is commonly used for calculating savings based on various rate optimization activities by comparing it with [Contracted Cost](#datasets.costandusage.contractedcost), [Billed Cost](#datasets.costandusage.billedcost), and [Effective Cost](#datasets.costandusage.effectivecost).
 
 ## Requirements
 
@@ -29,7 +35,7 @@ List Cost
 
 ## Description
 
-Cost calculated by multiplying List Unit Price and the corresponding Pricing Quantity.
+Cost of a *charge* prior to the application of any discounts.
 
 ## Content Constraints
 


### PR DESCRIPTION
## Summary

TODO

### Type of Change
* [x] Bug fix
* [ ] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
