### PR TITLE
Feedback #2543: Add ModelMesh to Fictitious Data Generator Reference and sort alphabetically

### DIFF
--- a/specification/appendix/appendix_overview.md
+++ b/specification/appendix/appendix_overview.md
@@ -48,7 +48,7 @@ The table below outlines the fictitious *data generators* used throughout the sp
 
 ## Fictitious Customer Reference<!--SkipTOC-->
 
-To contextualize the billing and cost allocation examples, this appendix utilizes fictitious customer profiles. These profiles represent common organizational structures and cloud adoption patterns.
+To contextualize the billing and cost allocation examples, this appendix utilizes fictitious customer profiles. These profiles represent common organizational structures and cloud adoption patterns, listed alphabetically by name:
 
 | Fictitious Customer | Company Profile | Customer Description |
 | :--- | :--- | :--- |
@@ -58,14 +58,14 @@ To contextualize the billing and cost allocation examples, this appendix utilize
 
 ## Fictitious Commitment Program Reference<!--SkipTOC-->
 
-To illustrate commitment program application and amortization without relying on vendor-specific terminology, the examples in this appendix use standardized fictitious commitment instruments. These constructs abstract the common commitment mechanisms used by major cloud and SaaS providers.
+To illustrate commitment program application and amortization without relying on vendor-specific terminology, the examples in this appendix use standardized fictitious commitment instruments. These constructs abstract the common commitment mechanisms used by major cloud and SaaS providers, listed alphabetically by name:
 
 | Fictitious Commitment Program | Acronym | Category | Fictitious Commitment Program Description | Similar Real-World Programs |
 | :--- | :--- | :--- | :--- | :--- |
-| **Resource Reservation** | RR | Usage | An upfront commitment to use a specific resource type, family, and region for a set term (e.g., 1 or 3 years) in exchange for a significantly reduced hourly rate. | Reserved Instances (AWS/Azure), Resource-based CUDs (GCP) |
-| **Flexible Spend Plan** | FSP | Spend | A commitment to spend a specific monetary amount per hour across a broad category of compute or service offerings, providing high flexibility as workloads shift. | Savings Plans (AWS) |
+| **Advance Resource Commitment** | ARC | Usage | An advance reservation of specific compute capacity in a region or availability zone, guaranteeing resource availability without necessarily providing a unit discount. Distinct from Resource Reservations, which are commitment discounts. | Capacity Reservations (AWS), On-demand Capacity Reservations (Azure), Zonal reservations (GCP) |
+| **Bulk Capacity Credit** | BCC | Spend | A pre-purchased pool of platform-specific credits or capacity units, consumed against usage over a contract period. Common among data and analytics platforms. | Capacity Commitments (Snowflake), Committed Use Discounts (Databricks) |
 | **Dynamic Compute Commitment** | DCC | Spend | A spend-based commitment covering aggregate compute resources (such as vCPU and memory) across multiple regions and machine families, converting the hourly spend into a usage discount. | Flexible CUDs (GCP) |
 | **Enterprise Spend Agreement** | ESA | Spend | An overarching, contractual agreement where an organization commits to a minimum aggregate spend across a provider's portfolio over a set term (e.g., 1-3 years) in exchange for a blanket percentage discount. | Enterprise Discount Programs (AWS), MACC (Azure) |
+| **Flexible Spend Plan** | FSP | Spend | A commitment to spend a specific monetary amount per hour across a broad category of compute or service offerings, providing high flexibility as workloads shift. | Savings Plans (AWS) |
 | **Interval Spend Commitment** | ISC | Spend | A recurring minimum-spend or minimum-usage agreement at fixed intervals (e.g., monthly, annual), common among SaaS observability and infrastructure monitoring providers. Program names inherently include the period reference. | Monthly/Annual Commitments (Datadog) |
-| **Bulk Capacity Credit** | BCC | Spend | A pre-purchased pool of platform-specific credits or capacity units, consumed against usage over a contract period. Common among data and analytics platforms. | Capacity Commitments (Snowflake), Committed Use Discounts (Databricks) |
-| **Advance Resource Commitment** | ARC | Usage | An advance reservation of specific compute capacity in a region or availability zone, guaranteeing resource availability without necessarily providing a unit discount. Distinct from Resource Reservations, which are commitment discounts. | Capacity Reservations (AWS), On-demand Capacity Reservations (Azure), Zonal reservations (GCP) |
+| **Resource Reservation** | RR | Usage | An upfront commitment to use a specific resource type, family, and region for a set term (e.g., 1 or 3 years) in exchange for a significantly reduced hourly rate. | Reserved Instances (AWS/Azure), Resource-based CUDs (GCP) |

