### PR TITLE
RM #2315: Add AllocatedServiceName requirements model rules

### DIFF
--- a/specification/requirements_model/releases/1.5/model_rules/datasets/cost_and_usage/columns/allocatedservicename.json
+++ b/specification/requirements_model/releases/1.5/model_rules/datasets/cost_and_usage/columns/allocatedservicename.json
@@ -1,0 +1,204 @@
+{
+  "CAU-AllocatedServiceName-C-000-C": {
+    "Function": "Composite",
+    "Reference": "AllocatedServiceName",
+    "EntityType": "Column",
+    "EntityName": "Allocated Service Name",
+    "EntityId": "AllocatedServiceName",
+    "Notes": "",
+    "ModelVersionIntroduced": "1.5",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "DATA_GENERATOR_SPLIT_COST_ALLOCATION_SUPPORTED"
+    ],
+    "Type": "Static",
+    "Order": 0,
+    "DatasetType": "CAU",
+    "DatasetId": "CostAndUsage",
+    "DatasetName": "Cost and Usage",
+    "ValidationCriteria": {
+      "MustSatisfy": "AllocatedServiceName MUST adhere to the following requirements:",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckModelRule",
+            "ModelRuleId": "CAU-AllocatedServiceName-C-001-M"
+          },
+          {
+            "CheckFunction": "CheckModelRule",
+            "ModelRuleId": "CAU-AllocatedServiceName-C-002-M"
+          },
+          {
+            "CheckFunction": "CheckModelRule",
+            "ModelRuleId": "CAU-AllocatedServiceName-C-003-C"
+          }
+        ]
+      },
+      "Condition": {},
+      "Dependencies": [
+        "CAU-AllocatedServiceName-C-001-M",
+        "CAU-AllocatedServiceName-C-002-M",
+        "CAU-AllocatedServiceName-C-003-C",
+        "CAU-CostAndUsage-D-099-C"
+      ]
+    }
+  },
+  "CAU-AllocatedServiceName-C-001-M": {
+    "Function": "Type",
+    "Reference": "AllocatedServiceName",
+    "EntityName": "Allocated Service Name",
+    "EntityId": "AllocatedServiceName",
+    "EntityType": "Column",
+    "Notes": "",
+    "ModelVersionIntroduced": "1.5",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "Order": 20,
+    "DatasetType": "CAU",
+    "DatasetId": "CostAndUsage",
+    "DatasetName": "Cost and Usage",
+    "ValidationCriteria": {
+      "MustSatisfy": "AllocatedServiceName MUST be of type String.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "TypeString",
+        "ColumnName": "AllocatedServiceName"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "CAU-AllocatedServiceName-C-002-M": {
+    "Function": "Format",
+    "Reference": "AllocatedServiceName",
+    "EntityName": "Allocated Service Name",
+    "EntityId": "AllocatedServiceName",
+    "EntityType": "Column",
+    "Notes": "",
+    "ModelVersionIntroduced": "1.5",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "Order": 30,
+    "DatasetType": "CAU",
+    "DatasetId": "CostAndUsage",
+    "DatasetName": "Cost and Usage",
+    "ValidationCriteria": {
+      "MustSatisfy": "AllocatedServiceName MUST conform to StringHandling requirements.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "FormatString",
+        "ColumnName": "AllocatedServiceName"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "CAU-AllocatedServiceName-C-003-C": {
+    "Function": "Composite",
+    "Reference": "AllocatedServiceName",
+    "EntityName": "Allocated Service Name",
+    "EntityId": "AllocatedServiceName",
+    "EntityType": "Column",
+    "Notes": "",
+    "ModelVersionIntroduced": "1.5",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "Order": 40,
+    "DatasetType": "CAU",
+    "DatasetId": "CostAndUsage",
+    "DatasetName": "Cost and Usage",
+    "ValidationCriteria": {
+      "MustSatisfy": "AllocatedServiceName MUST adhere to the following nullability requirements:",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "AND",
+        "Items": [
+          {
+            "CheckFunction": "CheckModelRule",
+            "ModelRuleId": "CAU-AllocatedServiceName-C-004-C"
+          },
+          {
+            "CheckFunction": "CheckModelRule",
+            "ModelRuleId": "CAU-AllocatedServiceName-C-005-C"
+          }
+        ]
+      },
+      "Condition": {},
+      "Dependencies": [
+        "CAU-AllocatedServiceName-C-004-C",
+        "CAU-AllocatedServiceName-C-005-C"
+      ]
+    }
+  },
+  "CAU-AllocatedServiceName-C-004-C": {
+    "Function": "Nullability",
+    "Reference": "AllocatedServiceName",
+    "EntityName": "Allocated Service Name",
+    "EntityId": "AllocatedServiceName",
+    "EntityType": "Column",
+    "Notes": "",
+    "ModelVersionIntroduced": "1.5",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "Order": 50,
+    "DatasetType": "CAU",
+    "DatasetId": "CostAndUsage",
+    "DatasetName": "Cost and Usage",
+    "ValidationCriteria": {
+      "MustSatisfy": "AllocatedServiceName MUST be null when AllocatedResourceId is null.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "CheckValue",
+        "ColumnName": "AllocatedServiceName",
+        "Value": null
+      },
+      "Condition": {
+        "CheckFunction": "CheckValue",
+        "ColumnName": "AllocatedResourceId",
+        "Value": null
+      },
+      "Dependencies": [
+        "CAU-AllocatedResourceId-C-003-C"
+      ]
+    }
+  },
+  "CAU-AllocatedServiceName-C-005-C": {
+    "Function": "Nullability",
+    "Reference": "AllocatedServiceName",
+    "EntityName": "Allocated Service Name",
+    "EntityId": "AllocatedServiceName",
+    "EntityType": "Column",
+    "Notes": "",
+    "ModelVersionIntroduced": "1.5",
+    "Status": "Active",
+    "ApplicabilityCriteria": [],
+    "Type": "Static",
+    "Order": 60,
+    "DatasetType": "CAU",
+    "DatasetId": "CostAndUsage",
+    "DatasetName": "Cost and Usage",
+    "ValidationCriteria": {
+      "MustSatisfy": "AllocatedServiceName MUST NOT be null when AllocatedResourceId is not null.",
+      "Keyword": "MUST NOT",
+      "Requirement": {
+        "CheckFunction": "CheckNotValue",
+        "ColumnName": "AllocatedServiceName",
+        "Value": null
+      },
+      "Condition": {
+        "CheckFunction": "CheckNotValue",
+        "ColumnName": "AllocatedResourceId",
+        "Value": null
+      },
+      "Dependencies": [
+        "CAU-AllocatedResourceId-C-003-C"
+      ]
+    }
+  }
+}

--- a/specification/requirements_model/releases/1.5/model_rules/datasets/cost_and_usage/costandusage.json
+++ b/specification/requirements_model/releases/1.5/model_rules/datasets/cost_and_usage/costandusage.json
@@ -399,6 +399,10 @@
           {
             "CheckFunction": "CheckModelRule",
             "ModelRuleId": "CAU-CostAndUsage-D-097-C"
+          },
+          {
+            "CheckFunction": "CheckModelRule",
+            "ModelRuleId": "CAU-CostAndUsage-D-099-C"
           }
         ]
       },
