### PR TITLE
AI #2587: Remove repeated condition links from the dataset files

### DIFF
--- a/specification/datasets/contract_commitment/dataset.md
+++ b/specification/datasets/contract_commitment/dataset.md
@@ -23,7 +23,7 @@ The Contract Commitment dataset is a supporting dataset that describes the terms
 | [Contract Commitment Offer Category](#datamodel.contractcommitment.contractcommitmentoffercategory) | Dimension | Mandatory | False | String |
 | [Contract Commitment Payment Interval](#datamodel.contractcommitment.contractcommitmentpaymentinterval) | Dimension | Mandatory | False | String |
 | [Contract Commitment Payment Model](#datamodel.contractcommitment.contractcommitmentpaymentmodel) | Dimension | Mandatory | False | String |
-| [Contract Commitment Payment Upfront Percentage](#datamodel.contractcommitment.contractcommitmentpaymentupfrontpercentage) | Metric | [Conditional](#conditions.includespartialupfrontpayments) | False | Decimal |
+| [Contract Commitment Payment Upfront Percentage](#datamodel.contractcommitment.contractcommitmentpaymentupfrontpercentage) | Metric | Conditional | False | Decimal |
 | [Contract Commitment Period End](#datamodel.contractcommitment.contractcommitmentperiodend) | Dimension | Mandatory | False | Date/Time |
 | [Contract Commitment Period Start](#datamodel.contractcommitment.contractcommitmentperiodstart) | Dimension | Mandatory | False | Date/Time |
 | [Contract Commitment Quantity](#datamodel.contractcommitment.contractcommitmentquantity) | Metric | Mandatory | True | Decimal |
@@ -33,8 +33,8 @@ The Contract Commitment dataset is a supporting dataset that describes the terms
 | [Contract Period End](#datamodel.contractcommitment.contractperiodend) | Dimension | Mandatory | False | Date/Time |
 | [Contract Period Start](#datamodel.contractcommitment.contractperiodstart) | Dimension | Mandatory | False | Date/Time |
 | [Invoice Issuer Name](#datamodel.contractcommitment.invoiceissuername) | Dimension | Mandatory | False | String |
-| [Pricing Currency](#datamodel.contractcommitment.pricingcurrency) | Dimension | [Conditional](#conditions.includespricing-billingcurrencydifferences) | False | String |
-| [Pricing Currency Contract Commitment Cost](#datamodel.contractcommitment.pricingcurrencycontractcommitmentcost) | Metric | [Conditional](#conditions.includespricing-billingcurrencydifferences) | True | Decimal |
+| [Pricing Currency](#datamodel.contractcommitment.pricingcurrency) | Dimension | Conditional | False | String |
+| [Pricing Currency Contract Commitment Cost](#datamodel.contractcommitment.pricingcurrencycontractcommitmentcost) | Metric | Conditional | True | Decimal |
 | [Service Provider Name](#datamodel.contractcommitment.serviceprovidername) | Dimension | Mandatory | False | String |
 
 ## Relationships<!--SkipTOC-->
@@ -81,7 +81,7 @@ ContractCommitment MUST adhere to the following requirements:
   * ContractCommitment MUST include [ContractPeriodStart](#datamodel.contractcommitment.contractperiodstart).
   * ContractCommitment MUST include [InvoiceIssuerName](#datamodel.contractcommitment.invoiceissuername).
   * ContractCommitment MUST include [PricingCurrency](#datamodel.contractcommitment.pricingcurrency) when the *operating model* [includes pricing and billing currency differences](#conditions.includespricing-billingcurrencydifferences).
-  * ContractCommitment MUST include [PricingCurrencyContractCommitmentCost](#datamodel.contractcommitment.pricingcurrencycontractcommitmentcost) when the *operating model* [includes pricing and billing currency differences](#conditions.includespricing-billingcurrencydifferences).
+  * ContractCommitment MUST include [PricingCurrencyContractCommitmentCost](#datamodel.contractcommitment.pricingcurrencycontractcommitmentcost) when the *operating model* includes pricing and billing currency differences.
   * ContractCommitment MUST include [ServiceProviderName](#datamodel.contractcommitment.serviceprovidername).
 * ContractCommitment MUST conform to [CorrectionHandling](#attributes.correctionhandling) requirements.
 * ContractCommitment MUST conform to [DatasetCompleteness](#attributes.datasetcompleteness) requirements.

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -95,7 +95,7 @@ CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MUST include [AllocatedMethodId](#datamodel.costandusage.allocatedmethodid) when the *operating model* includes split cost allocation.
   * CostAndUsage MUST include [AllocatedResourceId](#datamodel.costandusage.allocatedresourceid) when the *operating model* includes split cost allocation.
   * CostAndUsage MUST include [AllocatedResourceName](#datamodel.costandusage.allocatedresourcename) when the *operating model* includes split cost allocation.
-  * CostAndUsage MUST include [AllocatedServiceName](#datamodel.costandusage.allocatedservicename) when the *operating model* [includes split cost allocation](#conditions.includessplitcostallocation).
+  * CostAndUsage MUST include [AllocatedServiceName](#datamodel.costandusage.allocatedservicename) when the *operating model* includes split cost allocation.
   * CostAndUsage MUST include [AllocatedTags](#datamodel.costandusage.allocatedtags) when the *operating model* includes split cost allocation.
   * CostAndUsage SHOULD include [AvailabilityZone](#datamodel.costandusage.availabilityzone) when the *operating model* [includes availability zones](#conditions.includesavailabilityzones).
   * CostAndUsage MUST include [BilledCost](#datamodel.costandusage.billedcost).
@@ -136,16 +136,16 @@ CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MUST include [PricingCategory](#datamodel.costandusage.pricingcategory) when the *operating model* [includes multiple pricing categories](#conditions.includesmultiplepricingcategories).
   * CostAndUsage MUST include [PricingCurrency](#datamodel.costandusage.pricingcurrency) when the *operating model* [includes pricing and billing currency differences](#conditions.includespricing-billingcurrencydifferences).
   * CostAndUsage MUST adhere to the following [PricingCurrencyContractedUnitPrice](#datamodel.costandusage.pricingcurrencycontractedunitprice) requirements:
-    * CostAndUsage MUST include PricingCurrencyContractedUnitPrice when the *operating model* [includes virtual currency](#conditions.includesvirtualcurrency) and [includes list unit prices](#conditions.includeslistunitprices).
-    * CostAndUsage SHOULD include PricingCurrencyContractedUnitPrice when the *operating model* [includes pricing and billing currency differences](#conditions.includespricing-billingcurrencydifferences) and [includes list unit prices](#conditions.includeslistunitprices).
+    * CostAndUsage MUST include PricingCurrencyContractedUnitPrice when the *operating model* [includes virtual currency](#conditions.includesvirtualcurrency) and includes list unit prices.
+    * CostAndUsage SHOULD include PricingCurrencyContractedUnitPrice when the *operating model* includes pricing and billing currency differences and includes list unit prices.
     * CostAndUsage MAY include PricingCurrencyContractedUnitPrice in all other cases.
   * CostAndUsage MUST adhere to the following [PricingCurrencyEffectiveCost](#datamodel.costandusage.pricingcurrencyeffectivecost) requirements:
-    * CostAndUsage MUST include PricingCurrencyEffectiveCost when the *operating model* [includes virtual currency](#conditions.includesvirtualcurrency) and [includes list unit prices](#conditions.includeslistunitprices).
-    * CostAndUsage SHOULD include PricingCurrencyEffectiveCost when the *operating model* [includes pricing and billing currency differences](#conditions.includespricing-billingcurrencydifferences) and [includes list unit prices](#conditions.includeslistunitprices).
+    * CostAndUsage MUST include PricingCurrencyEffectiveCost when the *operating model* includes virtual currency and includes list unit prices.
+    * CostAndUsage SHOULD include PricingCurrencyEffectiveCost when the *operating model* includes pricing and billing currency differences and includes list unit prices.
     * CostAndUsage MAY include PricingCurrencyEffectiveCost in all other cases.
   * CostAndUsage MUST adhere to the following [PricingCurrencyListUnitPrice](#datamodel.costandusage.pricingcurrencylistunitprice) requirements:
-    * CostAndUsage MUST include PricingCurrencyListUnitPrice when the *operating model* [includes virtual currency](#conditions.includesvirtualcurrency) and [includes list unit prices](#conditions.includeslistunitprices).
-    * CostAndUsage SHOULD include PricingCurrencyListUnitPrice when the *operating model* [includes pricing and billing currency differences](#conditions.includespricing-billingcurrencydifferences) and [includes list unit prices](#conditions.includeslistunitprices).
+    * CostAndUsage MUST include PricingCurrencyListUnitPrice when the *operating model* includes virtual currency and includes list unit prices.
+    * CostAndUsage SHOULD include PricingCurrencyListUnitPrice when the *operating model* includes pricing and billing currency differences and includes list unit prices.
     * CostAndUsage MAY include PricingCurrencyListUnitPrice in all other cases.
   * CostAndUsage MUST include [PricingQuantity](#datamodel.costandusage.pricingquantity).
   * CostAndUsage MUST include [PricingUnit](#datamodel.costandusage.pricingunit).
@@ -159,9 +159,9 @@ CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MUST include [ServiceProviderName](#datamodel.costandusage.serviceprovidername).
   * CostAndUsage SHOULD include [ServiceSubcategory](#datamodel.costandusage.servicesubcategory).
   * CostAndUsage MUST include [SkuId](#datamodel.costandusage.skuid) when the *operating model* [includes unit pricing](#conditions.includesunitpricing).
-  * CostAndUsage MUST include [SkuMeter](#datamodel.costandusage.skumeter) when the *operating model* [includes unit pricing](#conditions.includesunitpricing).
-  * CostAndUsage MUST include [SkuPriceDetails](#datamodel.costandusage.skupricedetails) when the *operating model* [includes unit pricing](#conditions.includesunitpricing).
-  * CostAndUsage MUST include [SkuPriceId](#datamodel.costandusage.skupriceid) when the *operating model* [includes unit pricing](#conditions.includesunitpricing).
+  * CostAndUsage MUST include [SkuMeter](#datamodel.costandusage.skumeter) when the *operating model* includes unit pricing.
+  * CostAndUsage MUST include [SkuPriceDetails](#datamodel.costandusage.skupricedetails) when the *operating model* includes unit pricing.
+  * CostAndUsage MUST include [SkuPriceId](#datamodel.costandusage.skupriceid) when the *operating model* includes unit pricing.
   * CostAndUsage MUST include [SubAccountId](#datamodel.costandusage.subaccountid) when the *operating model* [includes sub accounts](#conditions.includessubaccounts).
   * CostAndUsage MUST include [SubAccountName](#datamodel.costandusage.subaccountname) when the *operating model* includes sub accounts.
   * CostAndUsage MUST include [SubAccountType](#datamodel.costandusage.subaccounttype) when the *operating model* [includes multiple sub account types](#conditions.includesmultiplesubaccounttypes).

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -12,7 +12,7 @@ The specification for the Cost and Usage dataset defines a group of columns that
 | [Allocated Method ID](#datamodel.costandusage.allocatedmethodid)                                     | Dimension          | Conditional | True         | String    |
 | [Allocated Resource ID](#datamodel.costandusage.allocatedresourceid)                                 | Dimension          | Conditional | True         | String    |
 | [Allocated Resource Name](#datamodel.costandusage.allocatedresourcename)                             | Dimension          | Conditional | True         | String    |
-| [Allocated Service Name](#datamodel.costandusage.allocatedservicename)                               | Dimension          | [Conditional](#conditions.includessplitcostallocation) | True         | String    |
+| [Allocated Service Name](#datamodel.costandusage.allocatedservicename)                               | Dimension          | Conditional | True         | String    |
 | [Allocated Tags](#datamodel.costandusage.allocatedtags)                                              | Dimension          | Conditional | True         | JSON      |
 | [Availability Zone](#datamodel.costandusage.availabilityzone)                                        | Dimension          | Recommended   | True         | String    |
 | [Billed Cost](#datamodel.costandusage.billedcost)                                                    | Metric             | Mandatory     | False        | Decimal   |
@@ -49,7 +49,7 @@ The specification for the Cost and Usage dataset defines a group of columns that
 | [Invoice ID](#datamodel.costandusage.invoiceid)                                                      | Dimension          | Conditional | True         | String    |
 | [Invoice Issuer Name](#datamodel.costandusage.invoiceissuername)                                     | Dimension          | Mandatory     | False        | String    |
 | [List Cost](#datamodel.costandusage.listcost)                                                        | Metric             | Mandatory     | False        | Decimal   |
-| [List Unit Price](#datamodel.costandusage.listunitprice)                                             | Metric             | [Conditional](#conditions.includeslistunitprices) | True         | Decimal   |
+| [List Unit Price](#datamodel.costandusage.listunitprice)                                             | Metric             | Conditional | True         | Decimal   |
 | [Pricing Category](#datamodel.costandusage.pricingcategory)                                          | Dimension          | Conditional | True         | String    |
 | [Pricing Currency](#datamodel.costandusage.pricingcurrency)                                          | Dimension          | Conditional | False        | String    |
 | [Pricing Currency Contracted Unit Price](#datamodel.costandusage.pricingcurrencycontractedunitprice) | Metric             | Conditional | True         | Decimal   |
@@ -66,10 +66,10 @@ The specification for the Cost and Usage dataset defines a group of columns that
 | [Service Name](#datamodel.costandusage.servicename)                                                  | Dimension          | Mandatory     | False        | String    |
 | [Service Provider Name](#datamodel.costandusage.serviceprovidername)                                 | Dimension          | Mandatory     | False        | String    |
 | [Service Subcategory](#datamodel.costandusage.servicesubcategory)                                    | Dimension          | Recommended   | False        | String    |
-| [SKU ID](#datamodel.costandusage.skuid)                                                              | Dimension          | [Conditional](#conditions.includesunitpricing) | True         | String    |
-| [SKU Meter](#datamodel.costandusage.skumeter)                                                        | Dimension          | [Conditional](#conditions.includesunitpricing) | True         | String    |
-| [SKU Price Details](#datamodel.costandusage.skupricedetails)                                         | Dimension          | [Conditional](#conditions.includesunitpricing) | True         | JSON      |
-| [SKU Price ID](#datamodel.costandusage.skupriceid)                                                   | Dimension          | [Conditional](#conditions.includesunitpricing) | True         | String    |
+| [SKU ID](#datamodel.costandusage.skuid)                                                              | Dimension          | Conditional | True         | String    |
+| [SKU Meter](#datamodel.costandusage.skumeter)                                                        | Dimension          | Conditional | True         | String    |
+| [SKU Price Details](#datamodel.costandusage.skupricedetails)                                         | Dimension          | Conditional | True         | JSON      |
+| [SKU Price ID](#datamodel.costandusage.skupriceid)                                                   | Dimension          | Conditional | True         | String    |
 | [Sub Account ID](#datamodel.costandusage.subaccountid)                                               | Dimension          | Conditional | True         | String    |
 | [Sub Account Name](#datamodel.costandusage.subaccountname)                                           | Dimension          | Conditional | True         | String    |
 | [Sub Account Type](#datamodel.costandusage.subaccounttype)                                           | Dimension          | Conditional | True         | String    |

--- a/specification/datasets/cost_and_usage/dataset.md
+++ b/specification/datasets/cost_and_usage/dataset.md
@@ -9,59 +9,59 @@ The specification for the Cost and Usage dataset defines a group of columns that
 | Column                                                                        | Column Type        | Feature Level | Allows Nulls | Data Type |
 | ----------------------------------------------------------------------------- | ------------------ | ------------- | ------------ | --------- |
 | [Allocated Method Details](#datamodel.costandusage.allocatedmethoddetails)                           | Dimension / Metric | Recommended   | True         | JSON      |
-| [Allocated Method ID](#datamodel.costandusage.allocatedmethodid)                                     | Dimension          | [Conditional](#conditions.includessplitcostallocation) | True         | String    |
-| [Allocated Resource ID](#datamodel.costandusage.allocatedresourceid)                                 | Dimension          | [Conditional](#conditions.includessplitcostallocation) | True         | String    |
-| [Allocated Resource Name](#datamodel.costandusage.allocatedresourcename)                             | Dimension          | [Conditional](#conditions.includessplitcostallocation) | True         | String    |
+| [Allocated Method ID](#datamodel.costandusage.allocatedmethodid)                                     | Dimension          | Conditional | True         | String    |
+| [Allocated Resource ID](#datamodel.costandusage.allocatedresourceid)                                 | Dimension          | Conditional | True         | String    |
+| [Allocated Resource Name](#datamodel.costandusage.allocatedresourcename)                             | Dimension          | Conditional | True         | String    |
 | [Allocated Service Name](#datamodel.costandusage.allocatedservicename)                               | Dimension          | [Conditional](#conditions.includessplitcostallocation) | True         | String    |
-| [Allocated Tags](#datamodel.costandusage.allocatedtags)                                              | Dimension          | [Conditional](#conditions.includessplitcostallocation) | True         | JSON      |
+| [Allocated Tags](#datamodel.costandusage.allocatedtags)                                              | Dimension          | Conditional | True         | JSON      |
 | [Availability Zone](#datamodel.costandusage.availabilityzone)                                        | Dimension          | Recommended   | True         | String    |
 | [Billed Cost](#datamodel.costandusage.billedcost)                                                    | Metric             | Mandatory     | False        | Decimal   |
 | [Billing Account ID](#datamodel.costandusage.billingaccountid)                                       | Dimension          | Mandatory     | False        | String    |
 | [Billing Account Name](#datamodel.costandusage.billingaccountname)                                   | Dimension          | Mandatory     | True         | String    |
-| [Billing Account Type](#datamodel.costandusage.billingaccounttype)                                   | Dimension          | [Conditional](#conditions.includesmultiplebillingaccounttypes) | False        | String    |
+| [Billing Account Type](#datamodel.costandusage.billingaccounttype)                                   | Dimension          | Conditional | False        | String    |
 | [Billing Currency](#datamodel.costandusage.billingcurrency)                                          | Dimension          | Mandatory     | False        | String    |
 | [Billing Period End](#datamodel.costandusage.billingperiodend)                                       | Dimension          | Mandatory     | False        | Date/Time |
 | [Billing Period Start](#datamodel.costandusage.billingperiodstart)                                   | Dimension          | Mandatory     | False        | Date/Time |
-| [Capacity Reservation ID](#datamodel.costandusage.capacityreservationid)                             | Dimension          | [Conditional](#conditions.includescapacityreservations) | True         | String    |
-| [Capacity Reservation Status](#datamodel.costandusage.capacityreservationstatus)                     | Dimension          | [Conditional](#conditions.includescapacityreservations) | True         | String    |
+| [Capacity Reservation ID](#datamodel.costandusage.capacityreservationid)                             | Dimension          | Conditional | True         | String    |
+| [Capacity Reservation Status](#datamodel.costandusage.capacityreservationstatus)                     | Dimension          | Conditional | True         | String    |
 | [Charge Category](#datamodel.costandusage.chargecategory)                                            | Dimension          | Mandatory     | False        | String    |
 | [Charge Class](#datamodel.costandusage.chargeclass)                                                  | Dimension          | Mandatory     | True         | String    |
 | [Charge Description](#datamodel.costandusage.chargedescription)                                      | Dimension          | Mandatory     | True         | String    |
 | [Charge Frequency](#datamodel.costandusage.chargefrequency)                                          | Dimension          | Recommended   | False        | String    |
 | [Charge Period End](#datamodel.costandusage.chargeperiodend)                                         | Dimension          | Mandatory     | False        | Date/Time |
 | [Charge Period Start](#datamodel.costandusage.chargeperiodstart)                                     | Dimension          | Mandatory     | False        | Date/Time |
-| [Commitment Discount Category](#datamodel.costandusage.commitmentdiscountcategory)                   | Dimension          | [Conditional](#conditions.includescommitmentdiscounts) | True         | String    |
-| [Commitment Discount ID](#datamodel.costandusage.commitmentdiscountid)                               | Dimension          | [Conditional](#conditions.includescommitmentdiscounts) | True         | String    |
-| [Commitment Discount Name](#datamodel.costandusage.commitmentdiscountname)                           | Dimension          | [Conditional](#conditions.includescommitmentdiscounts) | True         | String    |
-| [Commitment Discount Quantity](#datamodel.costandusage.commitmentdiscountquantity)                   | Metric             | [Conditional](#conditions.includescommitmentdiscounts) | True         | Decimal   |
-| [Commitment Discount Status](#datamodel.costandusage.commitmentdiscountstatus)                       | Dimension          | [Conditional](#conditions.includescommitmentdiscounts) | True         | String    |
-| [Commitment Discount Type](#datamodel.costandusage.commitmentdiscounttype)                           | Dimension          | [Conditional](#conditions.includescommitmentdiscounts) | True         | String    |
-| [Commitment Discount Unit](#datamodel.costandusage.commitmentdiscountunit)                           | Dimension          | [Conditional](#conditions.includescommitmentdiscounts) | True         | String    |
-| [Commitment Program Eligibility Details](#datamodel.costandusage.commitmentprogrameligibilitydetails)            | Dimension          | [Conditional](#conditions.includescommitmentprograms) | True         | JSON    |
-| [Consumed Quantity](#datamodel.costandusage.consumedquantity)                                        | Metric             | [Conditional](#conditions.includesusagemeasurement) | True         | Decimal   |
-| [Consumed Unit](#datamodel.costandusage.consumedunit)                                                | Dimension          | [Conditional](#conditions.includesusagemeasurement) | True         | String    |
-| [Contract Applied](#datamodel.costandusage.contractapplied)                                          | Dimension / Metric | [Conditional](#conditions.includescontractcommitments) | True         | JSON      |
+| [Commitment Discount Category](#datamodel.costandusage.commitmentdiscountcategory)                   | Dimension          | Conditional | True         | String    |
+| [Commitment Discount ID](#datamodel.costandusage.commitmentdiscountid)                               | Dimension          | Conditional | True         | String    |
+| [Commitment Discount Name](#datamodel.costandusage.commitmentdiscountname)                           | Dimension          | Conditional | True         | String    |
+| [Commitment Discount Quantity](#datamodel.costandusage.commitmentdiscountquantity)                   | Metric             | Conditional | True         | Decimal   |
+| [Commitment Discount Status](#datamodel.costandusage.commitmentdiscountstatus)                       | Dimension          | Conditional | True         | String    |
+| [Commitment Discount Type](#datamodel.costandusage.commitmentdiscounttype)                           | Dimension          | Conditional | True         | String    |
+| [Commitment Discount Unit](#datamodel.costandusage.commitmentdiscountunit)                           | Dimension          | Conditional | True         | String    |
+| [Commitment Program Eligibility Details](#datamodel.costandusage.commitmentprogrameligibilitydetails)            | Dimension          | Conditional | True         | JSON    |
+| [Consumed Quantity](#datamodel.costandusage.consumedquantity)                                        | Metric             | Conditional | True         | Decimal   |
+| [Consumed Unit](#datamodel.costandusage.consumedunit)                                                | Dimension          | Conditional | True         | String    |
+| [Contract Applied](#datamodel.costandusage.contractapplied)                                          | Dimension / Metric | Conditional | True         | JSON      |
 | [Contracted Cost](#datamodel.costandusage.contractedcost)                                            | Metric             | Mandatory     | False        | Decimal   |
-| [Contracted Unit Price](#datamodel.costandusage.contractedunitprice)                                 | Metric             | [Conditional](#conditions.includesnegotiatedpricing) | True         | Decimal   |
+| [Contracted Unit Price](#datamodel.costandusage.contractedunitprice)                                 | Metric             | Conditional | True         | Decimal   |
 | [Effective Cost](#datamodel.costandusage.effectivecost)                                              | Metric             | Mandatory     | False        | Decimal   |
 | [Host Provider Name](#datamodel.costandusage.hostprovidername)                                       | Dimension          | Mandatory     | False        | String    |
-| [Invoice Detail ID](#datamodel.costandusage.invoicedetailid)                                         | Dimension          | [Conditional](#conditions.includespayableinvoices) | True         | String    |
-| [Invoice ID](#datamodel.costandusage.invoiceid)                                                      | Dimension          | [Conditional](#conditions.includespayableinvoices) | True         | String    |
+| [Invoice Detail ID](#datamodel.costandusage.invoicedetailid)                                         | Dimension          | Conditional | True         | String    |
+| [Invoice ID](#datamodel.costandusage.invoiceid)                                                      | Dimension          | Conditional | True         | String    |
 | [Invoice Issuer Name](#datamodel.costandusage.invoiceissuername)                                     | Dimension          | Mandatory     | False        | String    |
 | [List Cost](#datamodel.costandusage.listcost)                                                        | Metric             | Mandatory     | False        | Decimal   |
 | [List Unit Price](#datamodel.costandusage.listunitprice)                                             | Metric             | [Conditional](#conditions.includeslistunitprices) | True         | Decimal   |
-| [Pricing Category](#datamodel.costandusage.pricingcategory)                                          | Dimension          | [Conditional](#conditions.includesmultiplepricingcategories) | True         | String    |
-| [Pricing Currency](#datamodel.costandusage.pricingcurrency)                                          | Dimension          | [Conditional](#conditions.includespricing-billingcurrencydifferences) | False        | String    |
-| [Pricing Currency Contracted Unit Price](#datamodel.costandusage.pricingcurrencycontractedunitprice) | Metric             | [Conditional](#conditions.includespricing-billingcurrencydifferences) | True         | Decimal   |
-| [Pricing Currency Effective Cost](#datamodel.costandusage.pricingcurrencyeffectivecost)              | Metric             | [Conditional](#conditions.includespricing-billingcurrencydifferences) | False        | Decimal   |
-| [Pricing Currency List Unit Price](#datamodel.costandusage.pricingcurrencylistunitprice)             | Metric             | [Conditional](#conditions.includespricing-billingcurrencydifferences) | True         | Decimal   |
+| [Pricing Category](#datamodel.costandusage.pricingcategory)                                          | Dimension          | Conditional | True         | String    |
+| [Pricing Currency](#datamodel.costandusage.pricingcurrency)                                          | Dimension          | Conditional | False        | String    |
+| [Pricing Currency Contracted Unit Price](#datamodel.costandusage.pricingcurrencycontractedunitprice) | Metric             | Conditional | True         | Decimal   |
+| [Pricing Currency Effective Cost](#datamodel.costandusage.pricingcurrencyeffectivecost)              | Metric             | Conditional | False        | Decimal   |
+| [Pricing Currency List Unit Price](#datamodel.costandusage.pricingcurrencylistunitprice)             | Metric             | Conditional | True         | Decimal   |
 | [Pricing Quantity](#datamodel.costandusage.pricingquantity)                                          | Metric             | Mandatory     | True         | Decimal   |
 | [Pricing Unit](#datamodel.costandusage.pricingunit)                                                  | Dimension          | Mandatory     | True         | String    |
-| [Region ID](#datamodel.costandusage.regionid)                                                        | Dimension          | [Conditional](#conditions.includesregions) | True         | String    |
-| [Region Name](#datamodel.costandusage.regionname)                                                    | Dimension          | [Conditional](#conditions.includesregions) | True         | String    |
-| [Resource ID](#datamodel.costandusage.resourceid)                                                    | Dimension          | [Conditional](#conditions.includesprovisionedresources) | True         | String    |
-| [Resource Name](#datamodel.costandusage.resourcename)                                                | Dimension          | [Conditional](#conditions.includesprovisionedresources) | True         | String    |
-| [Resource Type](#datamodel.costandusage.resourcetype)                                                | Dimension          | [Conditional](#conditions.includesprovisionedresources) | True         | String    |
+| [Region ID](#datamodel.costandusage.regionid)                                                        | Dimension          | Conditional | True         | String    |
+| [Region Name](#datamodel.costandusage.regionname)                                                    | Dimension          | Conditional | True         | String    |
+| [Resource ID](#datamodel.costandusage.resourceid)                                                    | Dimension          | Conditional | True         | String    |
+| [Resource Name](#datamodel.costandusage.resourcename)                                                | Dimension          | Conditional | True         | String    |
+| [Resource Type](#datamodel.costandusage.resourcetype)                                                | Dimension          | Conditional | True         | String    |
 | [Service Category](#datamodel.costandusage.servicecategory)                                          | Dimension          | Mandatory     | False        | String    |
 | [Service Name](#datamodel.costandusage.servicename)                                                  | Dimension          | Mandatory     | False        | String    |
 | [Service Provider Name](#datamodel.costandusage.serviceprovidername)                                 | Dimension          | Mandatory     | False        | String    |
@@ -70,10 +70,10 @@ The specification for the Cost and Usage dataset defines a group of columns that
 | [SKU Meter](#datamodel.costandusage.skumeter)                                                        | Dimension          | [Conditional](#conditions.includesunitpricing) | True         | String    |
 | [SKU Price Details](#datamodel.costandusage.skupricedetails)                                         | Dimension          | [Conditional](#conditions.includesunitpricing) | True         | JSON      |
 | [SKU Price ID](#datamodel.costandusage.skupriceid)                                                   | Dimension          | [Conditional](#conditions.includesunitpricing) | True         | String    |
-| [Sub Account ID](#datamodel.costandusage.subaccountid)                                               | Dimension          | [Conditional](#conditions.includessubaccounts) | True         | String    |
-| [Sub Account Name](#datamodel.costandusage.subaccountname)                                           | Dimension          | [Conditional](#conditions.includessubaccounts) | True         | String    |
-| [Sub Account Type](#datamodel.costandusage.subaccounttype)                                           | Dimension          | [Conditional](#conditions.includesmultiplesubaccounttypes) | True         | String    |
-| [Tags](#datamodel.costandusage.tags)                                                                 | Dimension          | [Conditional](#conditions.includestags) | True         | JSON      |
+| [Sub Account ID](#datamodel.costandusage.subaccountid)                                               | Dimension          | Conditional | True         | String    |
+| [Sub Account Name](#datamodel.costandusage.subaccountname)                                           | Dimension          | Conditional | True         | String    |
+| [Sub Account Type](#datamodel.costandusage.subaccounttype)                                           | Dimension          | Conditional | True         | String    |
+| [Tags](#datamodel.costandusage.tags)                                                                 | Dimension          | Conditional | True         | JSON      |
 
 ## Relationships<!--SkipTOC-->
 
@@ -92,11 +92,11 @@ CostAndUsage MUST adhere to the following requirements:
 
 * CostAndUsage column presence MUST adhere to the following requirements:
   * CostAndUsage SHOULD include [AllocatedMethodDetails](#datamodel.costandusage.allocatedmethoddetails) when the [*operating model*](#glossary:operating-model) [includes split cost allocation](#conditions.includessplitcostallocation).
-  * CostAndUsage MUST include [AllocatedMethodId](#datamodel.costandusage.allocatedmethodid) when the *operating model* [includes split cost allocation](#conditions.includessplitcostallocation).
-  * CostAndUsage MUST include [AllocatedResourceId](#datamodel.costandusage.allocatedresourceid) when the *operating model* [includes split cost allocation](#conditions.includessplitcostallocation).
-  * CostAndUsage MUST include [AllocatedResourceName](#datamodel.costandusage.allocatedresourcename) when the *operating model* [includes split cost allocation](#conditions.includessplitcostallocation).
+  * CostAndUsage MUST include [AllocatedMethodId](#datamodel.costandusage.allocatedmethodid) when the *operating model* includes split cost allocation.
+  * CostAndUsage MUST include [AllocatedResourceId](#datamodel.costandusage.allocatedresourceid) when the *operating model* includes split cost allocation.
+  * CostAndUsage MUST include [AllocatedResourceName](#datamodel.costandusage.allocatedresourcename) when the *operating model* includes split cost allocation.
   * CostAndUsage MUST include [AllocatedServiceName](#datamodel.costandusage.allocatedservicename) when the *operating model* [includes split cost allocation](#conditions.includessplitcostallocation).
-  * CostAndUsage MUST include [AllocatedTags](#datamodel.costandusage.allocatedtags) when the *operating model* [includes split cost allocation](#conditions.includessplitcostallocation).
+  * CostAndUsage MUST include [AllocatedTags](#datamodel.costandusage.allocatedtags) when the *operating model* includes split cost allocation.
   * CostAndUsage SHOULD include [AvailabilityZone](#datamodel.costandusage.availabilityzone) when the *operating model* [includes availability zones](#conditions.includesavailabilityzones).
   * CostAndUsage MUST include [BilledCost](#datamodel.costandusage.billedcost).
   * CostAndUsage MUST include [BillingAccountId](#datamodel.costandusage.billingaccountid).
@@ -106,7 +106,7 @@ CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MUST include [BillingPeriodEnd](#datamodel.costandusage.billingperiodend).
   * CostAndUsage MUST include [BillingPeriodStart](#datamodel.costandusage.billingperiodstart).
   * CostAndUsage MUST include [CapacityReservationId](#datamodel.costandusage.capacityreservationid) when the *operating model* [includes capacity reservations](#conditions.includescapacityreservations).
-  * CostAndUsage MUST include [CapacityReservationStatus](#datamodel.costandusage.capacityreservationstatus) when the *operating model* [includes capacity reservations](#conditions.includescapacityreservations).
+  * CostAndUsage MUST include [CapacityReservationStatus](#datamodel.costandusage.capacityreservationstatus) when the *operating model* includes capacity reservations.
   * CostAndUsage MUST include [ChargeCategory](#datamodel.costandusage.chargecategory).
   * CostAndUsage MUST include [ChargeClass](#datamodel.costandusage.chargeclass).
   * CostAndUsage MUST include [ChargeDescription](#datamodel.costandusage.chargedescription).
@@ -114,22 +114,22 @@ CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MUST include [ChargePeriodEnd](#datamodel.costandusage.chargeperiodend).
   * CostAndUsage MUST include [ChargePeriodStart](#datamodel.costandusage.chargeperiodstart).
   * CostAndUsage MUST include [CommitmentDiscountCategory](#datamodel.costandusage.commitmentdiscountcategory) when the *operating model* [includes commitment discounts](#conditions.includescommitmentdiscounts).
-  * CostAndUsage MUST include [CommitmentDiscountId](#datamodel.costandusage.commitmentdiscountid) when the *operating model* [includes commitment discounts](#conditions.includescommitmentdiscounts).
-  * CostAndUsage MUST include [CommitmentDiscountName](#datamodel.costandusage.commitmentdiscountname) when the *operating model* [includes commitment discounts](#conditions.includescommitmentdiscounts).
-  * CostAndUsage MUST include [CommitmentDiscountQuantity](#datamodel.costandusage.commitmentdiscountquantity) when the *operating model* [includes commitment discounts](#conditions.includescommitmentdiscounts).
-  * CostAndUsage MUST include [CommitmentDiscountStatus](#datamodel.costandusage.commitmentdiscountstatus) when the *operating model* [includes commitment discounts](#conditions.includescommitmentdiscounts).
-  * CostAndUsage MUST include [CommitmentDiscountType](#datamodel.costandusage.commitmentdiscounttype) when the *operating model* [includes commitment discounts](#conditions.includescommitmentdiscounts).
-  * CostAndUsage MUST include [CommitmentDiscountUnit](#datamodel.costandusage.commitmentdiscountunit) when the *operating model* [includes commitment discounts](#conditions.includescommitmentdiscounts).
+  * CostAndUsage MUST include [CommitmentDiscountId](#datamodel.costandusage.commitmentdiscountid) when the *operating model* includes commitment discounts.
+  * CostAndUsage MUST include [CommitmentDiscountName](#datamodel.costandusage.commitmentdiscountname) when the *operating model* includes commitment discounts.
+  * CostAndUsage MUST include [CommitmentDiscountQuantity](#datamodel.costandusage.commitmentdiscountquantity) when the *operating model* includes commitment discounts.
+  * CostAndUsage MUST include [CommitmentDiscountStatus](#datamodel.costandusage.commitmentdiscountstatus) when the *operating model* includes commitment discounts.
+  * CostAndUsage MUST include [CommitmentDiscountType](#datamodel.costandusage.commitmentdiscounttype) when the *operating model* includes commitment discounts.
+  * CostAndUsage MUST include [CommitmentDiscountUnit](#datamodel.costandusage.commitmentdiscountunit) when the *operating model* includes commitment discounts.
   * CostAndUsage MUST include [CommitmentProgramEligibilityDetails](#datamodel.costandusage.commitmentprogrameligibilitydetails) when the *operating model* [includes commitment programs](#conditions.includescommitmentprograms).
   * CostAndUsage MUST include [ConsumedQuantity](#datamodel.costandusage.consumedquantity) when the *operating model* [includes usage measurement](#conditions.includesusagemeasurement).
-  * CostAndUsage MUST include [ConsumedUnit](#datamodel.costandusage.consumedunit) when the *operating model* [includes usage measurement](#conditions.includesusagemeasurement).
+  * CostAndUsage MUST include [ConsumedUnit](#datamodel.costandusage.consumedunit) when the *operating model* includes usage measurement.
   * CostAndUsage MUST include [ContractApplied](#datamodel.costandusage.contractapplied) when the *operating model* [includes contract commitments](#conditions.includescontractcommitments).
   * CostAndUsage MUST include [ContractedCost](#datamodel.costandusage.contractedcost).
   * CostAndUsage MUST include [ContractedUnitPrice](#datamodel.costandusage.contractedunitprice) when the *operating model* [includes negotiated pricing](#conditions.includesnegotiatedpricing).
   * CostAndUsage MUST include [EffectiveCost](#datamodel.costandusage.effectivecost).
   * CostAndUsage MUST include [HostProviderName](#datamodel.costandusage.hostprovidername).
   * CostAndUsage MUST include [InvoiceDetailId](#datamodel.costandusage.invoicedetailid) when the *operating model* [includes payable invoices](#conditions.includespayableinvoices).
-  * CostAndUsage MUST include [InvoiceId](#datamodel.costandusage.invoiceid) when the *operating model* [includes payable invoices](#conditions.includespayableinvoices).
+  * CostAndUsage MUST include [InvoiceId](#datamodel.costandusage.invoiceid) when the *operating model* includes payable invoices.
   * CostAndUsage MUST include [InvoiceIssuerName](#datamodel.costandusage.invoiceissuername).
   * CostAndUsage MUST include [ListCost](#datamodel.costandusage.listcost).
   * CostAndUsage MUST include [ListUnitPrice](#datamodel.costandusage.listunitprice) when the *operating model* [includes list unit prices](#conditions.includeslistunitprices).
@@ -150,10 +150,10 @@ CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MUST include [PricingQuantity](#datamodel.costandusage.pricingquantity).
   * CostAndUsage MUST include [PricingUnit](#datamodel.costandusage.pricingunit).
   * CostAndUsage MUST include [RegionId](#datamodel.costandusage.regionid) when the *operating model* [includes regions](#conditions.includesregions).
-  * CostAndUsage MUST include [RegionName](#datamodel.costandusage.regionname) when the *operating model* [includes regions](#conditions.includesregions).
+  * CostAndUsage MUST include [RegionName](#datamodel.costandusage.regionname) when the *operating model* includes regions.
   * CostAndUsage MUST include [ResourceId](#datamodel.costandusage.resourceid) when the *operating model* [includes provisioned resources](#conditions.includesprovisionedresources).
-  * CostAndUsage MUST include [ResourceName](#datamodel.costandusage.resourcename) when the *operating model* [includes provisioned resources](#conditions.includesprovisionedresources).
-  * CostAndUsage MUST include [ResourceType](#datamodel.costandusage.resourcetype) when the *operating model* [includes provisioned resources](#conditions.includesprovisionedresources) and [includes resource type assignment](#conditions.includesresourcetypeassignment).
+  * CostAndUsage MUST include [ResourceName](#datamodel.costandusage.resourcename) when the *operating model* includes provisioned resources.
+  * CostAndUsage MUST include [ResourceType](#datamodel.costandusage.resourcetype) when the *operating model* includes provisioned resources and [includes resource type assignment](#conditions.includesresourcetypeassignment).
   * CostAndUsage MUST include [ServiceCategory](#datamodel.costandusage.servicecategory).
   * CostAndUsage MUST include [ServiceName](#datamodel.costandusage.servicename).
   * CostAndUsage MUST include [ServiceProviderName](#datamodel.costandusage.serviceprovidername).
@@ -163,7 +163,7 @@ CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MUST include [SkuPriceDetails](#datamodel.costandusage.skupricedetails) when the *operating model* [includes unit pricing](#conditions.includesunitpricing).
   * CostAndUsage MUST include [SkuPriceId](#datamodel.costandusage.skupriceid) when the *operating model* [includes unit pricing](#conditions.includesunitpricing).
   * CostAndUsage MUST include [SubAccountId](#datamodel.costandusage.subaccountid) when the *operating model* [includes sub accounts](#conditions.includessubaccounts).
-  * CostAndUsage MUST include [SubAccountName](#datamodel.costandusage.subaccountname) when the *operating model* [includes sub accounts](#conditions.includessubaccounts).
+  * CostAndUsage MUST include [SubAccountName](#datamodel.costandusage.subaccountname) when the *operating model* includes sub accounts.
   * CostAndUsage MUST include [SubAccountType](#datamodel.costandusage.subaccounttype) when the *operating model* [includes multiple sub account types](#conditions.includesmultiplesubaccounttypes).
   * CostAndUsage MUST include [Tags](#datamodel.costandusage.tags) when the *operating model* [includes tags](#conditions.includestags).
   * CostAndUsage SHOULD include [*custom columns*](#glossary:custom-column) needed to identify all applied discounts when [*FOCUS columns*](#glossary:FOCUS-column) are not sufficient.
@@ -173,7 +173,7 @@ CostAndUsage MUST adhere to the following requirements:
 * CostAndUsage MUST conform to [DeliveryHandling](#attributes.deliveryhandling) requirements.
 * CostAndUsage MUST include *charges* representing unused portions of a [*commitment*](#glossary:commitment) when the *commitment* is not fully utilized.
 * CostAndUsage MUST include separate *charges* representing discounted and non-discounted portions when a discount applies to only a portion of the originally incurred *charge*.
-* When the *operating model* [includes split cost allocation](#conditions.includessplitcostallocation), CostAndUsage MUST adhere to the following requirements:
+* When the *operating model* includes split cost allocation, CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MUST have its split cost allocation method documented and accessible to practitioners.
   * CostAndUsage SHOULD offer split cost allocation on an opt-in basis.
   * CostAndUsage MAY contain records for concepts not related to resource usage, when it aligns with the documented split cost allocation method.
@@ -181,7 +181,7 @@ CostAndUsage MUST adhere to the following requirements:
   * CostAndUsage MAY contain *allocated charges* with apportioned costs for unused or unallocated usage, when it aligns with the documented split cost allocation method.
 * CostAndUsage SHOULD reflect all applied discounts in *charges* they pertain to.
 * CostAndUsage SHOULD NOT represent applied discounts as separate negating or offsetting *charges*.
-* CostAndUsage *FOCUS columns* MUST conform to [DataGeneratorCalculatedSplitCostAllocationHandling](#attributes.datagenerator-calculatedsplitcostallocationhandling) requirements when the *operating model* [includes split cost allocation](#conditions.includessplitcostallocation).
+* CostAndUsage *FOCUS columns* MUST conform to [DataGeneratorCalculatedSplitCostAllocationHandling](#attributes.datagenerator-calculatedsplitcostallocationhandling) requirements when the *operating model* includes split cost allocation.
 * CostAndUsage *FOCUS columns* MUST conform to [FocusColumnHandling](#attributes.focuscolumnhandling) requirements.
 * CostAndUsage *FOCUS columns* MUST conform to [NullHandling](#attributes.nullhandling) requirements.
 * CostAndUsage *custom columns* MUST conform to [CustomColumnHandling](#attributes.customcolumnhandling) requirements.

--- a/specification/datasets/data_model.md
+++ b/specification/datasets/data_model.md
@@ -20,7 +20,7 @@ DataModel MUST adhere to the following requirements:
 * DataModel MUST include [CostAndUsage](#datamodel.costandusage).
 * DataModel MUST include [BillingPeriod](#datamodel.billingperiod) when the [*operating model*](#glossary:operating-model) [includes payable invoices](#conditions.includespayableinvoices).
 * DataModel MUST include [ContractCommitment](#datamodel.contractcommitment) when the *operating model* [includes contract commitments](#conditions.includescontractcommitments).
-* DataModel MUST include [InvoiceDetail](#datamodel.invoicedetail) when the *operating model* [includes payable invoices](#conditions.includespayableinvoices).
+* DataModel MUST include [InvoiceDetail](#datamodel.invoicedetail) when the *operating model* includes payable invoices.
 
 ## Data Model ID<!--SkipTOC-->
 

--- a/specification/datasets/invoice_detail/dataset.md
+++ b/specification/datasets/invoice_detail/dataset.md
@@ -21,12 +21,12 @@ The Invoice Detail dataset is a transactional dataset that represents the financ
 | [Invoice Issue Date](#datamodel.invoicedetail.invoiceissuedate)                   | Dimension   | Mandatory     | True        | Date/Time |
 | [Invoice Issue Status](#datamodel.invoicedetail.invoiceissuestatus)             | Dimension   | Mandatory     | False        | String    |
 | [Invoice Issuer Name](#datamodel.invoicedetail.invoiceissuername)                 | Dimension   | Mandatory     | False        | String    |
-| [Payment Currency](#datamodel.invoicedetail.paymentcurrency)                     | Dimension   | [Conditional](#conditions.includesbillingandpaymentcurrencydifferences)   | False        | String    |
-| [Payment Currency Billed Cost](#datamodel.invoicedetail.paymentcurrencybilledcost) | Metric      | [Conditional](#conditions.includesbillingandpaymentcurrencydifferences)   | False        | Decimal   |
-| [Payment Currency Invoice Detail ID](#datamodel.invoicedetail.paymentcurrencyinvoicedetailid) | Dimension | [Conditional](#conditions.includesaggregationlevelcurrencydifferences) | False | String |
+| [Payment Currency](#datamodel.invoicedetail.paymentcurrency)                     | Dimension   | Conditional   | False        | String    |
+| [Payment Currency Billed Cost](#datamodel.invoicedetail.paymentcurrencybilledcost) | Metric      | Conditional   | False        | Decimal   |
+| [Payment Currency Invoice Detail ID](#datamodel.invoicedetail.paymentcurrencyinvoicedetailid) | Dimension | Conditional | False | String |
 | [Payment Due Date](#datamodel.invoicedetail.paymentduedate)               | Dimension   | Mandatory     | True         | Date/Time |
 | [Payment Terms](#datamodel.invoicedetail.paymentterms)                     | Dimension   | Mandatory     | False        | String    |
-| [Purchase Order Number](#datamodel.invoicedetail.purchaseordernumber)             | Dimension   | [Conditional](#conditions.includespurchaseordernumbers)   | True        | String    |
+| [Purchase Order Number](#datamodel.invoicedetail.purchaseordernumber)             | Dimension   | Conditional   | True        | String    |
 | [Reference Invoice ID](#datamodel.invoicedetail.referenceinvoiceid)               | Dimension   | Mandatory     | False        | String    |
 
 ## Relationships<!--SkipTOC-->
@@ -63,7 +63,7 @@ InvoiceDetail MUST adhere to the following requirements:
   * InvoiceDetail MUST include [InvoiceIssueStatus](#datamodel.invoicedetail.invoiceissuestatus).
   * InvoiceDetail MUST include [InvoiceIssuerName](#datamodel.invoicedetail.invoiceissuername).
   * InvoiceDetail MUST include [PaymentCurrency](#datamodel.invoicedetail.paymentcurrency) when the [*operating model*](#glossary:operating-model) [includes billing and payment currency differences](#conditions.includesbillingandpaymentcurrencydifferences).
-  * InvoiceDetail MUST include [PaymentCurrencyBilledCost](#datamodel.invoicedetail.paymentcurrencybilledcost) when the *operating model* [includes billing and payment currency differences](#conditions.includesbillingandpaymentcurrencydifferences).
+  * InvoiceDetail MUST include [PaymentCurrencyBilledCost](#datamodel.invoicedetail.paymentcurrencybilledcost) when the *operating model* includes billing and payment currency differences.
   * InvoiceDetail MUST include [PaymentCurrencyInvoiceDetailId](#datamodel.invoicedetail.paymentcurrencyinvoicedetailid) when the *operating model* [includes aggregation level currency differences](#conditions.includesaggregationlevelcurrencydifferences).
   * InvoiceDetail MUST include [PaymentDueDate](#datamodel.invoicedetail.paymentduedate).
   * InvoiceDetail MUST include [PaymentTerms](#datamodel.invoicedetail.paymentterms).


### PR DESCRIPTION
## Summary

This PR removes condition link markup from the `dataset.md` and `data_model.md` files. Related changes:

1. Repeated condition links in the Requirements lists are converted to plain text, keeping the link on the first occurrence of each condition reference (AI #2587).
2. Condition links are removed from the Feature Level cells in the Columns tables, so that the first linked occurrence of a condition reference now appears in the Requirements list (FR #2441).

### Core changes

| File | Table cells delinked | Requirements occurrences delinked |
| --- | --- | --- |
| `specification/datasets/cost_and_usage/dataset.md` | 41 | 34 |
| `specification/datasets/contract_commitment/dataset.md` | 3 | 1 |
| `specification/datasets/invoice_detail/dataset.md` | 4 | 1 |
| `specification/datasets/data_model.md` | — | 1 |

After these changes, every condition reference in each file is linked exactly once, on its first occurrence.

### Columns table (FR #2441)

The rationale is that some columns are conditional on more than one condition, and the table links only one of them. For example:

- `Resource Type` is linked to `IncludesProvisionedResources` in the table, while the Requirements list conditions it on both `IncludesProvisionedResources` and `IncludesResourceTypeAssignment`.
- `Pricing Currency Contracted Unit Price` is linked to `IncludesPricing-BillingCurrencyDifferences` in the table, while the Requirements list conditions it on `IncludesVirtualCurrency` and `IncludesListUnitPrices`.

Linking a single condition in these cases is misleading, and the Requirements list is where the full set of conditions is stated.

### Notes

- No normative or material changes. Only link markup was removed; no requirement text was altered.
- `specification/datasets/billing_period/dataset.md` was reviewed and contains no condition links; no changes needed.
- Column alignment in the Columns tables was left as-is (to minimize conflicts during merge) and will be addressed separately.
- Addresses AI #2587 and FR #2441.

### Out of scope

- Repeated dataset and column links (e.g. `[CostAndUsage](#datamodel.costandusage)`, `[BillingPeriod](#datamodel.billingperiod)`) that appear in both the Columns/Datasets tables and the Requirements lists are intentionally left as-is. This PR only addresses repeated **condition** links.

### Type of Change

* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist

* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