--- a/specification/appendix/appendix_overview.md
+++ b/specification/appendix/appendix_overview.md
@@ -35,6 +35,7 @@ The table below outlines the fictitious *data generators* used throughout the ap
 | **CrestNode** | Cloud Service Provider | An enterprise-focused cloud platform with deep integrations into existing corporate software ecosystems and directory services. | Microsoft Azure |
 | **LatticeScale** | Cloud Service Provider | A cloud provider heavily optimized for machine learning, data analytics, and containerized Kubernetes workloads. | Google Cloud Platform (GCP) |
 | **Solora AI** | Foundation Model Developer | An AI lab that develops and trains foundation models that are sold directly and served by cloud providers as a first-party offering. | OpenAI, Anthropic |
+| **ModelMesh** | Foundation Model Developer | An AI lab that publishes open-weight foundation models, which are self-hosted or served by cloud providers and inference platforms. | Meta (Llama), Mistral AI |
 | **OmniQuery** | Data Platform | A centralized hub for storing, processing, and analyzing massive datasets to drive business intelligence. | Snowflake, Databricks |
 | **StackLens** | SaaS Observability | A monitoring tool that tracks application performance, logs, and system health in real-time to prevent downtime. | Datadog, New Relic |
 | **SprintCanvas** | Project Management | A collaborative workspace for planning, assigning, and tracking team tasks and agile workflows. | Jira, Asana, Trello |

