### PR TITLE
FR #2315: (Replace #2612) Enhance normative requirements for AllocatedServiceName

### DIFF
--- a/specification/datasets/cost_and_usage/columns/allocatedservicename.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedservicename.md
@@ -9,8 +9,10 @@ AllocatedServiceName MUST adhere to the following requirements:
 * AllocatedServiceName MUST be of type String.
 * AllocatedServiceName MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * AllocatedServiceName MUST adhere to the following nullability requirements:
-  * AllocatedServiceName MUST be null when [AllocatedResourceId](#datamodel.costandusage.allocatedresourceid) is null.
-  * AllocatedServiceName MUST NOT be null when AllocatedResourceId is not null.
+  * AllocatedServiceName MUST be null when [AllocatedMethodId](#datamodel.costandusage.allocatedresourceid) is null.
+  * AllocatedServiceName MUST NOT be null when AllocatedMethodId is not null.
+* AllocatedServiceName SHOULD match the ServiceName used by the data generator for the equivalent stand-alone service.
+* AllocatedServiceName SHOULD match the AllocatedServiceName used for other [allocated charges](#glossary.allocated-charge) related to the same [origin charge](#glossary:origin-charge) when a *charge* represents the unallocated portion of the origin charge.
 
 ## Column ID
 

--- a/specification/datasets/cost_and_usage/columns/allocatedservicename.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedservicename.md
@@ -9,7 +9,7 @@ AllocatedServiceName MUST adhere to the following requirements:
 * AllocatedServiceName MUST be of type String.
 * AllocatedServiceName MUST conform to [StringHandling](#attributes.stringhandling) requirements.
 * AllocatedServiceName MUST adhere to the following nullability requirements:
-  * AllocatedServiceName MUST be null when [AllocatedMethodId](#datamodel.costandusage.allocatedresourceid) is null.
+  * AllocatedServiceName MUST be null when [AllocatedMethodId](#datamodel.costandusage.allocatedmethodid) is null.
   * AllocatedServiceName MUST NOT be null when AllocatedMethodId is not null.
 * AllocatedServiceName SHOULD match the ServiceName used by the data generator for the equivalent stand-alone service.
 * AllocatedServiceName SHOULD match the AllocatedServiceName used for other [allocated charges](#glossary:allocated-charge) related to the same [origin charge](#glossary:origin-charge) when a *charge* represents the unallocated portion of the origin charge.

--- a/specification/datasets/cost_and_usage/columns/allocatedservicename.md
+++ b/specification/datasets/cost_and_usage/columns/allocatedservicename.md
@@ -12,7 +12,7 @@ AllocatedServiceName MUST adhere to the following requirements:
   * AllocatedServiceName MUST be null when [AllocatedMethodId](#datamodel.costandusage.allocatedresourceid) is null.
   * AllocatedServiceName MUST NOT be null when AllocatedMethodId is not null.
 * AllocatedServiceName SHOULD match the ServiceName used by the data generator for the equivalent stand-alone service.
-* AllocatedServiceName SHOULD match the AllocatedServiceName used for other [allocated charges](#glossary.allocated-charge) related to the same [origin charge](#glossary:origin-charge) when a *charge* represents the unallocated portion of the origin charge.
+* AllocatedServiceName SHOULD match the AllocatedServiceName used for other [allocated charges](#glossary:allocated-charge) related to the same [origin charge](#glossary:origin-charge) when a *charge* represents the unallocated portion of the origin charge.
 
 ## Column ID
 


### PR DESCRIPTION
## Summary

Per the conversation 20260824, this replaces https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pull/2612.

- Adjusted nullability requirements to use AllocatedMethodId which is not null for any split cost allocated charge
- Added normative requirement (SHOULD) reflecting the desire for AllocatedServiceName to reflect the existing service name used by providers, where applicable
  - SHOULD represents that there may be exceptions such as not be an existing service name to use for this.
- Added normative requirement (SHOULD) reflecting that unallocated charges should reflect the same AllocatedServiceName as the allocated charges
  - SHOULD represents that there may be exceptions such as where one Origin Charge is split into multiple AllocatedServiceNames

### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [X] Editorial / Formatting

### Author Checklist
* [ X ] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [ X ] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ NA ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
