### PR TITLE
AI #2665: Align the Unit Pricing and Price List glossary entries with the SKU Price condition

### DIFF
--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -272,7 +272,7 @@ An individual who performs FinOps within an organization to maximize the busines
 
 <a name="glossary:price-list"><b>Price List</b></a>
 
-A comprehensive list of prices offered by a service provider.
+A comprehensive, standing list of prices offered by a service provider.
 
 <a name="glossary:service-provider"><b>Service Provider</b></a>
 
@@ -328,7 +328,7 @@ An agreement specified on a [*contract*](#glossary:contract) or [*invoice*](#glo
 
 <a name="glossary:unit-pricing"><b>Unit Pricing</b></a>
 
-A billing concept where the cost of a [*charge*](#glossary:charge) is deterministically derived as the product of a unit price (defined per [*SKU Price*](#glossary:sku-price)) and the corresponding [Pricing Quantity](#datamodel.costandusage.pricingquantity), representing purchased or consumed volume of a [*SKU*](#glossary:sku).
+A billing concept where the cost of a [*charge*](#glossary:charge) is deterministically derived as the product of a unit price (defined per [*SKU Price*](#glossary:sku-price), where the [*operating model*](#glossary:operating-model) includes *SKU Prices*) and the corresponding [Pricing Quantity](#datamodel.costandusage.pricingquantity), representing purchased or consumed volume of a [*SKU*](#glossary:sku).
 
 <a name="glossary:virtual-currency"><b>Virtual Currency</b></a>
 

--- a/specification/operating_model_conditions/includesskuprices.md
+++ b/specification/operating_model_conditions/includesskuprices.md
@@ -2,14 +2,14 @@
 
 The Includes SKU Prices operating model condition represents a verifiable state indicating whether the [*operating model*](#glossary:operating-model) includes [*SKU Prices*](#glossary:sku-price).
 
+> **Note:** An *operating model* does not include *SKU Prices* when no [*service provider*](#glossary:service-provider) in it supplies a [*price list*](#glossary:price-list) (e.g., auction-based marketplaces, pure pass-through aggregation of third-party prices, or exclusively bespoke-quoted capacity).
+
 ## Requirements
 
 IncludesSkuPrices MUST adhere to the following requirements:
 
 * IncludesSkuPrices MUST evaluate to true when the *operating model* includes *SKU Prices*.
 * IncludesSkuPrices MUST evaluate to false when the *operating model* does not include *SKU Prices*.
-
-> **Note:** An *operating model* does not include *SKU Prices* when no billing party maintains a standing catalog of them (e.g., auction-based marketplaces, pure pass-through aggregation of third-party prices, or exclusively bespoke-quoted capacity).
 
 ## Operating Model Condition ID
 

--- a/specification/operating_model_conditions/includesskuprices.md
+++ b/specification/operating_model_conditions/includesskuprices.md
@@ -9,6 +9,8 @@ IncludesSkuPrices MUST adhere to the following requirements:
 * IncludesSkuPrices MUST evaluate to true when the *operating model* includes *SKU Prices*.
 * IncludesSkuPrices MUST evaluate to false when the *operating model* does not include *SKU Prices*.
 
+> **Note:** An *operating model* does not include *SKU Prices* when no billing party maintains a standing catalog of them (e.g., auction-based marketplaces, pure pass-through aggregation of third-party prices, or exclusively bespoke-quoted capacity).
+
 ## Operating Model Condition ID
 
 IncludesSkuPrices


### PR DESCRIPTION
## Summary

Suggestion on #2424, routed from AI #2665: three text changes that make the SKU Price dataset's Conditional designation self-consistent, following the September 1 TF-1 discussion of the dataset's feature level.

1. **Unit Pricing (glossary):** the unit price is now "defined per *SKU Price*, where the *operating model* includes *SKU Prices*." The unqualified parenthetical read as making unit pricing and SKU Prices inseparable, which conflicts with the *SKU Price* entry that excludes unit price amounts, and that tension fueled the reading of `IncludesSkuPrices` as equivalent to the retired `IncludesUnitPricing` condition.
2. **Price List (glossary):** "a comprehensive, standing list of prices offered by a service provider." One added word, so a one-off quote or bid does not read as a price list.
3. **IncludesSkuPrices (condition):** an informative note naming the operating models the condition excludes: those where no billing party maintains a standing catalog of SKU Prices (auction-based marketplaces, pure pass-through aggregation, exclusively bespoke-quoted capacity). These are the operating-model shapes identified in the census posted on #2665.

No requirement text changes: two glossary definitions are clarified and one informative note is added.

### Type of Change
* [ ] Bug fix
* [x] New feature / Specification update
* [ ] Editorial / Formatting

### Author Checklist
* [x] **AI Usage Guidelines:** I have read the [FOCUS AI Usage Guidelines](/guidelines/contributors/ai-usage-guidelines.md).
* [x] **Self Review Attestation:** I have performed a self-review of my own contribution.
* [x] **AI-Generated Examples:** If this PR includes examples generated by AI, I have manually verified that the data is mathematically accurate, logically consistent, and compliant with the FOCUS schema.

## Change Log

### September 1, 2026: Initial proposal

* Qualified the *Unit Pricing* parenthetical, added "standing" to the *Price List* definition, and added the informative exclusion note to `IncludesSkuPrices`.