--- a/specification/appendix/appendix_overview.md
+++ b/specification/appendix/appendix_overview.md
@@ -25,7 +25,7 @@
 
 To illustrate how FOCUS normalizes the presentation of data across diverse technology environments, the appendix uses a standardized set of fictitious [*data generators*](#metadata.datagenerator). These represent common architectural components, ranging from core cloud infrastructure to SaaS platforms. Using these examples demonstrates cross-vendor cost allocation, standardized billing schemas, and multi-cloud reporting without relying on proprietary vendor data.
 
-Disclaimer: *The fictitious entities (data generators, customers, and commitment programs) referenced in this appendix are intended solely for illustrative purposes to resemble real-world services and organizations. They do not reflect, represent, or imply the actual current or future FOCUS implementations, billing schemas, or data formats of any real-world companies or equivalents listed herein.*
+Disclaimer: *The fictitious entities (data generators, customers, and commitment programs) listed in this appendix are intended solely for illustrative purposes to resemble real-world services and organizations. They do not reflect, represent, or imply the actual current or future FOCUS implementations, billing schemas, or data formats of any real-world companies or equivalents listed herein.*
 
 The table below outlines the fictitious *data generators* used throughout the specification, their primary functions, and their real-world counterparts for context, listed alphabetically by name:
 
@@ -36,7 +36,7 @@ The table below outlines the fictitious *data generators* used throughout the sp
 | **CollabChat** | Team Communications | A messaging platform offering organized chat channels, direct messaging, and secure file sharing for remote teams. | Slack |
 | **CrestNode** | Cloud Service Provider | An enterprise-focused cloud platform with deep integrations into existing corporate software ecosystems and directory services. | Microsoft Azure |
 | **LatticeScale** | Cloud Service Provider | A cloud provider heavily optimized for machine learning, data analytics, and containerized Kubernetes workloads. | Google Cloud Platform (GCP) |
-| **ModelMesh** | Foundation Model Developer | An AI lab that publishes open-weight foundation models, which are self-hosted or served by cloud providers and inference platforms. | Meta (Llama), Mistral AI |
+| **ModelMesh** | Foundation Model Developer | An AI lab that develops and trains open-weight foundation models, which are self-hosted or served by cloud providers and inference platforms. | Meta (Llama), Mistral AI |
 | **OmniQuery** | Data Platform | A centralized hub for storing, processing, and analyzing massive datasets to drive business intelligence. | Snowflake, Databricks |
 | **PipelCRM** | CRM | A customer relationship management platform designed to track sales pipelines, manage contacts, and optimize lead conversion. | Salesforce, HubSpot |
 | **PulseMail** | Email API | A developer-friendly service for reliably routing, sending, and tracking both transactional and marketing emails. | SendGrid, Mailgun |

--- a/specification/appendix/appendix_overview.md
+++ b/specification/appendix/appendix_overview.md
@@ -27,24 +27,24 @@ To illustrate how FOCUS normalizes the presentation of data across diverse techn
 
 Disclaimer: *The fictitious entities (data generators, customers, and commitment programs) referenced in this appendix are intended solely for illustrative purposes to resemble real-world services and organizations. They do not reflect, represent, or imply the actual current or future FOCUS implementations, billing schemas, or data formats of any real-world companies or equivalents listed herein.*
 
-The table below outlines the fictitious *data generators* used throughout the appendix, their primary functions, and their real-world counterparts for context:
+The table below outlines the fictitious *data generators* used throughout the specification, their primary functions, and their real-world counterparts for context, listed alphabetically by name:
 
 | Fictitious Data Generator | Service Offering | Fictitious Data Generator Description | Similar Real-World Examples |
 | :--- | :--- | :--- | :--- |
 | **Aura Web** | Cloud Service Provider | A highly scalable, market-leading cloud infrastructure provider offering extensive compute, storage, and serverless options. | Amazon Web Services (AWS) |
+| **Budget Beacon** | Cost Management | A cloud cost-optimization platform that shines a spotlight on overspending, waste, and savings opportunities across multi-cloud environments. | Cloudability, CloudHealth, ProsperOps |
+| **CollabChat** | Team Communications | A messaging platform offering organized chat channels, direct messaging, and secure file sharing for remote teams. | Slack |
 | **CrestNode** | Cloud Service Provider | An enterprise-focused cloud platform with deep integrations into existing corporate software ecosystems and directory services. | Microsoft Azure |
 | **LatticeScale** | Cloud Service Provider | A cloud provider heavily optimized for machine learning, data analytics, and containerized Kubernetes workloads. | Google Cloud Platform (GCP) |
-| **Solora AI** | Foundation Model Developer | An AI lab that develops and trains foundation models that are sold directly and served by cloud providers as a first-party offering. | OpenAI, Anthropic |
 | **ModelMesh** | Foundation Model Developer | An AI lab that publishes open-weight foundation models, which are self-hosted or served by cloud providers and inference platforms. | Meta (Llama), Mistral AI |
 | **OmniQuery** | Data Platform | A centralized hub for storing, processing, and analyzing massive datasets to drive business intelligence. | Snowflake, Databricks |
-| **StackLens** | SaaS Observability | A monitoring tool that tracks application performance, logs, and system health in real-time to prevent downtime. | Datadog, New Relic |
-| **SprintCanvas** | Project Management | A collaborative workspace for planning, assigning, and tracking team tasks and agile workflows. | Jira, Asana, Trello |
-| **StoreStack** | Database as a Service | A fully managed, scalable cloud database solution that handles provisioning, backups, and routine maintenance. | MongoDB Atlas |
-| **CollabChat** | Team Communications | A messaging platform offering organized chat channels, direct messaging, and secure file sharing for remote teams. | Slack |
-| **PulseMail** | Email API | A developer-friendly service for reliably routing, sending, and tracking both transactional and marketing emails. | SendGrid, Mailgun |
 | **PipelCRM** | CRM | A customer relationship management platform designed to track sales pipelines, manage contacts, and optimize lead conversion. | Salesforce, HubSpot |
-| **Budget Beacon** | Cost Management | A cloud cost-optimization platform that shines a spotlight on overspending, waste, and savings opportunities across multi-cloud environments. | Cloudability, CloudHealth, ProsperOps |
+| **PulseMail** | Email API | A developer-friendly service for reliably routing, sending, and tracking both transactional and marketing emails. | SendGrid, Mailgun |
 | **SchemaWeaver** | Open Source Library | An open-source tool that refines raw cloud cost and usage data, normalizing it into FOCUS-compliant schemas for downstream analytics and reporting. Not a public service. | OpenCost, Cloud Intelligence Dashboards, FinOps toolkit |
+| **Solora AI** | Foundation Model Developer | An AI lab that develops and trains foundation models that are sold directly and served by cloud providers as a first-party offering. | OpenAI, Anthropic |
+| **SprintCanvas** | Project Management | A collaborative workspace for planning, assigning, and tracking team tasks and agile workflows. | Jira, Asana, Trello |
+| **StackLens** | SaaS Observability | A monitoring tool that tracks application performance, logs, and system health in real-time to prevent downtime. | Datadog, New Relic |
+| **StoreStack** | Database as a Service | A fully managed, scalable cloud database solution that handles provisioning, backups, and routine maintenance. | MongoDB Atlas |
 
 ## Fictitious Customer Reference<!--SkipTOC-->
 

--- a/specification/appendix/appendix_overview.md
+++ b/specification/appendix/appendix_overview.md
@@ -27,7 +27,7 @@ To illustrate how FOCUS normalizes the presentation of data across diverse techn
 
 Disclaimer: *The fictitious entities (data generators, customers, and commitment programs) listed in this appendix are intended solely for illustrative purposes to resemble real-world services and organizations. They do not reflect, represent, or imply the actual current or future FOCUS implementations, billing schemas, or data formats of any real-world companies or equivalents listed herein.*
 
-The table below outlines the fictitious *data generators* used throughout the specification, their primary functions, and their real-world counterparts for context, listed alphabetically by name:
+The table below outlines the fictitious *data generators* used throughout the specification, their primary functions, and their real-world counterparts for context. Entries are listed alphabetically by data generator name:
 
 | Fictitious Data Generator | Service Offering | Fictitious Data Generator Description | Similar Real-World Examples |
 | :--- | :--- | :--- | :--- |
@@ -48,7 +48,7 @@ The table below outlines the fictitious *data generators* used throughout the sp
 
 ## Fictitious Customer Reference<!--SkipTOC-->
 
-To contextualize the billing and cost allocation examples, this appendix utilizes fictitious customer profiles. These profiles represent common organizational structures and cloud adoption patterns, listed alphabetically by name:
+To contextualize the billing and cost allocation examples, this appendix utilizes fictitious customer profiles. These profiles represent common organizational structures and cloud adoption patterns. Entries are listed alphabetically by customer name:
 
 | Fictitious Customer | Company Profile | Customer Description |
 | :--- | :--- | :--- |
@@ -58,7 +58,7 @@ To contextualize the billing and cost allocation examples, this appendix utilize
 
 ## Fictitious Commitment Program Reference<!--SkipTOC-->
 
-To illustrate commitment program application and amortization without relying on vendor-specific terminology, the examples in this appendix use standardized fictitious commitment instruments. These constructs abstract the common commitment mechanisms used by major cloud and SaaS providers, listed alphabetically by name:
+To illustrate commitment program application and amortization without relying on vendor-specific terminology, the examples in this appendix use standardized fictitious commitment instruments. These constructs abstract the common commitment mechanisms used by major cloud and SaaS providers. Entries are listed alphabetically by commitment program name:
 
 | Fictitious Commitment Program | Acronym | Category | Fictitious Commitment Program Description | Similar Real-World Programs |
 | :--- | :--- | :--- | :--- | :--- |


### PR DESCRIPTION
## Summary

Closes #2543.

`ModelMesh` is used as an example value for the `ModelDeveloper`, `ModelFamily`, and `ModelId` properties in the [SkuPriceDetails](/specification/datasets/cost_and_usage/columns/skupricedetails.md) column definition, but it was never defined in the Fictitious Data Generator Reference table in [appendix_overview.md](/specification/appendix/appendix_overview.md). This PR adds it and sorts all three fictitious entity tables in that file alphabetically.

**1. Added a ModelMesh row.**

| Fictitious Data Generator | Service Offering | Fictitious Data Generator Description | Similar Real-World Examples |
| :--- | :--- | :--- | :--- |
| **ModelMesh** | Foundation Model Developer | An AI lab that publishes open-weight foundation models, which are self-hosted or served by cloud providers and inference platforms. | Meta (Llama), Mistral AI |

ModelMesh is described as an open-weight model developer. That distinguishes it from Solora AI, which develops proprietary models "sold directly and served by cloud providers as a first-party offering", and it fits the parameter count carried in the `modelmesh-general-7b` example model identifier. The original intent for ModelMesh was not recorded anywhere, so this is an inference from how the name is used. Reviewers who know the intent should redirect the framing.

**2. Sorted the table alphabetically by fictitious data generator name.** The table previously listed the three cloud service providers first and then appended later entries in the order they were added, which is what the issue's Additional Notes flagged. The sibling Fictitious Customer Reference table and the Appendix Entries table are both alphabetical. Row content is unchanged, and the reorder is in its own commit so it can be reviewed or dropped independently of the ModelMesh addition.

**3. Sorted the Fictitious Commitment Program Reference table alphabetically** by program name, which also puts it in acronym order (ARC, BCC, DCC, ESA, FSP, ISC, RR). It had the same append-order problem as the data generator table. Row content is unchanged. The Fictitious Customer Reference table in the same file was already alphabetical and its rows are untouched.

**4. Stated the alphabetical convention in each section's introductory sentence,** so all three tables carry the same rule and later additions have a stated insertion point rather than defaulting to the bottom of the table again.

**5. Broadened one phrase.** In the Fictitious Data Generator Reference intro, "used throughout the appendix" became "used throughout the specification". ModelMesh and Solora AI are referenced in the SkuPriceDetails column definition rather than in appendix content, so the previous wording no longer described what the table lists. This one goes past the literal ask and is easy to drop on its own.

### Verification

* `python3 enhanced_markdown_lint.py --config markdownlnt.cfg scan appendix/appendix_overview.md` passes.
* `python3 validate_includes.py appendix` passes.
* Confirmed both reorders preserve content: every row across all three tables is byte-identical to its previous version, with only position changed, and all three tables sort correctly.
* The full `make` build was not run locally, since pandoc, wkhtmltopdf, and markdown-pp are not installed in this environment. CI covers it.

### Changelog

* 2026-07-31: Opened. Added the ModelMesh row, sorted the Fictitious Data Generator Reference table alphabetically, and adjusted its introductory sentence.
* 2026-07-31: Extended the ordering pass to the remaining fictitious entity tables. Sorted the Fictitious Commitment Program Reference table alphabetically and stated the convention in the Fictitious Customer Reference and Fictitious Commitment Program Reference sections.

### Type of Change

* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist

* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
