### PR TITLE
AI #2610: Carry open AllocatedServiceName requirement threads out of PR #2395

### DIFF
--- a/specification/datasets/cost_and_usage/columns/allocatedservicename.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedservicename.md
@@ -9,8 +9,10 @@ AllocatedServiceName MUST adhere to the following requirements:
 * AllocatedServiceName MUST be of type String.
 * AllocatedServiceName MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * AllocatedServiceName MUST adhere to the following nullability requirements:
-  * AllocatedServiceName MUST be null when [AllocatedResourceId](#datasets.costandusage.allocatedresourceid) is null.
-  * AllocatedServiceName MUST NOT be null when AllocatedResourceId is not null.
+  * AllocatedServiceName MUST be null when a [*charge*](#glossary:charge) is not related to a data generator-calculated split cost allocation.
+  * AllocatedServiceName MUST be null when a *charge* represents the unallocated portion of the origin *charge* after split cost allocation.
+  * AllocatedServiceName MUST NOT be null when a *charge* represents the allocated portion of the origin *charge*.
+* AllocatedServiceName SHOULD match the ServiceName of the *service* to which cost is allocated when that *service* is represented by ServiceName in the FOCUS dataset.
 
 ## Column ID
 


### PR DESCRIPTION
## Summary

Carries the two open review threads on PR #2395 out of that PR, so PR #2395 can be delivered as approved. Both threads sit on the `AllocatedServiceName` requirements block, and this PR changes only that block. No other file is touched.

Opened against the PR #2395 branch (`2315-allocated-service-columns`). It re-points to `working_draft` on its own once PR #2395 merges.

### Nullability bullets state the condition directly

The bullets on PR #2395 anchor `AllocatedServiceName`'s nullability to `AllocatedResourceId`'s. That stands in for the condition this column cares about, which is whether the *charge* is the allocated portion of a split. The three cases here state that condition directly, in the wording `AllocatedResourceId` already uses for itself. Behavior is identical on every row where both columns are populated.

It also covers the case @pydi-aws raised on PR #2395. When a data generator's configuration suppresses resource identifiers on split rows, as with AWS Data Exports where `INCLUDE_RESOURCES` is disabled, the inherited wording requires `AllocatedServiceName` to be null even where the consuming *service* is known. Keying on the *charge's* role lets a generator surface it, without softening the rule to SHOULD.

### Value-consistency requirement added

From @kk09v's suggestion on PR #2395: a data generator that publishes a *service* under one `ServiceName` should not surface a permuted form of that name in `AllocatedServiceName`, so that "K8S" does not appear where the dataset elsewhere carries "Kubernetes".

The `when` condition follows @flanakin's proposal from TF-2 on 2026-08-05. It scopes the requirement to the *service* the column names, so the column can still carry a *service* different from the one in `ServiceName` on the same row, which is the reason the column exists. SHOULD rather than MUST for the reason @kk09v gave: an allocated *service* is not always offered on its own, so a data generator may have no stand-alone `ServiceName` to align to.

The bullet sits as a sibling of the nullability anchor rather than a child of it. The anchor reads "MUST adhere to the following nullability requirements:", which scopes its children to nullability, and this is a value-consistency expectation.

### Resulting block

```markdown
* AllocatedServiceName MUST adhere to the following nullability requirements:
  * AllocatedServiceName MUST be null when a [*charge*](#glossary:charge) is not related to a data generator-calculated split cost allocation.
  * AllocatedServiceName MUST be null when a *charge* represents the unallocated portion of the origin *charge* after split cost allocation.
  * AllocatedServiceName MUST NOT be null when a *charge* represents the allocated portion of the origin *charge*.
* AllocatedServiceName SHOULD match the ServiceName of the *service* to which cost is allocated when that *service* is represented by ServiceName in the FOCUS dataset.
```

### Verification

`enhanced_markdown_lint.py` passes on the changed file. The three nullability bullets are word-for-word the cases `AllocatedResourceId` states for itself, other than the column name and the first-occurrence glossary link on *charge*.

### Type of Change

* [x] New feature / Specification update

### Author Checklist

* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** Not applicable. This PR contains no examples.

### Changelog

* 2026-08-06: Opened against the PR #2395 branch carrying both open threads.

Closes #2610
Part of #2315
