### PR TITLE
AI #2535 - Extension: Add Grammatical subject structure and documentation-as-qualifier

### DIFF
--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -447,11 +447,12 @@ A Constrainable Entity MUST be a schema-level FOCUS Entity. The subsections belo
 
 ##### Documentation Qualifier Forms
 
-The `documentation` qualifier specifies the documentation aspect of a Constrainable Entity enumerated above. Documentation qualifiers use the following conventional forms:
+The `documentation` qualifier specifies the documentation aspect of a Constrainable Entity enumerated above.
 
-* `<Entity keyword> documentation` — documentation of any entity of that type (e.g., `FOCUS dataset documentation`, `FOCUS column documentation`, `Custom column documentation`)
-* `<Entity ID> documentation` — documentation of a specific entity (e.g., `InvoiceDetail documentation`, `BilledCost documentation`)
-* `<Entity reference> <SubQualifier> documentation` — documentation of a specific aspect of an entity (e.g., `FOCUS dataset delivery mechanism documentation`, `Custom column JSON object schema documentation`)
+* **Documentation aspect qualifier**, whereby use of:
+  * `<Entity keyword> documentation` represents documentation of any entity of that type (e.g., `FOCUS dataset documentation`, `FOCUS column documentation`, `Custom column documentation`)
+  * `<Entity ID> documentation` represents documentation of a specific entity (e.g., `InvoiceDetail documentation`, `BilledCost documentation`)
+  * `<Entity reference> <SubQualifier> documentation` represents documentation of a specific aspect of an entity (e.g., `FOCUS dataset delivery mechanism documentation`, `Custom column JSON object schema documentation`)
 
 #### Disallowed Constrainable Entities
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -380,7 +380,7 @@ This section defines allowed and disallowed forms of Constrainable Entity in nor
 
 #### Grammatical Subject Structure
 
