### PR TITLE
AI #2359: Expand the actor attribution examples to cover `Principal ID` and `Credential ID`

### DIFF
--- a/specification/appendix/actor_attribution.md
+++ b/specification/appendix/actor_attribution.md
@@ -1,21 +1,56 @@
 # Examples: Actor Attribution
 
-The examples below illustrate how [Principal ID](#datamodel.costandusage.principalid) is populated in the [Cost and Usage](#datamodel.costandusage) dataset across technology categories. Each scenario identifies the [*principal*](#glossary:principal) to which a [*service provider*](#glossary:service-provider) grants access to a [*resource*](#glossary:resource) or [*service*](#glossary:service), and notes where the party that benefits from the [*charge*](#glossary:charge) differs from that *principal*.
+The examples below illustrate how [Principal ID](#datamodel.costandusage.principalid) and [Credential ID](#datamodel.costandusage.credentialid) are populated in the [Cost and Usage](#datamodel.costandusage) dataset across technology categories. Each scenario identifies the [*principal*](#glossary:principal) to which access to a [*resource*](#glossary:resource) or [*service*](#glossary:service) is granted and the [*credential*](#glossary:credential) presented on the request that produced the [*charge*](#glossary:charge). Provider, customer, and identifier values below are illustrative.
 
-1. **Generative AI API:** Acme Corp uses an internal bot to summarize notes via a LatticeScale API. The bot authenticates as a service account, which LatticeScale records as the *principal* (`PrincipalId`). The employee whose notes are summarized benefits from the *charge* and is not the *principal*.
-2. **Multi-Tenant PaaS:** A shared BI engine runs a query on OmniQuery for a specific client of GearPeak Outdoors. OmniQuery grants access to the engine's service account, which is the *principal* (`PrincipalId`). The client that requested the report benefits from the *charge* and is not the *principal*.
-3. **Network Edge Processing:** At Acme Corp, traffic routed through an Aura Web edge network authenticates as a gateway service account, which Aura Web records as the *principal* (`PrincipalId`). The end users behind the aggregated traffic benefit from the *charge* and are not resolvable in the billing data.
-4. **Seat-Based SaaS:** Acme Corp pre-purchases SprintCanvas seats assigned to individual users. SprintCanvas grants each seat holder access under its own identity and access management model, so the seat holder is the *principal* (`PrincipalId`) and also the party that benefits from the *charge*.
-5. **Seat-Plus-Token SaaS:** Acme Corp subscribes to PipelCRM and uses its embedded AI assistant. The seat license and the per-token AI usage are reported as separate *charges* under the same seat holder (`PrincipalId`), who also benefits from both *charges*, so attribution follows the user as *service providers* shift from seat-based to hybrid seat and consumption-based pricing.
-6. **Direct PaaS Usage:** A data scientist at Acme Corp logs into a LatticeScale managed notebook using their individual SSO credential. LatticeScale grants access to that user identity, which is the *principal* (`PrincipalId`), and the same user benefits from the *charge*.
-7. **Billing System Charge:** Acme Corp receives a promotional credit or is charged applicable tax from LatticeScale. The *charge* originates in the *service provider's* billing system and is not associated with any entity in its identity and access management model, so `PrincipalId` is `null`.
+## Attribution Roles
 
-| # | Scenario | Data Generator | PrincipalId |
-| :--- | :--- | :--- | :--- |
-| 1 | **Generative AI API** | LatticeScale | `svc-acme-docbot-prod` |
-| 2 | **Multi-Tenant PaaS** | OmniQuery | `svc-bi-reporting-engine` |
-| 3 | **Network Edge Processing** | Aura Web | `svc-edge-gateway-prod` |
-| 4 | **Seat-Based SaaS** | SprintCanvas | `user_uuid_554321` |
-| 5 | **Seat-Plus-Token SaaS** | PipelCRM | `user_uuid_887766` |
-| 6 | **Direct PaaS Usage** | LatticeScale | `dev_uuid_112233` |
-| 7 | **Billing System Charge** | LatticeScale | `null` |
+The two columns answer different questions about the same *charge*:
+
+* Principal ID is the attribution dimension. A *principal* persists while the *credentials* it presents rotate, so grouping by Principal ID combines a user's or workload's *charges* regardless of how each request was credentialed.
+* Credential ID is the audit dimension. It separates *charges* that share a *principal* but originate from different *credentials*, and joins to the *credential* identifiers a [*service provider*](#glossary:service-provider) records in its own logs.
+
+Both columns identify the identity under which the usage that incurred a *charge* was initiated. Neither identifies the party that benefits from it. The two are frequently different: a shared workload, a gateway, or an embedded assistant initiates usage on behalf of employees, clients, or end users who do not appear in the billing data at all. Where a *principal* is also the beneficiary — a seat holder using their own seat, an engineer running their own query — that is a property of the scenario rather than something either column asserts, and a consumer cannot tell the two situations apart from these columns alone.
+
+Credential ID carries an identifier that references a *credential*, never the *credential* itself. Secret or permanent *credential* material (e.g., a key string, a bearer token, a session cookie) does not appear in the column. Where a *service provider* authenticates a request but publishes no identifier for the *credential* presented, Credential ID is null, as in Scenario 8.
+
+Either identifier is null when the *charge* is not associated with an entity of that kind, or when the *service provider* publishes no identifier for it. The two columns are independent: a *charge* may carry a *principal* with no *credential* identifier (Scenarios 7 through 10), a *credential* with no *principal* (Scenario 12), both (Scenarios 1 through 6, and 11), or neither (Scenario 13). Neither column repeats the other's value.
+
+> **Note:** A *credential* is what the request carries, not the factor used to log in. A password or a single sign-on assertion is exchanged at login for a session, and the request that produces a *charge* carries that session, so the identifier a *service provider* assigns to that session is what Credential ID records. Where a *service provider* establishes no session that it identifies separately from the *principal*, Credential ID is null. Scenarios 6 and 7 show the same login path for *service providers* that differ on this point. Session identifiers are commonly reissued on each login, so Credential ID is expected to be higher-cardinality and shorter-lived than Principal ID.
+
+## Scenarios
+
+1. **Generative AI API, User-Owned Key:** Acme Corp runs inference on Aura Web using an API key that Alex Rivera created under their own user account. Aura Web resolves the key to that user, so the user is the *principal* and the API key is the *credential*. Grouping by Principal ID combines this *charge* with Alex Rivera's other activity; grouping by Credential ID isolates the spend driven by this one key.
+2. **Generative AI API, Service Account Key:** Acme Corp uses an internal bot to summarize notes via a LatticeScale API. The bot authenticates with an API key issued to a service account, which LatticeScale records as the *principal*. The employees whose notes are summarized are not represented in either column.
+3. **Multi-Tenant PaaS:** A shared BI engine runs a query on OmniQuery for a specific client of GearPeak Outdoors. OmniQuery grants access to the engine's service account, which is the *principal*, and records the API key the engine presented as the *credential*. Every client's queries resolve to the same *principal*, so the *charges* cannot be separated by client from these columns.
+4. **Network Edge Processing:** At Acme Corp, traffic routed through an Aura Web edge network authenticates as a gateway service account presenting a gateway key. Aura Web records the service account as the *principal* and the key as the *credential*. The end users behind the aggregated traffic are not resolvable in the billing data at any grain.
+5. **Workload Identity:** A deployment pipeline at Acme Corp exchanges a short-lived federated token for access to a LatticeScale service. The token is the *credential* and the service account it maps to is the *principal*. LatticeScale assigns each exchange a federated session identifier, which is what Credential ID carries; the token itself is never published. A new session is established on every pipeline run, so Credential ID changes across *charges* that share a Principal ID, which is why attribution reporting reads the *principal* rather than the *credential*.
+6. **Direct PaaS Usage, Session Recorded:** A data scientist at Acme Corp logs into a LatticeScale managed notebook using their individual single sign-on credential. LatticeScale grants access to that user identity, which is the *principal*, and identifies the resulting console session separately, so the session is the *credential* and Credential ID carries the identifier LatticeScale assigns to it.
+7. **Direct PaaS Usage, No Session Recorded:** An engineer at Acme Corp runs a query from the StackLens console after signing in through the same organizational identity provider. StackLens attributes the *charge* to the user but does not identify the session separately from the user, so Principal ID carries the user and Credential ID is null.
+8. **Credential Without a Published Identifier:** Acme Corp calls a Meridian AI service with an API key issued to a named user. Meridian AI authenticates the request and resolves the key to that user, so Principal ID carries the user, but it assigns no identifier to the key that it publishes in billing data. The only value that would distinguish this *credential* is the key string itself, which is secret, so Credential ID is null. A *credential* being presented is not on its own sufficient for Credential ID to be populated.
+9. **Seat-Based SaaS:** Acme Corp pre-purchases SprintCanvas seats assigned to individual users. SprintCanvas grants each seat holder access under its own identity and access management model, so the seat holder is the *principal*. The *charge* is a recurring seat license rather than the product of an individual request, so no *credential* is associated with it and Credential ID is null.
+10. **Seat-Plus-Token SaaS:** Acme Corp subscribes to PipelCRM and uses its embedded AI assistant. The seat license and the per-token AI usage are reported as separate *charges* under the same seat holder, so attribution follows the user as *service providers* shift from seat-based to hybrid seat and consumption-based pricing. PipelCRM does not expose a *credential* for either *charge*.
+11. **Marketplace Purchase:** Acme Corp purchases a Meridian AI subscription through the Aura Web marketplace and consumes it under an Aura Web console session. Meridian AI is the *service provider* and Aura Web is the host provider and the data generator. The *principal* and the *credential* are both defined in the host provider's identity and access management model, because that is where the purchase was authenticated.
+12. **Credential Without a Determinable Principal:** Acme Corp runs an evaluation workload on Meridian AI using an API key that Meridian AI cannot map to an entity in its identity and access management model. Meridian AI publishes an identifier for the key itself, so Principal ID is null and Credential ID carries that identifier.
+13. **Billing System Charge:** Acme Corp receives a promotional credit or is charged applicable tax from LatticeScale. The *charge* originates in the *service provider's* billing system and is not associated with a *principal* or a *credential*, so both columns are null.
+
+## Summary
+
+| # | Scenario | Data Generator | PrincipalId | CredentialId | Credential Type |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| 1 | **Generative AI API, User-Owned Key** | Aura Web | `user_8842` | `key_01HQZX3M8N` | API Key |
+| 2 | **Generative AI API, Service Account Key** | LatticeScale | `svc-acme-docbot-prod` | `key_7734PLQZ` | API Key |
+| 3 | **Multi-Tenant PaaS** | OmniQuery | `svc-bi-reporting-engine` | `key_22XCVB88` | API Key |
+| 4 | **Network Edge Processing** | Aura Web | `svc-edge-gateway-prod` | `key_edge_9931` | API Key |
+| 5 | **Workload Identity** | LatticeScale | `svc-ci-deploy` | `fedsess_5FG2WQ7H` | Federated Session |
+| 6 | **Direct PaaS Usage, Session Recorded** | LatticeScale | `dev_uuid_112233` | `sess_9KD2LM4T` | Session |
+| 7 | **Direct PaaS Usage, No Session Recorded** | StackLens | `user_5521` | `null` | `null` |
+| 8 | **Credential Without a Published Identifier** | Meridian AI | `user_3390` | `null` | `null` |
+| 9 | **Seat-Based SaaS** | SprintCanvas | `user_uuid_554321` | `null` | `null` |
+| 10 | **Seat-Plus-Token SaaS** | PipelCRM | `user_uuid_887766` | `null` | `null` |
+| 11 | **Marketplace Purchase** | Aura Web | `hp_user_66120` | `sess_MK4471` | Session |
+| 12 | **Credential Without a Determinable Principal** | Meridian AI | `null` | `key_07PQXR2W9F` | API Key |
+| 13 | **Billing System Charge** | LatticeScale | `null` | `null` | `null` |
+
+Every CredentialId value above is an identifier a *service provider* assigns to a *credential* and publishes, not the *credential* itself. Scenarios 7 through 10 show the distinct reasons the column is null: no session identified separately from the *principal*, no published identifier for the *credential* presented, and no *credential* associated with the *charge* at all.
+
+The Credential Type column is not a FOCUS column. It shows the value a data generator would carry in the `Type` key of the `Credential` property in [Credential Details](#datamodel.costandusage.credentialdetails), and is included here to make the kind of *credential* in each scenario explicit.

--- a/specification/appendix/appendix_overview.md
+++ b/specification/appendix/appendix_overview.md
@@ -7,7 +7,7 @@
 | Topic | Description |
 | :--- | :--- |
 | [Discount Handling](#appendix.discounthandling) | Explains how discounts are represented and applied to charges in a FOCUS dataset. |
-| [Examples: Actor Attribution](#appendix.examples:actorattribution) | Illustrates how Principal ID is populated across different technology categories, including where the party that benefits from a charge differs from the principal. |
+| [Examples: Actor Attribution](#appendix.examples:actorattribution) | Illustrates how Principal ID and Credential ID are populated across different technology categories, including where a charge carries one identifier but not the other, and why neither column identifies the party that benefits from a charge. |
 | [Examples: AI Model Identity](#appendix.examples:aimodelidentity) | Illustrates how to represent the identity of an AI model in a Cost and Usage FOCUS dataset, including a directly purchased foundation model and the same model served by a cloud provider as a first-party service. |
 | [Examples: Commitment Discounts](#appendix.examples:commitmentdiscounts) | Explains the purchasing, usage, and amortization of commitment discounts in a FOCUS dataset. |
 | [Examples: Commitment Discount Flexibility](#appendix.examples:commitmentdiscountflexibility) | Demonstrates scenarios for usage-based commitment discounts with and without commitment discount flexibility. |


### PR DESCRIPTION
## Summary

Expands the Actor Attribution appendix, on top of #2360.

The `PrincipalId`, glossary, and `IncludesIdentityAttribution` wording this PR originally carried has since been applied directly to #2360, so this PR now reduces to the appendix.

**7 scenarios become 13, covering both `PrincipalId` and `CredentialId`.** New: a user-owned API key; workload identity, where the credential rotates every pipeline run while the principal holds steady; single sign-on with and without a recorded session; a marketplace purchase authenticated against the host provider; a credential with no published identifier; and a credential with no determinable principal. All seven original scenarios are retained with the credential dimension added.

**Three framing points are stated once rather than implied per scenario:**

* `PrincipalId` is the attribution dimension; `CredentialId` is the audit dimension.
* `CredentialId` carries an identifier that references a credential, never credential material. A credential with no published identifier leaves the column null, so a credential being presented is not on its own sufficient for the column to be populated.
* Neither column identifies the party that benefits from a charge. Where a principal happens also to be the beneficiary, that is a property of the scenario rather than something either column asserts, and a consumer cannot tell the two situations apart from these columns alone.

The previous version annotated the beneficiary per scenario, which read as though the data conveyed it.

Scenarios 7 through 10 show the three distinct reasons `CredentialId` is null: no session identified separately from the principal, no published identifier for the credential presented, and no credential associated with the charge at all.

## Merge order: do not merge before #2553

The appendix references `CredentialId`, `CredentialDetails`, and the `Credential` glossary term, none of which exist until #2553. This PR and #2553 are siblings off #2360, so merging this first leaves three dead anchors in the rendered output. The markdown linter does not catch it, because it does not resolve pandoc-generated anchors.

If the group prefers, these two files can move onto the credential branch instead, which would remove the ordering constraint entirely.

## Validation performed

* Linter clean on both changed files.
* Prose scenarios and summary table rows both number 13, with matching titles.
* The null-combination groupings in the framing section were checked against the table: principal only (7-10), credential only (12), both (1-6, 11), neither (13) — all 13 rows accounted for exactly once.
* No BCP-14 keyword appears in the appendix, and no dash or plus bullets.

> `make` does not complete past the markdown stage on the authoring machine, which has neither pandoc nor wkhtmltopdf. HTML and PDF generation is unverified.

### Type of Change
* [ ] Bug fix
* [x] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
