### PR TITLE
AI #2547: Restructure `Requester Details` as a JSON array of key-value entries

### DIFF
--- a/specification/appendix/json_object_examples/requester_details_examples.md
+++ b/specification/appendix/json_object_examples/requester_details_examples.md
@@ -1,54 +1,54 @@
 # Examples: Requester Details
 
-The examples below are not exhaustive and may change over time. [*Service providers*](#glossary:service-provider) are the authoritative source for the identity attributes they publish.
+The examples below are not exhaustive and may change over time. The authoritative source for each identity attribute is the party that publishes it.
 
 ## Aura Web (Inference Request via an API Key)
 
-Scenario: A generative AI inference [*charge*](#glossary:charge) authenticated with an API key that acts under a named user. The named user is the [*principal*](#glossary:principal), so the user's attributes sit at the top level, and the API key is the [*credential*](#glossary:credential) recorded in the `Credential` property. The `Credential` object repeats the CredentialId value in its `Id` key, which is optional; the examples that follow omit it.
+Scenario: A generative AI inference [*charge*](#glossary:charge) authenticated with an API key that acts under a named user. The named user is the [*principal*](#glossary:principal), described by the `Principal` entry, and the API key is the [*credential*](#glossary:credential), described by the `Credential` entry. The opaque identifiers are carried by the PrincipalId and CredentialId columns, so each entry's `value` holds only descriptive attributes.
 
 | ServiceProviderName | ServiceName | PrincipalId | CredentialId | RequesterDetails |
 |---------------------|-------------|-------------|--------------|-------------------|
-| Aura Web | Inference | user_8842 | key_01HQZX3M8N | {"Name": "Alex Rivera", "Email": "alex.rivera@example.com", "Type": "User", "Credential": {"Id": "key_01HQZX3M8N", "Type": "API Key", "Name": "prod-ingest-key"}} |
+| Aura Web | Inference | user_8842 | key_01HQZX3M8N | [{"key": "Principal", "value": {"Name": "Alex Rivera", "Email": "alex.rivera@example.com", "Type": "User"}}, {"key": "Credential", "value": {"Type": "API Key", "Name": "prod-ingest-key"}}] |
 
 ## LatticeScale (Direct Console Access)
 
-Scenario: An object storage charge initiated by a user authenticating directly through a console session that the *service provider* identifies separately from the user.
+Scenario: An object storage charge initiated by a user authenticating directly through a console session that is identified separately from the user.
 
 | ServiceProviderName | ServiceName | PrincipalId | CredentialId | RequesterDetails |
 |---------------------|-------------|-------------|--------------|-------------------|
-| LatticeScale | ObjectStorage | user_4417 | sess_6BN3XR8P | {"Name": "Jordan Lee", "Email": "jordan.lee@example.com", "Type": "User", "Credential": {"Type": "Session"}} |
+| LatticeScale | ObjectStorage | user_4417 | sess_6BN3XR8P | [{"key": "Principal", "value": {"Name": "Jordan Lee", "Email": "jordan.lee@example.com", "Type": "User"}}, {"key": "Credential", "value": {"Type": "Session"}}] |
 
 ## Aura Web (Scheduled Job Under a Service Account)
 
-Scenario: A compute charge initiated by a service account, where the *service provider* publishes no identifier for the *credential* the service account presented. CredentialId is null and the `Credential` property is omitted. A service account has no email address, so Email is omitted and Type distinguishes the *principal* from a human user.
+Scenario: A compute charge initiated by a service account, where the *credential* the service account presented has no published identifier. CredentialId is null and the `Credential` entry is omitted. A service account has no email address, so Email is omitted and Type distinguishes the *principal* from a human user.
 
 | ServiceProviderName | ServiceName | PrincipalId | CredentialId | RequesterDetails |
 |---------------------|-------------|-------------|--------------|-------------------|
-| Aura Web | Compute | svc_nightly_etl | null | {"Name": "svc-nightly-etl", "Type": "Service Account"} |
+| Aura Web | Compute | svc_nightly_etl | null | [{"key": "Principal", "value": {"Name": "svc-nightly-etl", "Type": "Service Account"}}] |
 
 ## Meridian AI (Credential Without a Determinable Principal)
 
-Scenario: An inference charge authenticated with an API key that the *service provider* cannot map to an entity in its identity and access management model. The *service provider* cannot determine a *principal*, so PrincipalId is null, while the *credential* it does know is recorded.
+Scenario: An inference charge authenticated with an API key that cannot be mapped to an entity in the identity and access management model. No *principal* can be determined, so PrincipalId is null, while the known *credential* is recorded in the `Credential` entry.
 
 | ServiceProviderName | ServiceName | PrincipalId | CredentialId | RequesterDetails |
 |---------------------|-------------|-------------|--------------|-------------------|
-| Meridian AI | Inference | null | key_07PQXR2W9F | {"Credential": {"Type": "API Key", "Name": "eval-sandbox"}} |
+| Meridian AI | Inference | null | key_07PQXR2W9F | [{"key": "Credential", "value": {"Type": "API Key", "Name": "eval-sandbox"}}] |
 
 ## StackLens (No Determinable Principal or Credential)
 
-Scenario: A platform subscription billed at the account level, with no entity in the *service provider's* identity and access management model associated with it and no *credential* presented. PrincipalId, CredentialId, and RequesterDetails are all null.
+Scenario: A platform subscription billed at the account level, with no entity in the identity and access management model associated with it and no *credential* presented. PrincipalId, CredentialId, and RequesterDetails are all null.
 
 | ServiceProviderName | ServiceName | PrincipalId | CredentialId | RequesterDetails |
 |---------------------|-------------|-------------|--------------|-------------------|
 | StackLens | Observability | null | null | null |
 
-## Aura Web (Provider-Specific Attributes)
+## Aura Web (Custom Identity Attribute)
 
-Scenario: A *service provider* publishes an identity attribute that has no FOCUS-defined property. The attribute is carried as a custom property prefixed with "x_".
+Scenario: An identity attribute is published that has no FOCUS-defined property. The attribute describes the *principal*, so it is carried as a custom property prefixed with "x_" within the `value` of the `Principal` entry.
 
 | ServiceProviderName | ServiceName | PrincipalId | CredentialId | RequesterDetails |
 |---------------------|-------------|-------------|--------------|-------------------|
-| Aura Web | Inference | user_8842 | key_01HQZX3M8N | {"Name": "Alex Rivera", "Email": "alex.rivera@example.com", "Type": "User", "Credential": {"Type": "API Key", "Name": "prod-ingest-key"}, "x_DirectoryGroup": "platform-engineering"} |
+| Aura Web | Inference | user_8842 | key_01HQZX3M8N | [{"key": "Principal", "value": {"Name": "Alex Rivera", "Email": "alex.rivera@example.com", "Type": "User", "x_DirectoryGroup": "platform-engineering"}}, {"key": "Credential", "value": {"Type": "API Key", "Name": "prod-ingest-key"}}] |
 
 ## Cost Attribution by Principal and by Credential
 
@@ -57,9 +57,9 @@ This example demonstrates how the two identifier columns support different attri
 Acme Corp runs generative AI inference and scheduled compute on Aura Web. Four charges land in a single charge period (2025-04-01):
 
 1. **Inference via an API key** (Row 1): Alex Rivera, presenting `prod-ingest-key`. [BilledCost](#datamodel.costandusage.billedcost) is $120.00.
-2. **Inference via a console session** (Row 2): Alex Rivera, working in the Aura Web console, which identifies the session separately from the user. BilledCost is $30.00.
+2. **Inference via a console session** (Row 2): Alex Rivera, working in the Aura Web console, where the session is identified separately from the user. BilledCost is $30.00.
 3. **Inference via an API key** (Row 3): Jordan Lee, presenting `batch-key`. BilledCost is $75.00.
-4. **Scheduled compute** (Row 4): the `svc-nightly-etl` service account, which has no email address and for which Aura Web publishes no *credential* identifier. BilledCost is $45.00.
+4. **Scheduled compute** (Row 4): the `svc-nightly-etl` service account, which has no email address and for which no *credential* identifier is published. BilledCost is $45.00.
 
 Grouping by PrincipalId answers which *requester* incurred the cost, and combines a user's charges regardless of which *credential* was presented:
 

--- a/specification/attributes/json_object_format.md
+++ b/specification/attributes/json_object_format.md
@@ -6,7 +6,7 @@ JSON Objects extend the [Key-Value Format](#attributes.key-valueformat) to add s
 
 Column conforming to JsonObjectFormat attribute MUST adhere to the following requirements:
 
-* [*FOCUS dataset column*](#glossary:FOCUS-dataset-column) MUST contain a serialized JSON string, consistent with the [ECMA 404](https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf) definition of an object.
+* [*FOCUS dataset column*](#glossary:FOCUS-dataset-column) MUST contain a serialized JSON string, consistent with the [ECMA 404](https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf) definition of an object or an array.
 * *FOCUS dataset column* MUST conform to all requirements of the corresponding column definition, which may specify or restrict the shape or contents of the object.
 * Object in *FOCUS dataset column* SHOULD NOT exceed 3 levels of nesting.
 * Key in Object in *FOCUS dataset column* MUST be unique.

--- a/specification/datasets/cost_and_usage/columns/requesterdetails.md
+++ b/specification/datasets/cost_and_usage/columns/requesterdetails.md
@@ -1,10 +1,10 @@
 # Requester Details
 
-Requester Details represents a set of properties describing the [*requester*](#glossary:requester) on whose behalf a request that produced a [*charge*](#glossary:charge) was made. A [*service provider*](#glossary:service-provider) commonly represents a *requester* at more than one level: the [*principal*](#glossary:principal) to which access to a [*resource*](#glossary:resource) or [*service*](#glossary:service) is granted, and the [*credential*](#glossary:credential) that *principal* presented on the request. Requester Details describes the *principal* identified by [Principal ID](#datamodel.costandusage.principalid) through its top-level properties, and describes the *credential* identified by [Credential ID](#datamodel.costandusage.credentialid) in a nested `Credential` property.
+Requester Details represents a set of properties describing the [*requester*](#glossary:requester) on whose behalf a request that produced a [*charge*](#glossary:charge) was made. A *requester* is commonly represented at more than one level: the [*principal*](#glossary:principal) to which access to a [*resource*](#glossary:resource) or [*service*](#glossary:service) is granted, and the [*credential*](#glossary:credential) that *principal* presented on the request. Requester Details carries these as a collection of key-value entries, where the `Principal` entry describes the *principal* identified by [Principal ID](#datamodel.costandusage.principalid) and the `Credential` entry describes the *credential* identified by [Credential ID](#datamodel.costandusage.credentialid).
 
-Where Principal ID and Credential ID provide opaque identifiers suited to grouping and joining, Requester Details carries the descriptive attributes a *service provider* publishes alongside those identifiers, such as a display name, an email address, and the kind of *principal* or *credential* the identifier represents. A request may be authenticated with an API key acting under a named user, or with a workload identity acting under a service account; in each case the named user or service account is the *principal*, and the API key or workload identity is the *credential*. Keeping the descriptive attributes of the *principal* at the top level means the most common analyses (e.g., grouping *charges* by principal name or email) read directly from those properties.
+Where Principal ID and Credential ID provide opaque identifiers suited to grouping and joining, Requester Details carries the descriptive attributes published alongside those identifiers, such as a display name, an email address, and the kind of *principal* or *credential* the identifier represents. A request may be authenticated with an API key acting under a named user, or with a workload identity acting under a service account; in each case the named user or service account is the *principal*, and the API key or workload identity is the *credential*.
 
-Requester Details helps practitioners attribute cost to a recognizable *requester* while preserving Principal ID and Credential ID as stable, opaque keys, and gives *service providers* a defined location for identity attributes that would otherwise appear as custom columns. A *service provider* that represents a *requester* at levels beyond the *principal* and the *credential* describes each additional level in its own nested object, so the levels this specification defines and the levels a *service provider* defines share one shape.
+Requester Details helps practitioners attribute cost to a recognizable *requester* while preserving Principal ID and Credential ID as stable, opaque keys, and provides a defined location for identity attributes that would otherwise appear as custom columns.
 
 ## Requirements
 
@@ -22,7 +22,7 @@ RequesterDetails MUST adhere to the following requirements:
 
 ## Requester Details Object
 
-Requester Details consists of a valid JSON object whose top-level properties describe the *principal* identified by PrincipalId. An optional `Credential` property describes the *credential* identified by CredentialId.
+Requester Details consists of an array of entries, where each entry is an object carrying a `key` property naming what the entry describes and a `value` property carrying its attributes. The `Principal` entry describes the *principal* identified by PrincipalId, and the `Credential` entry describes the *credential* identified by CredentialId.
 
 The following section details the normative requirements for the RequesterDetailsObject and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datamodel.costandusage.requesterdetails.requesterdetailsobject.objectschemastructure) and [Object Example](#datamodel.costandusage.requesterdetails.requesterdetailsobject.objectexample) sections.
 
@@ -31,80 +31,93 @@ The following section details the normative requirements for the RequesterDetail
 RequesterDetailsObject MUST adhere to the following requirements:
 
 * RequesterDetailsObject MUST conform to the [RequesterDetailsObjectSchema](#schemas.costandusage.requesterdetailsobjectschema) JSON Schema.
-* RequesterDetailsObject MUST NOT include properties that are not applicable to the *requester* associated with the *charge*.
-* RequesterDetailsObject.Name MUST represent a readable display name for the *principal* identified by PrincipalId.
-* RequesterDetailsObject.Email MUST represent an email address associated with the *principal* identified by PrincipalId.
-* RequesterDetailsObject.Type MUST represent the kind of *principal* identified by PrincipalId.
-* RequesterDetailsObject.Type MUST be a consistent, readable display value.
-* RequesterDetailsObject SHOULD include Type when the *service provider* distinguishes kinds of *principals*.
-* RequesterDetailsObject.Credential MUST represent the *credential* identified by CredentialId.
-* RequesterDetailsObject.Credential.Id MUST match CredentialId.
-* RequesterDetailsObject.Credential.Type MUST represent the kind of *credential* identified by CredentialId.
-* RequesterDetailsObject.Credential.Type MUST be a consistent, readable display value.
-* RequesterDetailsObject.Credential.Name MUST represent a readable display name for the *credential* identified by CredentialId.
-* RequesterDetailsObject SHOULD represent a level of the *requester* that is neither the *principal* nor the *credential* as a custom property whose value is an object.
-* RequesterDetailsObject custom properties representing a level of the *requester* SHOULD include the Id, Type, and Name entries defined for RequesterDetailsObject.Credential.
+* RequesterDetailsObject MUST be an array of entries.
+* RequesterDetailsObject MUST include at least one entry.
+* RequesterDetailsObject MUST NOT include entries that are not applicable to the *requester* associated with the *charge*.
+
+RequesterDetailsObject entries MUST adhere to the following requirements:
+
+* Entry in RequesterDetailsObject MUST include a `key` property.
+* Entry in RequesterDetailsObject MUST include a `value` property.
+* Entry.key in RequesterDetailsObject MUST be "Principal", "Credential", or a custom key.
+* Entry.key in RequesterDetailsObject MUST be unique within RequesterDetailsObject.
+* Entry.value in RequesterDetailsObject MUST be an object carrying the descriptive attributes of the *requester* level named by Entry.key.
+* Entry.value.Type MUST represent the kind of entity described by the entry.
+* Entry.value.Name MUST represent a readable display name for the entity described by the entry.
+* Entry.value.Email MUST represent an email address associated with the entity described by the entry.
+* Custom entry in RequesterDetailsObject MUST represent a level of the *requester* that is neither the *principal* nor the *credential*.
 
 ### Object Schema Structure
 
-RequesterDetails contains a structured JSON object describing the *principal* identified by PrincipalId and the *credential* identified by CredentialId.
+RequesterDetails contains an array of key-value entries describing the *principal* identified by PrincipalId and the *credential* identified by CredentialId.
 
-<div class="h7-nonindex">Top-Level Properties</div>
+<div class="h7-nonindex">Entry Properties</div>
+
+Each entry in the array contains the following properties:
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| `Name` | String | False | Readable display name for the *principal* identified by Principal ID. |
-| `Email` | String | False | Email address associated with the *principal* identified by Principal ID. |
-| `Type` | String | False | The kind of *principal* identified by Principal ID (e.g., "User", "Service Account", "Application"). |
-| `Credential` | Object | False | The *credential* identified by Credential ID. |
+| `key` | String | True | Names what the entry describes. One of the FOCUS-defined keys below, or a custom key. |
+| `value` | Object | True | The attributes applicable to `key`. |
 
-<div class="h7-nonindex">Credential Object</div>
+<div class="h7-nonindex">FOCUS-Defined Keys</div>
 
-The `Credential` property contains an object with the following entries:
+| Key | Required | Description |
+| :--- | :--- | :--- |
+| `Principal` | False | The *principal* identified by Principal ID. |
+| `Credential` | False | The *credential* identified by Credential ID. |
 
-| Key | Type | Required | Description |
+<div class="h7-nonindex">Value Properties</div>
+
+The `value` of each entry is an object. FOCUS supports the properties below for describing the entity; a data generator uses them as necessary and may include additional custom properties.
+
+| Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| `Id` | String | False | The value of Credential ID for the *credential* described by this object. |
-| `Type` | String | True | The kind of *credential* identified by Credential ID (e.g., "API Key", "Session", "Delegated Role"). |
-| `Name` | String | False | Readable display name for the *credential* identified by Credential ID. |
+| `Type` | String | False | The kind of entity the entry describes (e.g., "User", "Service Account", "API Key", "Session"). |
+| `Name` | String | False | Readable display name for the entity the entry describes. |
+| `Email` | String | False | Email address associated with the entity the entry describes. |
 
 ### Object Implementation Guidance
 
-<div class="h7-nonindex">Custom Properties</div>
+<div class="h7-nonindex">Custom Keys and Properties</div>
 
-To facilitate querying data across *principals* and across *service providers*, a data generator may include one or more custom properties. These may be placed at the top level of the object (alongside `Name`) or nested within the `Credential` object. Custom keys must be prefixed with "x_" followed by PascalCase format (e.g., `x_MyCustomKey`) to make them easy to identify as well as prevent collisions with FOCUS-defined keys.
+To facilitate querying data across *principals* and across [*service providers*](#glossary:service-provider), a data generator may include one or more custom entries, or custom properties within the `value` of a FOCUS-defined entry. Custom entry keys and custom property names MUST be prefixed with "x_" followed by PascalCase format (e.g., `x_MyCustomKey`) to make them easy to identify as well as prevent collisions with FOCUS-defined keys.
 
 <div class="h7-nonindex">Additional Levels</div>
 
-The `Credential` object is the shape a level of the *requester* takes: `Id` for the identifier the *service provider* publishes for that level, `Type` for the kind of entity the level represents, and `Name` for a readable display name. A *service provider* that represents a *requester* at further levels (e.g., a tenant, a delegating identity, an intermediate role) describes each one as a custom property holding an object of that same shape.
+Every entry value uses the same set of properties, so the *principal*, the *credential*, and any additional level share one shape. A *requester* represented at further levels (e.g., a tenant, a delegating identity, an intermediate role) carries each one as a custom entry whose value uses those same properties.
 
 This specification defines the *principal* and the *credential* because they are the two levels that appear across *service providers*. It does not enumerate the levels between them, which vary by authorization model. Reusing one shape for every level means a level named by a data generator and a level named by a later version of this specification are read the same way.
 
-<div class="h7-nonindex">Property Placement</div>
+<div class="h7-nonindex">Entry Placement</div>
 
-Attributes describing the *principal* identified by PrincipalId belong at the top level of the object. Attributes describing the *credential* identified by CredentialId belong in the `Credential` object. A top-level property whose value is an object describes a level of the *requester* rather than an attribute of the *principal*. Placing the descriptive attributes of the *principal* at the top level allows analyses that group or filter on those attributes to read them directly.
-
-`Credential.Id` repeats the value carried in CredentialId. A *service provider* that publishes the *credential* identifier alongside its descriptive attributes has a FOCUS-defined key available for it rather than a custom property. Analyses that group or filter on the *credential* read CredentialId, which is available without parsing the object.
-
-Where a *service provider* publishes no identifier for the *credential* presented, CredentialId is null and the `Credential` property is omitted. The attributes describing the *principal* remain at the top level.
+Attributes describing the *principal* identified by PrincipalId belong in the `value` of the `Principal` entry. Attributes describing the *credential* identified by CredentialId belong in the `value` of the `Credential` entry. An entry is present only when attributes for it are published, so a *charge* with a *principal* and no identified *credential* carries a `Principal` entry alone.
 
 ### Object Example
 
-Here is a basic example of the object format.
+Here is an example of the object format.
 
 * For more detailed examples, please see this column's entry in the JSON Object Examples appendix entry [here](#appendix.examples:jsonobject.examples:requesterdetails).
 * For the JSON schema, please see [Requester Details Object Schema](#schemas.costandusage.requesterdetailsobjectschema).
 
 ```json
-{
-  "Name" : "Alex Rivera",
-  "Email" : "alex.rivera@example.com",
-  "Type" : "User",
-  "Credential" : {
-    "Type" : "API Key",
-    "Name" : "prod-ingest-key"
+[
+  {
+    "key" : "Principal",
+    "value" : {
+      "Name" : "Alex Rivera",
+      "Email" : "alex.rivera@example.com",
+      "Type" : "User"
+    }
+  },
+  {
+    "key" : "Credential",
+    "value" : {
+      "Type" : "API Key",
+      "Name" : "prod-ingest-key"
+    }
   }
-}
+]
 ```
 
 ### Object ID

--- a/specification/datasets/cost_and_usage/columns/requesterdetails.md
+++ b/specification/datasets/cost_and_usage/columns/requesterdetails.md
@@ -46,6 +46,8 @@ RequesterDetailsObject entries MUST adhere to the following requirements:
 * Entry.value.Name MUST represent a readable display name for the entity described by the entry.
 * Entry.value.Email MUST represent an email address associated with the entity described by the entry.
 * Custom entry in RequesterDetailsObject MUST represent a level of the *requester* that is neither the *principal* nor the *credential*.
+* Custom Entry.key in RequesterDetailsObject MUST begin with the string "x_" followed by PascalCase.
+* Custom property name in Entry.value in RequesterDetailsObject MUST begin with the string "x_" followed by PascalCase.
 
 ### Object Schema Structure
 

--- a/specification/datasets/cost_and_usage/columns/requesterdetails.md
+++ b/specification/datasets/cost_and_usage/columns/requesterdetails.md
@@ -12,44 +12,44 @@ Requester Details helps practitioners attribute cost to a recognizable *requeste
 
 RequesterDetails MUST adhere to the following requirements:
 
-* RequesterDetails MUST be of type JSON Object (serialized as a String where necessary).
+* RequesterDetails MUST be a valid JSON value (serialized as a String where necessary).
 * RequesterDetails MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * RequesterDetails MUST conform to [JsonObjectFormat](#attributes.jsonobjectformat) requirements.
 * RequesterDetails MUST adhere to the following nullability requirements:
   * RequesterDetails MAY be null when PrincipalId is null and CredentialId is null.
   * RequesterDetails MUST NOT be null when PrincipalId is not null or CredentialId is not null.
-* RequesterDetails MUST conform to [RequesterDetailsObject](#datamodel.costandusage.requesterdetails.requesterdetailsobject) requirements when RequesterDetails is not null.
+* RequesterDetails MUST conform to [RequesterDetailsValue](#datamodel.costandusage.requesterdetails.requesterdetailsvalue) requirements when RequesterDetails is not null.
 
-## Requester Details Object
+## Requester Details Value
 
-Requester Details consists of an array of entries, where each entry is an object carrying a `key` property naming what the entry describes and a `value` property carrying its attributes. The `Principal` entry describes the *principal* identified by PrincipalId, and the `Credential` entry describes the *credential* identified by CredentialId.
+Requester Details consists of a JSON array of entries, where each entry is an object carrying a `key` property naming what the entry describes and a `value` property carrying its attributes. The `Principal` entry describes the *principal* identified by PrincipalId, and the `Credential` entry describes the *credential* identified by CredentialId.
 
-The following section details the normative requirements for the RequesterDetailsObject and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datamodel.costandusage.requesterdetails.requesterdetailsobject.objectschemastructure) and [Object Example](#datamodel.costandusage.requesterdetails.requesterdetailsobject.objectexample) sections.
+The following section details the normative requirements for the RequesterDetailsValue and its nested properties. For a logical overview of the expected content, see the [Schema Structure](#datamodel.costandusage.requesterdetails.requesterdetailsvalue.valueschemastructure) and [Value Example](#datamodel.costandusage.requesterdetails.requesterdetailsvalue.valueexample) sections.
 
-### Object Requirements
+### Value Requirements
 
-RequesterDetailsObject MUST adhere to the following requirements:
+RequesterDetailsValue MUST adhere to the following requirements:
 
-* RequesterDetailsObject MUST conform to the [RequesterDetailsObjectSchema](#schemas.costandusage.requesterdetailsobjectschema) JSON Schema.
-* RequesterDetailsObject MUST be an array of entries.
-* RequesterDetailsObject MUST include at least one entry.
-* RequesterDetailsObject MUST NOT include entries that are not applicable to the *requester* associated with the *charge*.
+* RequesterDetailsValue MUST conform to the [RequesterDetailsValueSchema](#schemas.costandusage.requesterdetailsvalueschema) JSON Schema.
+* RequesterDetailsValue MUST be an array of entries.
+* RequesterDetailsValue MUST include at least one entry.
+* RequesterDetailsValue MUST NOT include entries that are not applicable to the *requester* associated with the *charge*.
 
-RequesterDetailsObject entries MUST adhere to the following requirements:
+RequesterDetailsValue entries MUST adhere to the following requirements:
 
-* Entry in RequesterDetailsObject MUST include a `key` property.
-* Entry in RequesterDetailsObject MUST include a `value` property.
-* Entry.key in RequesterDetailsObject MUST be "Principal", "Credential", or a custom key.
-* Entry.key in RequesterDetailsObject MUST be unique within RequesterDetailsObject.
-* Entry.value in RequesterDetailsObject MUST be an object carrying the descriptive attributes of the *requester* level named by Entry.key.
+* Entry in RequesterDetailsValue MUST include a `key` property.
+* Entry in RequesterDetailsValue MUST include a `value` property.
+* Entry.key in RequesterDetailsValue MUST be "Principal", "Credential", or a custom key.
+* Entry.key in RequesterDetailsValue MUST be unique within RequesterDetailsValue.
+* Entry.value in RequesterDetailsValue MUST be an object carrying the descriptive attributes of the *requester* level named by Entry.key.
 * Entry.value.Type MUST represent the kind of entity described by the entry.
 * Entry.value.Name MUST represent a readable display name for the entity described by the entry.
 * Entry.value.Email MUST represent an email address associated with the entity described by the entry.
-* Custom entry in RequesterDetailsObject MUST represent a level of the *requester* that is neither the *principal* nor the *credential*.
-* Custom Entry.key in RequesterDetailsObject MUST begin with the string "x_" followed by PascalCase.
-* Custom property name in Entry.value in RequesterDetailsObject MUST begin with the string "x_" followed by PascalCase.
+* Custom entry in RequesterDetailsValue MUST represent a level of the *requester* that is neither the *principal* nor the *credential*.
+* Custom Entry.key in RequesterDetailsValue MUST begin with the string "x_" followed by PascalCase.
+* Custom property name in Entry.value in RequesterDetailsValue MUST begin with the string "x_" followed by PascalCase.
 
-### Object Schema Structure
+### Value Schema Structure
 
 RequesterDetails contains an array of key-value entries describing the *principal* identified by PrincipalId and the *credential* identified by CredentialId.
 
@@ -79,7 +79,7 @@ The `value` of each entry is an object. FOCUS supports the properties below for 
 | `Name` | String | False | Readable display name for the entity the entry describes. |
 | `Email` | String | False | Email address associated with the entity the entry describes. |
 
-### Object Implementation Guidance
+### Value Implementation Guidance
 
 <div class="h7-nonindex">Custom Keys and Properties</div>
 
@@ -95,12 +95,12 @@ This specification defines the *principal* and the *credential* because they are
 
 Attributes describing the *principal* identified by PrincipalId belong in the `value` of the `Principal` entry. Attributes describing the *credential* identified by CredentialId belong in the `value` of the `Credential` entry. An entry is present only when attributes for it are published, so a *charge* with a *principal* and no identified *credential* carries a `Principal` entry alone.
 
-### Object Example
+### Value Example
 
-Here is an example of the object format.
+Here is an example of the value format.
 
 * For more detailed examples, please see this column's entry in the JSON Object Examples appendix entry [here](#appendix.examples:jsonobject.examples:requesterdetails).
-* For the JSON schema, please see [Requester Details Object Schema](#schemas.costandusage.requesterdetailsobjectschema).
+* For the JSON schema, please see [Requester Details Value Schema](#schemas.costandusage.requesterdetailsvalueschema).
 
 ```json
 [
@@ -122,13 +122,13 @@ Here is an example of the object format.
 ]
 ```
 
-### Object ID
+### Value ID
 
-RequesterDetailsObject
+RequesterDetailsValue
 
-### Object Display Name
+### Value Display Name
 
-Requester Details Object
+Requester Details Value
 
 ## Column ID
 
@@ -152,7 +152,7 @@ A set of properties describing the *requester* on whose behalf a request that pr
 | Allows nulls | True |
 | Data type | JSON |
 | Value format | [JSON Object Format](#attributes.jsonobjectformat) |
-| Object | [RequesterDetailsObject](#datamodel.costandusage.requesterdetails.requesterdetailsobject) |
+| Value | [RequesterDetailsValue](#datamodel.costandusage.requesterdetails.requesterdetailsvalue) |
 
 ## Version Introduced
 

--- a/specification/datasets/cost_and_usage/columns/requesterdetails.md
+++ b/specification/datasets/cost_and_usage/columns/requesterdetails.md
@@ -83,7 +83,7 @@ The `value` of each entry is an object. FOCUS supports the properties below for 
 
 <div class="h7-nonindex">Custom Keys and Properties</div>
 
-To facilitate querying data across *principals* and across [*service providers*](#glossary:service-provider), a data generator may include one or more custom entries, or custom properties within the `value` of a FOCUS-defined entry. Custom entry keys and custom property names MUST be prefixed with "x_" followed by PascalCase format (e.g., `x_MyCustomKey`) to make them easy to identify as well as prevent collisions with FOCUS-defined keys.
+To facilitate querying data across *principals* and across [*service providers*](#glossary:service-provider), a data generator may include one or more custom entries, or custom properties within the `value` of a FOCUS-defined entry. The "x_" prefix followed by PascalCase format (e.g., `x_MyCustomKey`) makes custom keys easy to identify and prevents collisions with FOCUS-defined keys.
 
 <div class="h7-nonindex">Additional Levels</div>
 

--- a/specification/requirements_model/releases/1.5/model_rules/attributes/jsonobjectformat.json
+++ b/specification/requirements_model/releases/1.5/model_rules/attributes/jsonobjectformat.json
@@ -73,7 +73,7 @@
     "Type": "Dynamic",
     "Order": 10,
     "ValidationCriteria": {
-      "MustSatisfy": "FOCUS dataset column MUST contain a serialized JSON string, consistent with the ECMA 404 definition of an object.",
+      "MustSatisfy": "FOCUS dataset column MUST contain a serialized JSON string, consistent with the ECMA 404 definition of an object or an array.",
       "Keyword": "MUST",
       "Requirement": {},
       "Condition": {},

--- a/specification/schemas/datasets/cost_and_usage/requesterdetailsobjectschema.json
+++ b/specification/schemas/datasets/cost_and_usage/requesterdetailsobjectschema.json
@@ -2,58 +2,63 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://focus.finops.org/schemas/requesterdetailsobject.json",
     "title": "Requester Details Object",
-    "description": "Schema for validating the Requester Details column JSON object structure in FOCUS datasets",
-    "type": "object",
-    "minProperties": 1,
-    "properties": {
-        "Name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "description": "Readable display name for the principal identified by Principal ID"
+    "description": "Schema for validating the Requester Details column structure in FOCUS datasets. The column is an array of key-value entries, where each entry's value is an object of FOCUS-defined descriptive properties (Type, Name, Email) plus optional custom properties.",
+    "type": "array",
+    "minItems": 1,
+    "items": {
+        "type": "object",
+        "required": [
+            "key",
+            "value"
+        ],
+        "properties": {
+            "key": {
+                "type": "string",
+                "description": "Names the requester level the entry describes: \"Principal\", \"Credential\", or a custom key",
+                "anyOf": [
+                    {
+                        "enum": [
+                            "Principal",
+                            "Credential"
+                        ]
+                    },
+                    {
+                        "pattern": "^x_[A-Z][a-zA-Z0-9]*$"
+                    }
+                ]
+            },
+            "value": {
+                "$ref": "#/$defs/entryValue"
+            }
         },
-        "Email": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "description": "Email address associated with the principal identified by Principal ID"
-        },
-        "Type": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "description": "The kind of principal identified by Principal ID (e.g., User, Service Account, Application)"
-        },
-        "Credential": {
-            "type": [
-                "object",
-                "null"
-            ],
-            "description": "The credential identified by Credential ID",
-            "required": [
-                "Type"
-            ],
+        "additionalProperties": false
+    },
+    "$defs": {
+        "entryValue": {
+            "type": "object",
+            "minProperties": 1,
+            "description": "Descriptive attributes of the requester level named by the entry key",
             "properties": {
-                "Id": {
+                "Type": {
                     "type": [
                         "string",
                         "null"
                     ],
-                    "description": "The value of Credential ID for the credential described by this object"
-                },
-                "Type": {
-                    "type": "string",
-                    "description": "The kind of credential identified by Credential ID (e.g., API Key, Session, Delegated Role)"
+                    "description": "The kind of entity the entry describes (e.g., User, Service Account, API Key, Session)"
                 },
                 "Name": {
                     "type": [
                         "string",
                         "null"
                     ],
-                    "description": "Readable display name for the credential identified by Credential ID"
+                    "description": "Readable display name for the entity the entry describes"
+                },
+                "Email": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Email address associated with the entity the entry describes"
                 }
             },
             "patternProperties": {
@@ -63,11 +68,5 @@
             },
             "additionalProperties": false
         }
-    },
-    "patternProperties": {
-        "^x_[A-Z][a-zA-Z0-9]*$": {
-            "description": "Custom data generator-defined top-level properties prefixed with x_ in PascalCase format. A property whose value is an object may describe a further level of the requester, using the same Id, Type, and Name entries as the Credential object."
-        }
-    },
-    "additionalProperties": false
+    }
 }

--- a/specification/schemas/datasets/cost_and_usage/requesterdetailsvalueschema.json
+++ b/specification/schemas/datasets/cost_and_usage/requesterdetailsvalueschema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://focus.finops.org/schemas/requesterdetailsobject.json",
-    "title": "Requester Details Object",
+    "$id": "https://focus.finops.org/schemas/requesterdetailsvalue.json",
+    "title": "Requester Details Value",
     "description": "Schema for validating the Requester Details column structure in FOCUS datasets. The column is an array of key-value entries, where each entry's value is an object of FOCUS-defined descriptive properties (Type, Name, Email) plus optional custom properties.",
     "type": "array",
     "minItems": 1,

--- a/specification/schemas/schemas.mdpp
+++ b/specification/schemas/schemas.mdpp
@@ -38,10 +38,10 @@ The Contract Applied Object Schema defines the structure for the [Contract Appli
 
 !INCLUDECODE "schemas/datasets/cost_and_usage/contractappliedobjectschema.json" (json)
 
-### Requester Details Object Schema
+### Requester Details Value Schema
 
-The Requester Details Object Schema defines the structure for the [Requester Details](#datamodel.costandusage.requesterdetails) column.
+The Requester Details Value Schema defines the structure for the [Requester Details](#datamodel.costandusage.requesterdetails) column.
 
-[Download from GitHub](/specification/schemas/datasets/cost_and_usage/requesterdetailsobjectschema.json)
+[Download from GitHub](/specification/schemas/datasets/cost_and_usage/requesterdetailsvalueschema.json)
 
-!INCLUDECODE "schemas/datasets/cost_and_usage/requesterdetailsobjectschema.json" (json)
+!INCLUDECODE "schemas/datasets/cost_and_usage/requesterdetailsvalueschema.json" (json)


### PR DESCRIPTION
## Summary

Restructures `RequesterDetails` from a single nested JSON object into a JSON array of key-value entries, and updates the supporting schema and attribute to match.

## What changed

* **`RequesterDetails` is now a JSON array of key-value entries.** Each entry has a `key` (`Principal`, `Credential`, or an `x_`-prefixed custom key) and a `value` object of descriptive attributes (`Type`, `Name`, `Email`, plus `x_`-prefixed custom properties). Every level shares one shape, so a newly defined level adds an entry instead of widening the structure.
* **Top-level construct renamed `RequesterDetailsObject` → `RequesterDetailsValue`.** The construct is an array, not an object, so its ID, headings, display name, and schema (`requesterdetailsvalueschema.json`, `$id`, `title`) now say "Value". References to genuine objects (each entry's `value`) are unchanged.
* **`JsonObjectFormat` relaxed to permit a top-level array.** The ECMA-404 "object" allowance becomes "object or an array". This only relaxes the attribute, so existing object-valued columns (`ContractApplied`, `AllocatedMethodDetails`, `CommitmentProgramEligibilityDetails`, `ContractCommitmentApplicability`) remain conformant unchanged.
* **Schema and examples updated** to the array shape; each entry validates against one uniform value schema under `additionalProperties: false`.

## Note

`Entry.key MUST be unique within RequesterDetailsValue` is normative but not expressible in JSON Schema (`uniqueItems` only rejects wholly identical entries), so uniqueness requires a build-time check.

### Type of Change
* [ ] Bug fix
* [x] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