-A normative bullet references its Constrainable Entity through the **grammatical subject** — the text at the subject position of the bullet. The grammatical subject consists of:
+A normative bullet references its Constrainable Entity through the **grammatical subject**, i.e., the text at the subject position of the bullet. The grammatical subject consists of:
 
 * a **reference to a Constrainable Entity** (using an ID, generic keyword, or dot-notation path per [FOCUS Entity Reference Conventions](#focus-entity-reference-conventions)), and
 * optionally, one or more **qualifiers** that specify a subset, aspect, or context of the Constrainable Entity.

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -389,7 +389,7 @@ Common qualifier types are:
 
 * **content or type** (e.g., `FOCUS column containing numeric values`)
 * **structural context** (e.g., `Key in Object in FOCUS dataset column`)
-* **aspect** (e.g., `InvoiceDetail documentation` — the `documentation` qualifier specifies the InvoiceDetail dataset's documentation aspect; `FOCUS dataset delivery mechanism documentation` — specifies documentation about the dataset's delivery mechanism)
+* **aspect** (e.g., `InvoiceDetail documentation`, `FOCUS dataset delivery mechanism documentation`)
 
 Rules in this document that refer to what a requirement **constrains** apply to the Constrainable Entity. Rules that refer to the **wording or position** of the reference apply to the grammatical subject.
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -376,15 +376,32 @@ When a FOCUS dataset concept appears in a **non-subject position** (e.g., in con
 
 ### Constrainable Entity
 
-A Constrainable Entity is a FOCUS Entity whose conformance can be directly evaluated through normative requirements and to which an obligation and constraint can be applied. Reference conventions for a Constrainable Entity in the grammatical subject position (use of IDs, prohibition on Display Names, singular form) are defined in the [FOCUS Entity Reference Conventions](#focus-entity-reference-conventions) section.
+This section defines allowed and disallowed forms of [Constrainable Entity](#normative-requirement-model) in normative requirements, and the grammatical subject forms used to reference them. Reference conventions (use of IDs, prohibition on Display Names, singular form) are defined in the [FOCUS Entity Reference Conventions](#focus-entity-reference-conventions) section.
 
-The following subsections define the allowed and disallowed Constrainable Entities and their grammatical subject forms.
+#### Grammatical Subject Structure
+
+A normative bullet references its Constrainable Entity through the **grammatical subject** — the text at the subject position of the bullet. The grammatical subject consists of:
+
+* a **reference to a Constrainable Entity** (using an ID, generic keyword, or dot-notation path per [FOCUS Entity Reference Conventions](#focus-entity-reference-conventions)), and
+* optionally, one or more **qualifiers** that specify a subset, aspect, or context of the Constrainable Entity.
+
+Common qualifier types are:
+
+* **content or type** (e.g., `FOCUS column containing numeric values`)
+* **structural context** (e.g., `Key in Object in FOCUS dataset column`)
+* **aspect** (e.g., `InvoiceDetail documentation` — the `documentation` qualifier specifies the InvoiceDetail dataset's documentation aspect; `FOCUS dataset delivery mechanism documentation` — specifies documentation about the dataset's delivery mechanism)
+
+Rules in this document that refer to what a requirement **constrains** apply to the Constrainable Entity. Rules that refer to the **wording or position** of the reference apply to the grammatical subject.
+
+The grammatical subject SHOULD be explicit and unambiguous.
+
+**Exception for Aggregate Expressions:** When a requirement describes an aggregate or derived value (e.g., sums, products, counts), the aggregate expression (e.g., `The sum of`, `The product of`) MAY be used as the grammatical subject when it improves readability. The aggregate expression is not itself a Constrainable Entity; the column or metric being constrained MUST still be clearly identifiable within the requirement.
 
 #### Allowed Constrainable Entities
 
-A Constrainable Entity MUST be a schema-level FOCUS Entity, such as:
+A Constrainable Entity MUST be a schema-level FOCUS Entity. The subsections below enumerate the allowed categories.
 
-##### Data Model Entities
+##### Data Model Entity
 
 * **FOCUS Data Model**, whereby `DataModel` identifies the FOCUS Data Model.
 
@@ -428,17 +445,6 @@ A Constrainable Entity MUST be a schema-level FOCUS Entity, such as:
     * `<ObjectId>.<PropertyPath>` for JSON Object property-level requirements (e.g., `ContractCommitmentApplicabilityObject.Applicability.Cost`)
     * `<ObjectId>.<PropertyPath>[*].<PropertyPath>` for properties within arrays (e.g., `ContractAppliedObject.Elements[*].ContractId`, `ContractCommitmentApplicabilityObject.Inclusions[*].Dimension`)
 
-##### Documentation Constraint Targets
-
-* **Documentation**, whereby use of:
-  * `FOCUS dataset documentation` keyword represents documentation of any FOCUS dataset
-  * `{DatasetId} documentation` represents documentation of a specific dataset (e.g., `InvoiceDetail documentation`)
-  * `{Qualifier} documentation` represents documentation identified by a specific qualifier (e.g., `FOCUS dataset delivery mechanism documentation`, `Custom column JSON object schema documentation`, `Data generator-calculated split cost allocation method documentation`)
-
-The subject SHOULD be explicit and unambiguous.
-
-**Exception for Aggregate Expressions:** When a requirement describes an aggregate or derived value (e.g., sums, products, counts), the aggregate expression (e.g., `The sum of`, `The product of`) MAY be used as the grammatical subject when it improves readability. The aggregate expression is not itself a Constrainable Entity; the column or metric being constrained MUST still be clearly identifiable within the requirement.
-
 #### Disallowed Constrainable Entities
 
 The following MUST NOT be used as Constrainable Entities or as the grammatical subjects of normative requirements:
@@ -446,7 +452,7 @@ The following MUST NOT be used as Constrainable Entities or as the grammatical s
 * Actors (e.g., `data generator`, `service provider`, `consumer`)
 * Processes or mechanisms (e.g., `Delivery Handling`, `Correction Handling`, etc.)
 
-> **Note:** Actors and processes/mechanisms can appear as part of a documentation qualifier without violating this rule. In such cases, the constraint target and grammatical subject are the documentation itself, not the actor or mechanism. For example, in `Data generator-calculated split cost allocation method documentation`, the subject is the documentation, not the data generator; in `FOCUS dataset delivery mechanism documentation`, the subject is the documentation, not the delivery mechanism.
+> **Note:** Actors and processes/mechanisms MUST NOT be Constrainable Entities, but they MAY appear inside a qualifier — most commonly inside a documentation qualifier that describes what the documentation is about. In such cases the Constrainable Entity is the FOCUS entity being documented (typically a FOCUS dataset or column), and the actor or mechanism appears only within the qualifier chain, never as the entity reference itself. For example, in `FOCUS dataset delivery mechanism documentation`, the Constrainable Entity is `FOCUS dataset` and `delivery mechanism documentation` is the qualifier chain that narrows to the documentation of the delivery mechanism aspect.
 
 ### Explicit Conditions in Normative Requirements
 
@@ -466,9 +472,7 @@ Specifically:
 * The primary verb of the obligation (i.e., the verb that directly follows the BCP-14 keyword) MUST define a verifiable state.
 * Process-oriented verbs (e.g., `ensure`, `handle`, `support`, `provide`) MUST NOT be used as the primary verb of the obligation.
 * Process-oriented verbs MAY be used in non-normative or explanatory clauses (e.g., to describe intent or rationale).
-* When a requirement refers to actor behavior, it MUST be expressed as:
-  * a constraint on the resulting state of a schema-level entity (e.g., dataset, column, object), or
-  * a constraint on documentation.
+* When a requirement refers to actor behavior, it MUST be expressed as a constraint on the resulting state of a schema-level entity (e.g., dataset, column, object), including its documentation aspect where applicable.
 
 #### Common Non-Compliant Verbs (Non-Exhaustive)
 
@@ -1164,7 +1168,7 @@ CommitmentDiscountQuantity MUST adhere to the following requirements:
 
 ### Role of Attributes in the Specification
 
-Attributes define reusable sets of normative constraints applicable to FOCUS datasets, columns (both FOCUS and custom), and column sub-elements (e.g., objects, keys, key values). Although Attributes are FOCUS Entities, they serve only as containers for these constraints and are not Constrainable Entities.
+Attributes define reusable sets of normative constraints applicable to FOCUS datasets, columns (both FOCUS and custom), and column sub-elements (e.g., objects and object properties, including keys and key values). Although Attributes are FOCUS Entities, they serve only as containers for these constraints and are not Constrainable Entities.
 
 An entity is considered conforming to an Attribute if it explicitly declares conformance or inherits it from a parent entity. For example, when a dataset declares conformance to `NullHandling`, all columns within that dataset are considered conforming to that Attribute.
 
@@ -1210,12 +1214,12 @@ These Constrainable Entities define the targets of individual requirements withi
 
 When an Attribute's requirements do not apply to all entities within scope but only to a subset, a qualifier condition narrows the scope by describing that subset (e.g., `When FOCUS column contains numeric values, FOCUS column MUST adhere to the following requirements`). This ensures that the applicability of each requirement is explicit and does not rely solely on the conformance declaration.
 
-The following table provides an overview of anchor subject types and requirement targets used across all Attributes, with each Attribute typically targeting only a subset of these targets.
+The following table provides an overview of anchor subject types and grammatical subject forms used across all Attributes. Each grammatical subject form identifies a Constrainable Entity, optionally accompanied by a qualifier. Each Attribute typically targets only a subset of these Constrainable Entities.
 
-| Anchor Subject Type | Constrainable Entity or Documentation Constraint Target |
+| Anchor Subject Type | Constrainable Entity (with optional qualifier) |
 |---|---|
 | Dataset | FOCUS dataset |
-| Dataset | [Qualifier] documentation |
+| Dataset | FOCUS dataset with documentation qualifier |
 | Column | FOCUS dataset column |
 | Column | FOCUS column |
 | Column | Custom column |
@@ -1225,7 +1229,7 @@ The following table provides an overview of anchor subject types and requirement
 | Column | Key value in Object in FOCUS dataset column |
 | Column | Key in FOCUS dataset column |
 | Column | Key value in FOCUS dataset column |
-| Column | [Qualifier] documentation |
+| Column | FOCUS dataset column with documentation qualifier |
 
 ### FOCUS Dataset Column vs FOCUS Column vs Custom Column Requirements
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -461,7 +461,7 @@ The following MUST NOT be used as Constrainable Entities or as the grammatical s
 * Actors (e.g., `data generator`, `service provider`, `consumer`)
 * Processes or mechanisms (e.g., `Delivery Handling`, `Correction Handling`, etc.)
 
-> **Note:** Actors and processes/mechanisms MUST NOT be Constrainable Entities, but they MAY appear inside a qualifier — most commonly inside a documentation qualifier that describes what the documentation is about. In such cases the Constrainable Entity is the FOCUS entity being documented (typically a FOCUS dataset or column), and the actor or mechanism appears only within the qualifier chain, never as the entity reference itself. For example, in `FOCUS dataset delivery mechanism documentation`, the Constrainable Entity is `FOCUS dataset` and `delivery mechanism documentation` is the qualifier chain that narrows to the documentation of the delivery mechanism aspect.
+> **Note:** Actors and processes/mechanisms can appear inside a qualifier (most commonly inside a documentation qualifier that describes what the documentation is about). In such cases the Constrainable Entity is the FOCUS entity being documented (typically a FOCUS dataset or column), and the actor or mechanism appears only within the qualifier chain, never as the entity reference itself. For example, in `FOCUS dataset delivery mechanism documentation`, the Constrainable Entity is `FOCUS dataset` and `delivery mechanism documentation` is the qualifier chain that narrows to the documentation of the delivery mechanism aspect.
 
 ### Explicit Conditions in Normative Requirements
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -376,7 +376,7 @@ When a FOCUS dataset concept appears in a **non-subject position** (e.g., in con
 
 ### Constrainable Entity
 
-This section defines allowed and disallowed forms of [Constrainable Entity](#normative-requirement-model) in normative requirements, and the grammatical subject forms used to reference them. Reference conventions (use of IDs, prohibition on Display Names, singular form) are defined in the [FOCUS Entity Reference Conventions](#focus-entity-reference-conventions) section.
+This section defines allowed and disallowed forms of Constrainable Entity in normative requirements, and the grammatical subject forms used to reference them. Reference conventions (use of IDs, prohibition on Display Names, singular form) are defined in the [FOCUS Entity Reference Conventions](#focus-entity-reference-conventions) section.
 
 #### Grammatical Subject Structure
 

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -445,6 +445,14 @@ A Constrainable Entity MUST be a schema-level FOCUS Entity. The subsections belo
     * `<ObjectId>.<PropertyPath>` for JSON Object property-level requirements (e.g., `ContractCommitmentApplicabilityObject.Applicability.Cost`)
     * `<ObjectId>.<PropertyPath>[*].<PropertyPath>` for properties within arrays (e.g., `ContractAppliedObject.Elements[*].ContractId`, `ContractCommitmentApplicabilityObject.Inclusions[*].Dimension`)
 
+##### Documentation Qualifier Forms
+
+The `documentation` qualifier specifies the documentation aspect of a Constrainable Entity enumerated above. Documentation qualifiers use the following conventional forms:
+
+* `<Entity keyword> documentation` — documentation of any entity of that type (e.g., `FOCUS dataset documentation`, `FOCUS column documentation`, `Custom column documentation`)
+* `<Entity ID> documentation` — documentation of a specific entity (e.g., `InvoiceDetail documentation`, `BilledCost documentation`)
+* `<Entity reference> <SubQualifier> documentation` — documentation of a specific aspect of an entity (e.g., `FOCUS dataset delivery mechanism documentation`, `Custom column JSON object schema documentation`)
+
 #### Disallowed Constrainable Entities
 
 The following MUST NOT be used as Constrainable Entities or as the grammatical subjects of normative requirements:

--- a/guidelines/contributors/normative-requirements-guidelines.md
+++ b/guidelines/contributors/normative-requirements-guidelines.md
@@ -196,7 +196,7 @@ Standalone requirement MUST adhere to the following rules:
 Standalone normative requirements use the following canonical form:
 
 ``` markdown
-* <Subject> <BCP 14 Keyword> <Verifiable State Descriptor>[ Conditions].
+* <GrammaticalSubject> <BCP-14-Keyword> <VerifiableStateDescriptor>[ Conditions].
 ```
 
 * **Example** (illustrative):
@@ -261,7 +261,7 @@ A condition grouping bullet introduces a shared condition that applies to all ne
 It uses the following canonical form:
 
 ``` markdown
-* When <Condition>, <Subject> MUST adhere to the following requirements:
+* When <Condition>, <GrammaticalSubject> MUST adhere to the following requirements:
 ```
 
 * **Example** (illustrative):
@@ -281,7 +281,7 @@ Context grouping bullets may be used for different requirement contexts, such as
 Column presence grouping bullets are used in dataset requirements. They use the following canonical form:
 
 ``` markdown
-* <Subject> <context> MUST adhere to the following requirements:
+* <GrammaticalSubject> <ContextLabel> MUST adhere to the following requirements:
 ```
 
 * **Example** (illustrative):
@@ -295,7 +295,7 @@ Column presence grouping bullets are used in dataset requirements. They use the 
 Nullability grouping bullets are used in column requirements. They use the following canonical form:
 
 ``` markdown
-* <Subject> MUST adhere to the following <context> requirements:
+* <GrammaticalSubject> MUST adhere to the following <ContextLabel> requirements:
 ```
 
 * **Example** (illustrative):
@@ -705,12 +705,12 @@ Use standardized phrasing and terminology, and apply common requirement patterns
 ##### Other Requirements: Documentation
 
 ```markdown
-* <DatasetId> documentation MUST <verifiable state>.
+* <DatasetId> documentation MUST <VerifiableStateDescriptor>.
 ```
 
 ```markdown
 * <DatasetId> documentation MUST adhere to the following requirements:
-  * <DatasetId> documentation MUST <verifiable state>.
+  * <DatasetId> documentation MUST <VerifiableStateDescriptor>.
 ```
 
 ### Dataset Normative Requirements Examples
@@ -1063,12 +1063,12 @@ To ensure clarity and consistency across columns and corresponding requirements,
 ##### Other Requirements: Documentation
 
 ```markdown
-* <Qualifier> documentation MUST <verifiable state>.
+* <ColumnId> documentation MUST <VerifiableStateDescriptor>.
 ```
 
 ```markdown
-* <Qualifier> documentation MUST adhere to the following requirements:
-  * <Qualifier> documentation MUST <verifiable state>.
+* <ColumnId> documentation MUST adhere to the following requirements:
+  * <ColumnId> documentation MUST <VerifiableStateDescriptor>.
 ```
 
 #### Column Requirement Standardized Terminology
@@ -1209,10 +1209,10 @@ The canonical form of the structural anchor is:
 
 Where `[Dataset|Column]` is the primary schema-level entity targeted by the Attribute — either Dataset or Column. Most Attributes target either datasets or columns, but not both. When an Attribute targets both datasets and columns, a separate structural anchor MUST be used for each entity type.
 
-When an Attribute is applicable only under specific conditions, the structural anchor MAY be preceded by an applicability criteria condition:
+When an Attribute is applicable only under specific conditions, the structural anchor MAY be preceded by an operating model condition:
 
 ```markdown
-When <actor> <applicability-criteria-condition>, [Dataset|Column] conforming to <AttributeId> attribute MUST adhere to the following requirements:
+When <Actor> <OperatingModelCondition>, [Dataset|Column] conforming to <AttributeId> attribute MUST adhere to the following requirements:
 ```
 
 ### Constrainable Entities in Attribute Requirements


### PR DESCRIPTION
## Summary

This PR extends #2646 with additional refinements to the Constrainable Entity model.

***Note:** An extension PR was preferred over inline changes because the additions are numerous, span multiple sections of the document, and touch on related-but-distinct concerns (model, terminology, canonical forms). Keeping them separate preserves reviewability and allows #2646 to merge on its own merits.*

### Model extension

The Constrainable Entity section now opens with a **Grammatical Subject Structure** subsection that establishes the relationship between Constrainable Entity, grammatical subject, and qualifier. This provides the central conceptual model referenced throughout the document — rules that refer to what a requirement *constrains* apply to the Constrainable Entity; rules that refer to the *wording or position* of the reference apply to the grammatical subject. Qualifiers are defined as optional modifiers that specify a subset, aspect, or context of the Constrainable Entity, with three common types (content/type, structural context, aspect).

### Documentation as qualifier

Documentation is now treated as an **aspect qualifier** applied to Constrainable Entities, rather than as a distinct constraint target. The previous "Documentation Constraint Targets" subsection and its "pending architectural decision" note are replaced by a new **Documentation Qualifier Forms** subsection under Allowed Constrainable Entities, which enumerates conventional forms for documentation-qualified grammatical subjects (`<Entity keyword> documentation`, `<Entity ID> documentation`, `<Entity reference> <SubQualifier> documentation`).

Downstream implications of this reframing are also reflected: the **Disallowed Constrainable Entities** note now describes actors and mechanisms as elements that may appear within a documentation qualifier chain (never as the entity reference itself); the **Verifiable State Descriptor** section treats documentation as an aspect of a schema-level entity rather than a parallel category; and the **Attribute Requirements** table caption, column header, and documentation rows are reframed accordingly.

### Consistency updates

Several small alignments were made to keep the document internally consistent:

- The **Constrainable Entity** section no longer opens with a duplicated definition; the canonical definition remains in Normative Requirement Model, and the section starts with a scope statement.
- Canonical forms use **`<GrammaticalSubject>`** (previously `<Subject>`) to match the terminology introduced in the new Grammatical Subject Structure subsection.
- Placeholder casing across canonical forms follows **PascalCase** (e.g., `<VerifiableStateDescriptor>`, `<GrammaticalSubject>`), with hyphens retained only where they preserve external references (e.g., `<BCP-14-Keyword>`).
- `<verifiable state>` and `<VerifiableStateDescriptor>` — previously two names for the same concept — are now unified under `<VerifiableStateDescriptor>`.
- Column documentation patterns use **`<ColumnId>`** in place of the previous `<Qualifier>` placeholder, matching the Dataset documentation pattern style and the Documentation Qualifier Forms conventions.
- The wording for column sub-elements in **Role of Attributes** is aligned with the wording in Sub-Element Entities.
### Type of Change
* [ ] Bug fix
* [ ] New feature / Specification update
* [x] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [ ] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.