@@ -471,7 +475,8 @@
         "CAU-CostAndUsage-D-073-C",
         "CAU-CostAndUsage-D-074-C",
         "CAU-CostAndUsage-D-075-M",
-        "CAU-CostAndUsage-D-076-M"
+        "CAU-CostAndUsage-D-076-M",
+        "CAU-CostAndUsage-D-099-C"
       ]
     }
   },
@@ -511,6 +516,10 @@
           {
             "CheckFunction": "CheckModelRule",
             "ModelRuleId": "CAU-AllocatedResourceName-C-000-C"
+          },
+          {
+            "CheckFunction": "CheckModelRule",
+            "ModelRuleId": "CAU-AllocatedServiceName-C-000-C"
           },
           {
             "CheckFunction": "CheckModelRule",
@@ -764,6 +773,7 @@
         "CAU-AllocatedMethodDetails-C-000-C",
         "CAU-AllocatedResourceId-C-000-C",
         "CAU-AllocatedResourceName-C-000-C",
+        "CAU-AllocatedServiceName-C-000-C",
         "CAU-AllocatedTags-C-000-C",
         "CAU-AvailabilityZone-C-000-C",
         "CAU-BilledCost-C-000-M",
@@ -2833,6 +2843,34 @@
       "Requirement": {
         "CheckFunction": "ColumnPresent",
         "ColumnName": "AllocatedTags"
+      },
+      "Condition": {},
+      "Dependencies": []
+    }
+  },
+  "CAU-CostAndUsage-D-099-C": {
+    "Function": "Presence",
+    "Reference": "AllocatedServiceName",
+    "EntityType": "Dataset",
+    "EntityName": "Allocated Service Name",
+    "EntityId": "AllocatedServiceName",
+    "DatasetType": "CAU",
+    "DatasetId": "CostAndUsage",
+    "DatasetName": "Cost and Usage",
+    "Notes": "",
+    "ModelVersionIntroduced": "1.5",
+    "Status": "Active",
+    "ApplicabilityCriteria": [
+      "DATA_GENERATOR_SPLIT_COST_ALLOCATION_SUPPORTED"
+    ],
+    "Order": 65,
+    "Type": "Static",
+    "ValidationCriteria": {
+      "MustSatisfy": "CostAndUsage MUST include AllocatedServiceName when the operating model includes split cost allocation.",
+      "Keyword": "MUST",
+      "Requirement": {
+        "CheckFunction": "ColumnPresent",
+        "ColumnName": "AllocatedServiceName"
       },
       "Condition": {},
       "Dependencies": []


### PR DESCRIPTION
## Summary

Adds requirements model rules for the `AllocatedServiceName` column introduced in spec PR #2395. Per RM TF agreement, requirements model updates are handled in separate PRs from spec content changes.

**Depends on PR #2395 merging first.**

Changes:
* New file: `allocatedservicename.json` — column rules `CAU-AllocatedServiceName-C-000-C` through `CAU-AllocatedServiceName-C-005-C` covering type, format, and nullability requirements.
* Updated: `costandusage.json` — adds presence rule `CAU-CostAndUsage-D-099-C` (AllocatedServiceName MUST be included when the operating model includes split cost allocation) and wires it into the dataset composite rule.

Part of #2315

## Type of Change

* [ ] New column or attribute
* [x] Requirements model update
* [ ] Editorial / non-normative

## Author Checklist

* [x] I have read the [AI Usage Guidelines](guidelines/contributors/ai-usage-guidelines.md) and this contribution complies with the attestation requirements.
* [x] This PR depends on #2395 and is noted as such.
* [x] RM rules follow the `<ArtifactName>-<Type>-<NumericId>-<Status>` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)