### PR TITLE
FR #2130: Remove duplicative cost-formula requirement from PricingQuantity

### DIFF
--- a/specification/datasets/cost_and_usage/columns/pricingquantity.md
+++ b/specification/datasets/cost_and_usage/columns/pricingquantity.md
@@ -13,7 +13,6 @@ PricingQuantity MUST adhere to the following requirements:
   * PricingQuantity MUST be null when [ChargeCategory](#datamodel.costandusage.chargecategory) is "Tax".
   * PricingQuantity MUST NOT be null when ChargeCategory is "Usage" or "Purchase" and [ChargeClass](#datamodel.costandusage.chargeclass) is not "Correction".
   * PricingQuantity MAY be null in all other cases.
-* Cost metric (e.g., [ContractedCost](#datamodel.costandusage.contractedcost)) MUST equal the product of the corresponding unit price (e.g., [ContractedUnitPrice](#datamodel.costandusage.contractedunitprice)) and PricingQuantity when the unit price is not null and PricingQuantity is not null.
 
 ## Usability Constraints
 


### PR DESCRIPTION
## Summary

This PR removes the duplicative cost-formula requirement from `PricingQuantity`.

The removed requirement restated the cost formula relationship already authoritatively defined in the `ListCost` and `ContractedCost` requirements. Keeping the same requirement in multiple locations created maintenance risk, as future updates could cause the duplicated versions to diverge.

The authoritative requirements remain unchanged:
- `ListCost` continues to define the relationship between `ListCost`, `ListUnitPrice`, and `PricingQuantity`.
- `ContractedCost` continues to define the relationship between `ContractedCost`, `ContractedUnitPrice`, and `PricingQuantity`.

This change follows the same DRY principle established in PR #2067, which removed identical duplicate requirements from `ListUnitPrice` and `ContractedUnitPrice`.

No behavioral changes are introduced. This is a specification refinement that reduces maintenance risk by ensuring each normative requirement is defined in a single authoritative location.

### Type of Change
* [x] Bug fix
* [ ] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
